### PR TITLE
exclude-rules.txtとnoisy-rules.txtをコメントに対応

### DIFF
--- a/config/exclude-rules-full.txt
+++ b/config/exclude-rules-full.txt
@@ -1,9 +1,0 @@
-4fe151c2-ecf9-4fae-95ae-b88ec9c2fca6 # ./rules/sigma/other/msexchange/win_exchange_transportagent.yml
-c92f1896-d1d2-43c3-92d5-7a5b35c217bb # ./rules/sigma/other/msexchange/win_exchange_cve_2021_42321.yml
-9f7aa113-9da6-4a8d-907c-5f1a4b908299 # ./rules/sigma/deprecated/powershell_syncappvpublishingserver_exe.yml
-
-# Replaced by hayabusa rules
-c265cf08-3f99-46c1-8d59-328247057d57 # ./rules/sigma/builtin/security/win_user_added_to_local_administrators.yml
-66b6be3d-55d0-4f47-9855-d69df21740ea # ./rules/sigma/builtin/security/win_user_creation.yml
-7b449a5e-1db5-4dd0-a2dc-4e3a67282538 # ./rules/sigma/builtin/security/win_hidden_user_creation.yml
-b20f6158-9438-41be-83da-a5a16ac90c2b # ./rules/sigma/other/taskscheduler/win_rare_schtask_creation.yml

--- a/config/exclude-rules.txt
+++ b/config/exclude-rules.txt
@@ -1,7 +1,9 @@
-4fe151c2-ecf9-4fae-95ae-b88ec9c2fca6
-c92f1896-d1d2-43c3-92d5-7a5b35c217bb
-7b449a5e-1db5-4dd0-a2dc-4e3a67282538
-c265cf08-3f99-46c1-8d59-328247057d57
-66b6be3d-55d0-4f47-9855-d69df21740ea
-9f7aa113-9da6-4a8d-907c-5f1a4b908299
-b20f6158-9438-41be-83da-a5a16ac90c2b
+4fe151c2-ecf9-4fae-95ae-b88ec9c2fca6 # ./rules/sigma/other/msexchange/win_exchange_transportagent.yml
+c92f1896-d1d2-43c3-92d5-7a5b35c217bb # ./rules/sigma/other/msexchange/win_exchange_cve_2021_42321.yml
+9f7aa113-9da6-4a8d-907c-5f1a4b908299 # ./rules/sigma/deprecated/powershell_syncappvpublishingserver_exe.yml
+
+# Replaced by hayabusa rules
+c265cf08-3f99-46c1-8d59-328247057d57 # ./rules/sigma/builtin/security/win_user_added_to_local_administrators.yml
+66b6be3d-55d0-4f47-9855-d69df21740ea # ./rules/sigma/builtin/security/win_user_creation.yml
+7b449a5e-1db5-4dd0-a2dc-4e3a67282538 # ./rules/sigma/builtin/security/win_hidden_user_creation.yml
+b20f6158-9438-41be-83da-a5a16ac90c2b # ./rules/sigma/other/taskscheduler/win_rare_schtask_creation.yml

--- a/config/noisy-rules-full.txt
+++ b/config/noisy-rules-full.txt
@@ -1,9 +1,0 @@
-0f06a3a5-6a09-413f-8743-e6cf35561297 # ./rules/sigma/wmi_event/sysmon_wmi_event_subscription.yml
-b0d77106-7bb0-41fe-bd94-d1752164d066 # ./rules/sigma/builtin/security/win_rare_schtasks_creations.yml
-66bfef30-22a5-4fcd-ad44-8d81e60922ae # ./rules/sigma/builtin/system/win_rare_service_installs.yml
-e98374a6-e2d9-4076-9b5c-11bdb2569995 # ./rules/sigma/builtin/security/win_susp_failed_logons_single_source.yml
-6309ffc4-8fa2-47cf-96b8-a2f72e58e538 # ./rules/sigma/builtin/security/win_susp_failed_logons_single_source2.yml
-61ab5496-748e-4818-a92f-de78e20fe7f1 # ./rules/sigma/process_creation/win_multiple_suspicious_cli.yml
-add2ef8d-dc91-4002-9e7e-f2702369f53a # ./rules/sigma/builtin/security/win_susp_failed_remote_logons_single_source.yml
-196a29c2-e378-48d8-ba07-8a9e61f7fab9 # ./rules/sigma/builtin/security/win_susp_failed_logons_explicit_credentials.yml
-72124974-a68b-4366-b990-d30e0b2a190d # ./rules/sigma/builtin/security/win_metasploit_authentication.yml

--- a/config/noisy-rules.txt
+++ b/config/noisy-rules.txt
@@ -1,9 +1,9 @@
-0f06a3a5-6a09-413f-8743-e6cf35561297
-b0d77106-7bb0-41fe-bd94-d1752164d066
-66bfef30-22a5-4fcd-ad44-8d81e60922ae
-e98374a6-e2d9-4076-9b5c-11bdb2569995
-6309ffc4-8fa2-47cf-96b8-a2f72e58e538
-61ab5496-748e-4818-a92f-de78e20fe7f1
-add2ef8d-dc91-4002-9e7e-f2702369f53a
-196a29c2-e378-48d8-ba07-8a9e61f7fab9
-72124974-a68b-4366-b990-d30e0b2a190d
+0f06a3a5-6a09-413f-8743-e6cf35561297 # ./rules/sigma/wmi_event/sysmon_wmi_event_subscription.yml
+b0d77106-7bb0-41fe-bd94-d1752164d066 # ./rules/sigma/builtin/security/win_rare_schtasks_creations.yml
+66bfef30-22a5-4fcd-ad44-8d81e60922ae # ./rules/sigma/builtin/system/win_rare_service_installs.yml
+e98374a6-e2d9-4076-9b5c-11bdb2569995 # ./rules/sigma/builtin/security/win_susp_failed_logons_single_source.yml
+6309ffc4-8fa2-47cf-96b8-a2f72e58e538 # ./rules/sigma/builtin/security/win_susp_failed_logons_single_source2.yml
+61ab5496-748e-4818-a92f-de78e20fe7f1 # ./rules/sigma/process_creation/win_multiple_suspicious_cli.yml
+add2ef8d-dc91-4002-9e7e-f2702369f53a # ./rules/sigma/builtin/security/win_susp_failed_remote_logons_single_source.yml
+196a29c2-e378-48d8-ba07-8a9e61f7fab9 # ./rules/sigma/builtin/security/win_susp_failed_logons_explicit_credentials.yml
+72124974-a68b-4366-b990-d30e0b2a190d # ./rules/sigma/builtin/security/win_metasploit_authentication.yml

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -19,7 +19,7 @@ pub fn exclude_ids() -> RuleExclude {
     };
     let reader = BufReader::new(f);
     for v in reader.lines() {
-        let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].to_string();
+        let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].trim().to_string();
         if v.is_empty() {
             // 空行は無視する。
             continue;
@@ -39,7 +39,7 @@ pub fn exclude_ids() -> RuleExclude {
         };
         let reader = BufReader::new(f);
         for v in reader.lines() {
-            let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].to_string();
+            let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].trim().to_string();
             if v.is_empty() {
                 // 空行は無視する。
                 continue;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -62,7 +62,7 @@ impl RuleExclude {
                 .trim()
                 .to_string();
             if v.is_empty() || !IDS_REGEX.is_match(&v) {
-                // 空行は無視する。
+                // 空行は無視する。IDの検証
                 continue;
             }
             self.no_use_rule.insert(v);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,15 +2,16 @@ use crate::detections::configs;
 use crate::detections::print::AlertMessage;
 use crate::detections::print::ERROR_LOG_STACK;
 use crate::detections::print::QUIET_ERRORS_FLAG;
+use lazy_static::lazy_static;
+use regex::Regex;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::BufWriter;
 use std::io::{BufRead, BufReader};
-use lazy_static::lazy_static;
-use regex::Regex;
 
 lazy_static! {
-    static ref IDS_REGEX :Regex = Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
+    static ref IDS_REGEX: Regex =
+        Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
 }
 
 #[derive(Clone, Debug)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -45,7 +45,7 @@ impl RuleExclude {
             if configs::CONFIG.read().unwrap().args.is_present("verbose") {
                 AlertMessage::alert(
                     &mut BufWriter::new(std::io::stderr().lock()),
-                    &format!("[ERROR] {}", f.as_ref().unwrap_err()),
+                    &format!("{} does not exist", filename),
                 )
                 .ok();
             }
@@ -53,7 +53,7 @@ impl RuleExclude {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", f.as_ref().unwrap_err()));
+                    .push(format!("{} does not exist", filename));
             }
             return ();
         }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,6 +6,12 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::BufWriter;
 use std::io::{BufRead, BufReader};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref IDS_REGEX :Regex = Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
+}
 
 #[derive(Clone, Debug)]
 pub struct RuleExclude {
@@ -55,7 +61,7 @@ impl RuleExclude {
             let v = v.unwrap().split("#").collect::<Vec<&str>>()[0]
                 .trim()
                 .to_string();
-            if v.is_empty() {
+            if v.is_empty() || !IDS_REGEX.is_match(&v) {
                 // 空行は無視する。
                 continue;
             }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,10 @@
 use crate::detections::configs;
+use crate::detections::print::AlertMessage;
+use crate::detections::print::ERROR_LOG_STACK;
+use crate::detections::print::QUIET_ERRORS_FLAG;
 use std::collections::HashSet;
 use std::fs::File;
+use std::io::BufWriter;
 use std::io::{BufRead, BufReader};
 
 #[derive(Clone, Debug)]
@@ -13,40 +17,49 @@ pub fn exclude_ids() -> RuleExclude {
         no_use_rule: HashSet::new(),
     };
 
-    let f = match File::open("config/exclude-rules.txt") {
-        Ok(file) => file,
-        Err(_) => panic!("config/exclude-rules.txt does not exist"),
-    };
-    let reader = BufReader::new(f);
-    for v in reader.lines() {
-        let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].trim().to_string();
-        if v.is_empty() {
-            // 空行は無視する。
-            continue;
-        }
-        exclude_ids.no_use_rule.insert(v);
-    }
-
     if !configs::CONFIG
         .read()
         .unwrap()
         .args
         .is_present("enable-noisy-rules")
     {
-        let f = match File::open("config/noisy-rules.txt") {
-            Ok(file) => file,
-            Err(_) => panic!("config/noisy-rules.txt does not exist"),
-        };
-        let reader = BufReader::new(f);
+        exclude_ids.insert_ids("config/noisy-rules.txt");
+    };
+
+    exclude_ids.insert_ids("config/exclude-rules.txt");
+
+    return exclude_ids;
+}
+
+impl RuleExclude {
+    fn insert_ids(&mut self, filename: &str) {
+        let f = File::open(filename);
+        if f.is_err() {
+            if configs::CONFIG.read().unwrap().args.is_present("verbose") {
+                AlertMessage::alert(
+                    &mut BufWriter::new(std::io::stderr().lock()),
+                    &format!("[ERROR] {}", f.as_ref().unwrap_err()),
+                )
+                .ok();
+            }
+            if !*QUIET_ERRORS_FLAG {
+                ERROR_LOG_STACK
+                    .lock()
+                    .unwrap()
+                    .push(format!("[ERROR] {}", f.as_ref().unwrap_err()));
+            }
+            return ();
+        }
+        let reader = BufReader::new(f.unwrap());
         for v in reader.lines() {
-            let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].trim().to_string();
+            let v = v.unwrap().split("#").collect::<Vec<&str>>()[0]
+                .trim()
+                .to_string();
             if v.is_empty() {
                 // 空行は無視する。
                 continue;
             }
-            exclude_ids.no_use_rule.insert(v);
+            self.no_use_rule.insert(v);
         }
-    };
-
-    return exclude_ids;
+    }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,7 @@
 use crate::detections::configs;
 use std::collections::HashSet;
-use std::fs;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 
 #[derive(Clone, Debug)]
 pub struct RuleExclude {
@@ -8,11 +9,23 @@ pub struct RuleExclude {
 }
 
 pub fn exclude_ids() -> RuleExclude {
-    let mut ids;
-    match fs::read("config/exclude-rules.txt") {
-        Ok(file) => ids = String::from_utf8(file).unwrap(),
+    let mut exclude_ids = RuleExclude {
+        no_use_rule: HashSet::new(),
+    };
+
+    let f = match File::open("config/exclude-rules.txt") {
+        Ok(file) => file,
         Err(_) => panic!("config/exclude-rules.txt does not exist"),
     };
+    let reader = BufReader::new(f);
+    for v in reader.lines() {
+        let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].to_string();
+        if v.is_empty() {
+            // 空行は無視する。
+            continue;
+        }
+        exclude_ids.no_use_rule.insert(v);
+    }
 
     if !configs::CONFIG
         .read()
@@ -20,25 +33,20 @@ pub fn exclude_ids() -> RuleExclude {
         .args
         .is_present("enable-noisy-rules")
     {
-        ids += "\n"; // 改行を入れないとexclude-rulesの一番最後の行とnoisy-rules.txtの一番最初の行が一行にまとめられてしまう。
-        match fs::read("config/noisy-rules.txt") {
-            Ok(file) => ids += &String::from_utf8(file).unwrap(),
+        let f = match File::open("config/noisy-rules.txt") {
+            Ok(file) => file,
             Err(_) => panic!("config/noisy-rules.txt does not exist"),
         };
-    }
-
-    let mut exclude_ids = RuleExclude {
-        no_use_rule: HashSet::new(),
-    };
-
-    for v in ids.split_whitespace() {
-        let v = v.to_string();
-        if v.is_empty() {
-            // 空行は無視する。
-            continue;
+        let reader = BufReader::new(f);
+        for v in reader.lines() {
+            let v = v.unwrap().split("#").collect::<Vec<&str>>()[0].to_string();
+            if v.is_empty() {
+                // 空行は無視する。
+                continue;
+            }
+            exclude_ids.no_use_rule.insert(v);
         }
-        exclude_ids.no_use_rule.insert(v);
-    }
+    };
 
     return exclude_ids;
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -43,7 +43,7 @@ impl RuleExclude {
         let f = File::open(filename);
         if f.is_err() {
             if configs::CONFIG.read().unwrap().args.is_present("verbose") {
-                AlertMessage::alert(
+                AlertMessage::warn(
                     &mut BufWriter::new(std::io::stderr().lock()),
                     &format!("{} does not exist", filename),
                 )


### PR DESCRIPTION
fix #358.

アルゴリズムは、一行ずつ取り出して、#を基準にして、split()で配列に分けて、0番目の添え字に対して、ID validationが通れば、そのIDを対象とすることにしています。

このアルゴリズムがダメだったら、指摘してください。