### PR TITLE
RevertedMerge: Feature/remove process speed#289

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ impl App {
             &filter::exclude_ids(),
         );
         let mut pb = ProgressBar::new(evtx_files.len() as u64);
+        pb.show_speed = false;
         self.rule_keys = self.get_all_keys(&rule_files);
         let mut detection = detection::Detection::new(rule_files);
         for evtx_file in evtx_files {


### PR DESCRIPTION
今回のプルリクエストの背景は以下の通りです。内容は #292 で承認いただきましたものと変更ありませんのでApproveのほどよろしくおねがいいたします。結果についても #292 と同様のため省略いたします。

1. #293 マージ前に #292 をマージしたため #293 でConflictが発生
2.  #298 で #292 のRevertを実施
3. #293 のConflictが解消したためmainにマージ
4. 今回のブランチ(feature/remove_process_speed#289) に #293 をマージして#292 分の修正を追加した本pull requestを依頼。

