### PR TITLE
removed process-speed view in progress bar #289

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn analysis_files(evtx_files: Vec<PathBuf>) {
         &filter::exclude_ids(),
     );
     let mut pb = ProgressBar::new(evtx_files.len() as u64);
+    pb.show_speed = false;
     let mut detection = detection::Detection::new(rule_files);
     for evtx_file in evtx_files {
         if configs::CONFIG.read().unwrap().args.is_present("verbose") {


### PR DESCRIPTION
progress bar内の処理速度の部分を削除

## 証跡


![#289](https://user-images.githubusercontent.com/2350416/146512193-b9963f94-9fc1-4f54-b849-0efc90798b89.gif)

