### PR TITLE
Feature/except hidden file#335

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,14 @@ impl App {
                 });
             } else {
                 let path_str = path.to_str().unwrap_or("");
-                if path_str.ends_with(".evtx") && !path_str.starts_with(".") {
+                if path_str.ends_with(".evtx")
+                    && !Path::new(path_str)
+                        .file_stem()
+                        .unwrap_or(OsStr::new("."))
+                        .to_str()
+                        .unwrap()
+                        .starts_with(".")
+                {
                     ret.push(path);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use hhmmss::Hhmmss;
 use pbr::ProgressBar;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fmt::Display;
 use std::io::BufWriter;
 use std::path::Path;
@@ -85,10 +86,18 @@ impl App {
             }
         }
         if let Some(filepath) = configs::CONFIG.read().unwrap().args.value_of("filepath") {
-            if !filepath.ends_with(".evtx") {
+            if !filepath.ends_with(".evtx")
+                || Path::new(filepath)
+                    .file_stem()
+                    .unwrap_or(OsStr::new("."))
+                    .to_str()
+                    .unwrap()
+                    .trim()
+                    .starts_with(".")
+            {
                 AlertMessage::alert(
                     &mut BufWriter::new(std::io::stderr().lock()),
-                    &"--filepath only accepts .evtx files.".to_string(),
+                    &"--filepath only accepts .evtx files. no hidden file.".to_string(),
                 )
                 .ok();
                 return;
@@ -156,7 +165,7 @@ impl App {
                 });
             } else {
                 let path_str = path.to_str().unwrap_or("");
-                if path_str.ends_with(".evtx") {
+                if path_str.ends_with(".evtx") && !path_str.starts_with(".") {
                     ret.push(path);
                 }
             }


### PR DESCRIPTION
closes #335 

## 変更箇所

- evtxのファイルパスにおいて隠しファイルを読み込まないようにした #335 

## 証跡

.evtx拡張子となっているものは以下の例だと4つあるが、1つが隠しファイルとなっている。ディレクトリ指定時に隠しファイルを除外し読み込み数が3となっていることと、隠しファイルをファイル指定したときにエラーを返すことを確認済み

```
PS >ls -Recurse .\test_files\evtx\

    Directory: ...\hayabusa\test_files\evtx

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          2021/11/28     4:36                sub
-a---          2021/12/22    19:35              0 .test1.evtx
-a---          2021/11/28     4:36              0 test.txt
-a---          2021/06/04    11:00              0 test1.evtx

    Directory: ...\hayabusa\test_files\evtx\sub

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          2021/11/28     4:36              0 test.txt
-a---          2021/06/04    11:00              0 test2.evtx
-a---          2021/06/04    11:00              0 testtest4.evtx

PS >.\hayabusa.exe -d -q .\test_files\evtx\                                        
Analyzing event files: 3
Hayabusa rules: 49
Sigma rules: 1146
Ignored rules: 29
Rule parsing errors: 0
Total enabled detection rules: 1195

An error occurred while trying to deserialize evtx stream.

Total detections: 0
Total critical detections: 0
Total high detections: 0
Total medium detections: 0
Total low detections: 0
Total informational detections: 0
Total undefined detections: 0
Unique rules: 0
Unique critical rules: 0
Unique high rules: 0
Unique medium rules: 0
Unique low rules: 0
Unique informational rules: 0
Unique undefined rules: 0
Elapsed Time: 00:00:03.266

PS >.\hayabusa.exe -f -q .\test_files\evtx\.test1.evtx
[ERROR] --filepath only accepts .evtx files. no hidden file.

```