### PR TITLE
fixed contents and rule-count #333

### DIFF
--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -258,7 +258,10 @@ impl Detection {
         });
         println!("Ignored rules: {}", ignore_count);
         println!("Rule parsing errors: {}", parseerror_count);
-        println!("Total detection rules: {}", total);
+        println!(
+            "Total enabled detection rules: {}",
+            total - ignore_count - parseerror_count
+        );
         println!("");
     }
 }


### PR DESCRIPTION
closes #333 

実施結果

```
PS >.\hayabusa.exe -d .\hayabusa-sample-evtx\ -r .\test_files\rules\yaml\               

██╗  ██╗ █████╗ ██╗   ██╗ █████╗ ██████╗ ██╗   ██╗███████╗ █████╗
██║  ██║██╔══██╗╚██╗ ██╔╝██╔══██╗██╔══██╗██║   ██║██╔════╝██╔══██╗
███████║███████║ ╚████╔╝ ███████║██████╔╝██║   ██║███████╗███████║
██╔══██║██╔══██║  ╚██╔╝  ██╔══██║██╔══██╗██║   ██║╚════██║██╔══██║
██║  ██║██║  ██║   ██║   ██║  ██║██████╔╝╚██████╔╝███████║██║  ██║
╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝
   by Yamato Security 

Analyzing event files: 509
[WARN] Failed to parse yml: .\test_files\rules\yaml\error.yml
unexpected character: `%' at line 11 column 22
SIGMA rules: 9
Other rules: 4
Ignored rules: 10
Rule parsing errors: 1
Total enabled detection rules: 13
```