### PR TITLE
removed filepath extension #162

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -167,7 +167,7 @@ fn test_emit_csv() {
     let expect = "Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details\n".to_string()
         + &expect_tz.clone().format("%Y-%m-%dT%H:%M:%S%:z").to_string()
         + ","
-        + testfilepath
+        + &testfilepath.replace(".evtx", "").to_string()
         + ","
         + testrulepath
         + ","

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -50,7 +50,7 @@ impl Message {
         event_detail: String,
     ) {
         let detect_info = DetectInfo {
-            filepath: target_file,
+            filepath: target_file.replace(".evtx", ""),
             rulepath: rule_path,
             level: level,
             computername: computername,


### PR DESCRIPTION
closes #162 

ファイルパスのevtx拡張子を削除しました

## Results

```
PS >.\hayabusa.exe -f ..\test_files\kerberoasting.evtx

Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details
2021-04-29T18:23:54.244226+09:00,..\test_files\kerberoasting,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T18:23:58.718239+09:00,..\test_files\kerberoasting,rules\Security\4768_T1558.003_Kerberoasting.yml,high,DC-Server-1.labcorp.local,4768,Kerberoasting,Possible Kerberoasting Risk Activity.

Events Detected:2
Elapsed Time: 00:00:00.115

PS >.\hayabusa.exe -d ..\test_files                   

Time,Filepath,Rulepath,Level,Computername,Eventid,Alert,Details
2020-09-17T19:57:37.013214+09:00,..\test_files\remote_pwd_reset_rpc_mimikatz_postzerologon_target_DC,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,01566s-win16-ir.threebeesco.com,1102,Security log was cleared,User: a-jbrown
2021-04-29T16:55:53.423761+09:00,..\test_files\asreproasting,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T16:56:26.869344+09:00,..\test_files\asreproasting,rules\Security\4768_T1558.004_AS-REP-Roasting.yml,high,DC-Server-1.labcorp.local,4768,AS-REP Roasting,Possible AS-REP Roasting
2021-04-29T18:23:54.244226+09:00,..\test_files\kerberoasting,rules\Security\1102_T1070.001_SecurityLogCleared.yml,high,DC-Server-1.labcorp.local,1102,Security log was cleared,User: Administrator
2021-04-29T18:23:58.718239+09:00,..\test_files\kerberoasting,rules\Security\4768_T1558.003_Kerberoasting.yml,high,DC-Server-1.labcorp.local,4768,Kerberoasting,Possible Kerberoasting Risk Activity.

Events Detected:5
Elapsed Time: 00:00:00.080

PS >
```