### PR TITLE
update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "hayabusa"
 version = "1.0.0"
-authors = ["akiranishikawa <nishikawa@kagosec.net>"]
-edition = "2018"
+authors = ["Yamato Security @yamatosecurity"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
editionを2018から2021に変更しました。
buildもtestも問題なかったので、大丈夫だと思いますが、

特に話し合いもせずに、着手したので、大切なところのログを残しておきます。
方針上問題あれば、rejectしていただいて、大丈夫です。


やったこと
1. cargo fix --edition
2. change edition in Cargo.toml
3. cargo build && cargo test

```
$cargo fix --edition
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  itoa v0.4.6 (as host dependency) removed features: default, std
  libc v0.2.102 removed features: align
  libc v0.2.102 (as host dependency) removed features: align, default, std
  serde v1.0.116 (as host dependency) removed features: derive, serde_derive
  standback v0.2.17 (as host dependency) removed features: std
  winapi v0.3.9 (as host dependency) removed features: cfg, evntrace, handleapi, impl-debug, impl-default, in6addr, inaddr, ioapiset, lmcons, minschannel, minwinbase, mswsock, namedpipeapi, ntdef, ntstatus, schannel, securitybaseapi, sspi, synchapi, sysinfoapi, threadpoollegacyapiset, timezoneapi, wincrypt, windef, winioctl, winreg, winsock2, winuser, ws2def, ws2ipdef, ws2tcpip

Migrating src\lib.rs from 2018 edition to 2021                                                                          
Migrating src\main.rs from 2018 edition to 2021 
```