### PR TITLE
changed output format #152

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -17,8 +17,10 @@ pub struct CsvFormat<'a> {
     filepath: &'a str,
     rulepath: &'a str,
     level: &'a str,
-    title: &'a str,
-    message: &'a str,
+    computername: &'a str,
+    eventid: &'a str,
+    alert: &'a str,
+    details: &'a str,
 }
 
 pub fn after_fact() {
@@ -82,8 +84,10 @@ fn emit_csv<W: std::io::Write>(writer: &mut W) -> Result<(), Box<dyn Error>> {
                 filepath: &detect_info.filepath,
                 rulepath: &detect_info.rulepath,
                 level: &detect_info.level,
-                title: &detect_info.title,
-                message: &detect_info.detail,
+                computername: &detect_info.computername,
+                eventid: &detect_info.eventid,
+                alert: &detect_info.alert,
+                details: &detect_info.detail,
             })?;
         }
         detect_count += detect_infos.len();
@@ -123,6 +127,8 @@ fn test_emit_csv() {
     let testrulepath: &str = "test-rule.yml";
     let test_title = "test_title";
     let test_level = "high";
+    let test_computername = "testcomputer";
+    let test_eventid = "1111";
     let output = "pokepoke";
     {
         let mut messages = print::MESSAGES.lock().unwrap();
@@ -147,6 +153,8 @@ fn test_emit_csv() {
             testrulepath.to_string(),
             &event,
             test_level.to_string(),
+            test_computername.to_string(),
+            test_eventid.to_string(),
             test_title.to_string(),
             output.to_string(),
         );
@@ -156,7 +164,7 @@ fn test_emit_csv() {
         .datetime_from_str("1996-02-27T01:05:01Z", "%Y-%m-%dT%H:%M:%SZ")
         .unwrap();
     let expect_tz = expect_time.with_timezone(&Local);
-    let expect = "Time,Filepath,Rulepath,Level,Title,Message\n".to_string()
+    let expect = "Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details\n".to_string()
         + &expect_tz.clone().format("%Y-%m-%dT%H:%M:%S%:z").to_string()
         + ","
         + testfilepath
@@ -164,6 +172,10 @@ fn test_emit_csv() {
         + testrulepath
         + ","
         + test_level
+        + ","
+        + test_computername
+        + ","
+        + test_eventid
         + ","
         + test_title
         + ","

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -159,6 +159,10 @@ impl Detection {
             rule.rulepath.to_string(),
             &record_info.record,
             rule.yaml["level"].as_str().unwrap_or("").to_string(),
+            record_info.record["Event"]["System"]["Computer"]
+                .to_string()
+                .replace("\"", ""),
+            record_info.record["Event"]["System"]["EventID"].to_string(),
             rule.yaml["title"].as_str().unwrap_or("").to_string(),
             rule.yaml["output"].as_str().unwrap_or("").to_string(),
         );
@@ -172,6 +176,8 @@ impl Detection {
             rule.rulepath.to_string(),
             agg_result.start_timedate,
             rule.yaml["level"].as_str().unwrap_or("").to_string(),
+            "-".to_string(),
+            "-".to_string(),
             rule.yaml["title"].as_str().unwrap_or("").to_string(),
             output.to_string(),
         )

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -19,7 +19,9 @@ pub struct DetectInfo {
     pub filepath: String,
     pub rulepath: String,
     pub level: String,
-    pub title: String,
+    pub computername: String,
+    pub eventid: String,
+    pub alert: String,
     pub detail: String,
 }
 
@@ -42,6 +44,8 @@ impl Message {
         rule_path: String,
         event_time: DateTime<Utc>,
         level: String,
+        computername: String,
+        eventid: String,
         event_title: String,
         event_detail: String,
     ) {
@@ -49,7 +53,9 @@ impl Message {
             filepath: target_file,
             rulepath: rule_path,
             level: level,
-            title: event_title,
+            computername: computername,
+            eventid: eventid,
+            alert: event_title,
             detail: event_detail,
         };
 
@@ -71,6 +77,8 @@ impl Message {
         rule_path: String,
         event_record: &Value,
         level: String,
+        computername: String,
+        eventid: String,
         event_title: String,
         output: String,
     ) {
@@ -82,6 +90,8 @@ impl Message {
             rule_path,
             time,
             level,
+            computername,
+            eventid,
             event_title,
             message.to_string(),
         )
@@ -145,7 +155,7 @@ impl Message {
         let mut detect_count = 0;
         for (key, detect_infos) in self.map.iter() {
             for detect_info in detect_infos.iter() {
-                println!("{} <{}> {}", key, detect_info.title, detect_info.detail);
+                println!("{} <{}> {}", key, detect_info.alert, detect_info.detail);
             }
             detect_count += detect_infos.len();
         }
@@ -214,6 +224,8 @@ mod tests {
             "test_rule".to_string(),
             &event_record_1,
             "high".to_string(),
+            "testcomputer1".to_string(),
+            "1".to_string(),
             "test1".to_string(),
             "CommandLine1: %CommandLine%".to_string(),
         );
@@ -238,6 +250,8 @@ mod tests {
             "test_rule2".to_string(),
             &event_record_2,
             "high".to_string(),
+            "testcomputer2".to_string(),
+            "2".to_string(),
             "test2".to_string(),
             "CommandLine2: %CommandLine%".to_string(),
         );
@@ -262,6 +276,8 @@ mod tests {
             "test_rule3".to_string(),
             &event_record_3,
             "high".to_string(),
+            "testcomputer3".to_string(),
+            "3".to_string(),
             "test3".to_string(),
             "CommandLine3: %CommandLine%".to_string(),
         );
@@ -281,13 +297,15 @@ mod tests {
             "test_rule4".to_string(),
             &event_record_4,
             "medium".to_string(),
+            "testcomputer4".to_string(),
+            "4".to_string(),
             "test4".to_string(),
             "CommandLine4: %CommandLine%".to_string(),
         );
 
         let display = format!("{}", format_args!("{:?}", message));
         println!("display::::{}", display);
-        let expect = "Message { map: {1970-01-01T00:00:00Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule4\", level: \"medium\", title: \"test4\", detail: \"CommandLine4: hoge\" }], 1996-02-27T01:05:01Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule\", level: \"high\", title: \"test1\", detail: \"CommandLine1: hoge\" }, DetectInfo { filepath: \"a\", rulepath: \"test_rule2\", level: \"high\", title: \"test2\", detail: \"CommandLine2: hoge\" }], 2000-01-21T09:06:01Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule3\", level: \"high\", title: \"test3\", detail: \"CommandLine3: hoge\" }]} }";
+        let expect = "Message { map: {1970-01-01T00:00:00Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule4\", level: \"medium\", computername: \"testcomputer4\", eventid: \"4\", alert: \"test4\", detail: \"CommandLine4: hoge\" }], 1996-02-27T01:05:01Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule\", level: \"high\", computername: \"testcomputer1\", eventid: \"1\", alert: \"test1\", detail: \"CommandLine1: hoge\" }, DetectInfo { filepath: \"a\", rulepath: \"test_rule2\", level: \"high\", computername: \"testcomputer2\", eventid: \"2\", alert: \"test2\", detail: \"CommandLine2: hoge\" }], 2000-01-21T09:06:01Z: [DetectInfo { filepath: \"a\", rulepath: \"test_rule3\", level: \"high\", computername: \"testcomputer3\", eventid: \"3\", alert: \"test3\", detail: \"CommandLine3: hoge\" }]} }";
         assert_eq!(display, expect);
     }
 


### PR DESCRIPTION
closes #152 

- Titleの表記をAlertに変更
- Messageの表記をDetailsに変更
- 出力にComputernameとイベントIDを追加(Aggregation Conditionの場合はこれらの情報は統一できない可能性があるため"-"を出力する)

## Changed 
- Title->Alert
- Message->Details
- add Computername and EventID

## Result

```
PS >.\hayabusa.exe -f '..\test_files\kerberoasting.evtx'Events Detected:2
Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details
2021-04-29T18:23:54.244226+09:00,..\test_files\kerberoasting.evtx,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T18:23:58.718239+09:00,..\test_files\kerberoasting.evtx,rules\Security\4768_T1558.003_Kerberoasting.yml,high,DC-Server-1.labcorp.local,4768,Kerberoasting,Possible Kerberoasting Risk Activity.PS >.\hayabusa.exe -d '..\test_files\'                  
Events Detected:5

Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details
2020-09-17T19:57:37.013214+09:00,..\test_files\remote_pwd_reset_rpc_mimikatz_postzerologon_target_DC.evtx,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,01566s-win16-ir.threebeesco.com,1102,Security log was cleared,User: a-jbrown
2021-04-29T16:55:53.423761+09:00,..\test_files\asreproasting.evtx,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T16:56:26.869344+09:00,..\test_files\asreproasting.evtx,rules\Security\4768_T1558.004_AS-REP-Roasting.yml,high,DC-Server-1.labcorp.local,4768,AS-REP Roasting,Possible AS-REP Roasting
2021-04-29T18:23:54.244226+09:00,..\test_files\kerberoasting.evtx,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T18:23:58.718239+09:00,..\test_files\kerberoasting.evtx,rules\Security\4768_T1558.003_Kerberoasting.yml,high,DC-Server-1.labcorp.local,4768,Kerberoasting,Possible Kerberoasting Risk Activity.
PS >
```