### PR TITLE
fixed error message test #72

### DIFF
--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -251,6 +251,6 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let result = AlertMessage::alert(&mut buf, input.to_string());
         assert!(result.is_ok());
-        assert_eq!(buf, b"[ERROR] error");
+        assert_eq!(buf, b"[ERROR] TEST!\n");
     }
 }


### PR DESCRIPTION
closed #72 

エラーメッセージ構造体のテストが常に通ってしまっていたためテストケースの記載を修正

error test case example

```rust
fn test_error_message() {
	let input = "TEST!";
        let mut buf = Vec::<u8>::new();
        let result = AlertMessage::alert(&mut buf, input.to_string());
        assert!(result.is_ok());
        assert_eq!(buf, b"[ERROR] error");
}
```

> cargo test test_error_message
> warning: unused manifest key: target.i686-pc-windows-gnu.linker
> warning: unused manifest key: target.x86_64-pc-windows-gnu.linker
>    Compiling yamato_event_analyzer v0.1.0 (D:\gitprojects\YamatoEventAnalyzer)
>     Finished test [unoptimized + debuginfo] target(s) in 2.66s
>      Running target\debug\deps\yamato_event_analyzer-5839d1cdde102c18.exe
> 
> running 1 test
> test detections::print::tests::test_error_message ... FAILED
> 
> failures:
> 
> ---- detections::print::tests::test_error_message stdout ----
> thread 'detections::print::tests::test_error_message' panicked at 'assertion failed: `(left == right)`
>   left: `[91, 69, 82, 82, 79, 82, 93, 32, 84, 69, 83, 84, 33, 10]`,
>  right: `[91, 69, 82, 82, 79, 82, 93, 32, 101, 114, 114, 111, 114]`', src\detections\print.rs:254:9
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> 
> 
> failures:
>     detections::print::tests::test_error_message
> 
> test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s
> 