### PR TITLE
Hotfix/regex filename replace lack#296

### DIFF
--- a/rules/hayabusa/alerts/System/7045_CreateOrModiftySystemProcess-WindowsService_MaliciousServiceInstalled.yml
+++ b/rules/hayabusa/alerts/System/7045_CreateOrModiftySystemProcess-WindowsService_MaliciousServiceInstalled.yml
@@ -20,7 +20,7 @@ detection:
             regexes: ./config/regex/detectlist_suspicous_services.txt
         ImagePath:
             min_length: 1000
-            allowlist: ./config/regex/allowlist_legimate_serviceimage.txt
+            allowlist: ./config/regex/allowlist_legitimate_services.txt
     condition: selection
 falsepositives:
     - normal system usage


### PR DESCRIPTION
closes #296 

## 修正内容

#291 で追加対応したファイル名変更で一部ymlファイルで修正誤りがあったため修正

## 結果

対象のymlファイル以外に同様の問題がないことを確認し、実行時のルールパースエラーがなくなったことを確認

![image](https://user-images.githubusercontent.com/2350416/146592111-c562014f-332c-49d7-8fb7-7415e98b9ba2.png)




