### PR TITLE
一度に読み込むイベントログの行数を変更 #276

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 // 一度にtimelineやdetectionを実行する行数
-const MAX_DETECT_RECORDS: usize = 40000;
+const MAX_DETECT_RECORDS: usize = 5000;
 
 fn main() {
     let analysis_start_time: DateTime<Local> = Local::now();


### PR DESCRIPTION
closes #276 

一度に読み込むイベントログの行数を減らすことで、メモリの使用量を減らす。
hayabusaレポジトリにアップロードされているサンプルイベントログで計測し、
commitの前後で速度に変化がないことを確認済み。

* commit前
`````````````````
C:\Users\takai\dev\git\hayabusa>cargo run --release -- --directory=C:\Users\takai\dev\git\hayabusa\sample-evtx --csv-timeline=hoge.csv

Analyzing event files: 503
SIGMA rules: 1086
hayabusa rules: 39
Ignored rules: 11
Rule parsing errors: 0
Total detection rules: 1136

Total events detected: 11616
Critical alerts: 31
High alerts: 132
Medium alerts: 77
Low alerts: 30
Informational alerts: 16
Undefined alerts: 0
Unique events detected: 286
Elapsed Time: 00:00:25.643
``````````````````

* commit後
```````````````
C:\Users\takai\dev\git\hayabusa>cargo run --release -- --directory=C:\Users\takai\dev\git\hayabusa\sample-evtx --csv-timeline=hoge.csv
Analyzing event files: 503
SIGMA rules: 1086
hayabusa rules: 39
Ignored rules: 11
Rule parsing errors: 0
Total detection rules: 1136

Total events detected: 11616
Critical alerts: 31
High alerts: 132
Medium alerts: 77
Low alerts: 30
Informational alerts: 16
Undefined alerts: 0
Unique events detected: 286
Elapsed Time: 00:00:25.230
````````````````