### PR TITLE
refactor

### DIFF
--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -48,9 +48,6 @@ impl Detection {
                 )
             });
         });
-
-        // output message
-        message.print();
     }
 
     // serialize evtx files to json


### PR DESCRIPTION
2重で標準出力に結果が出力されていたため不要な出力コードを削除