### PR TITLE
[WIP] ルール場所指定オプションでファイルを扱えるようにする。

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -55,7 +55,7 @@ fn build_app<'a>() -> ArgMatches<'a> {
 
     let usages = "-d --directory=[DIRECTORY] 'Directory of multiple .evtx files'
     -f --filepath=[FILEPATH] 'File path to one .evtx file'
-    -r --rules=[RULEDIRECTORY] 'Rule file directory (default: ./rules)'
+    -r --rules=[RULEDIRECTORY/RULEFILE] 'Rule file or directory (default: ./rules)'
     -o --output=[CSV_TIMELINE] 'Save the timeline in CSV format. Example: results.csv'
     -v --verbose 'Output verbose information'
     -D --enable-deprecated-rules 'Enable sigma rules marked as deprecated'

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -69,7 +69,7 @@ impl Detection {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", errmsg));
+                    .push(format!("{}", errmsg));
             }
             return vec![];
         }
@@ -95,12 +95,12 @@ impl Detection {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("[WARN] {}", errmsg_body));
+                        .push(format!("{}", errmsg_body));
                     err_msgs.iter().for_each(|err_msg| {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[WARN] {}", err_msg));
+                            .push(format!("{}", err_msg));
                     });
                 }
                 parseerror_count += 1;

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -66,10 +66,7 @@ impl Detection {
                 AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg).ok();
             }
             if !*QUIET_ERRORS_FLAG {
-                ERROR_LOG_STACK
-                    .lock()
-                    .unwrap()
-                    .push(format!("{}", errmsg));
+                ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
             }
             return vec![];
         }
@@ -97,10 +94,7 @@ impl Detection {
                         .unwrap()
                         .push(format!("{}", errmsg_body));
                     err_msgs.iter().for_each(|err_msg| {
-                        ERROR_LOG_STACK
-                            .lock()
-                            .unwrap()
-                            .push(format!("{}", err_msg));
+                        ERROR_LOG_STACK.lock().unwrap().push(format!("{}", err_msg));
                     });
                 }
                 parseerror_count += 1;

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -93,10 +93,7 @@ fn get_alias_value_in_record(
                 AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg).ok();
             }
             if !*QUIET_ERRORS_FLAG {
-                ERROR_LOG_STACK
-                    .lock()
-                    .unwrap()
-                    .push(format!("{}", errmsg));
+                ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
             }
             return None;
         }
@@ -195,10 +192,7 @@ impl TimeFrameInfo {
                 AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg).ok();
             }
             if !*QUIET_ERRORS_FLAG {
-                ERROR_LOG_STACK
-                    .lock()
-                    .unwrap()
-                    .push(format!("{}", errmsg));
+                ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
             }
         }
         return TimeFrameInfo {

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -96,7 +96,7 @@ fn get_alias_value_in_record(
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", errmsg));
+                    .push(format!("{}", errmsg));
             }
             return None;
         }
@@ -198,7 +198,7 @@ impl TimeFrameInfo {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", errmsg));
+                    .push(format!("{}", errmsg));
             }
         }
         return TimeFrameInfo {
@@ -236,7 +236,7 @@ pub fn get_sec_timeframe(rule: &RuleNode) -> Option<i64> {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", errmsg.to_string()));
+                    .push(format!("{}", errmsg.to_string()));
             }
             return Option::None;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,10 +148,7 @@ impl App {
                 AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg).ok();
             }
             if !*QUIET_ERRORS_FLAG {
-                ERROR_LOG_STACK
-                    .lock()
-                    .unwrap()
-                    .push(format!("{}", errmsg));
+                ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
             }
             return vec![];
         }
@@ -263,10 +260,7 @@ impl App {
                             .ok();
                     }
                     if !*QUIET_ERRORS_FLAG {
-                        ERROR_LOG_STACK
-                            .lock()
-                            .unwrap()
-                            .push(format!("{}", errmsg));
+                        ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
                     }
                     continue;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ impl App {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("[ERROR] {}", errmsg));
+                    .push(format!("{}", errmsg));
             }
             return vec![];
         }
@@ -266,7 +266,7 @@ impl App {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[ERROR] {}", errmsg));
+                            .push(format!("{}", errmsg));
                     }
                     continue;
                 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -62,10 +62,7 @@ impl ParseYaml {
                 AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
             }
             if !*QUIET_ERRORS_FLAG {
-                ERROR_LOG_STACK
-                    .lock()
-                    .unwrap()
-                    .push(format!("{}", errmsg));
+                ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
             }
         }
         let mut yaml_docs = vec![];
@@ -93,10 +90,7 @@ impl ParseYaml {
                     AlertMessage::warn(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
                 }
                 if !*QUIET_ERRORS_FLAG {
-                    ERROR_LOG_STACK
-                        .lock()
-                        .unwrap()
-                        .push(format!("{}", errmsg));
+                    ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -114,10 +108,7 @@ impl ParseYaml {
                     AlertMessage::warn(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
                 }
                 if !*QUIET_ERRORS_FLAG {
-                    ERROR_LOG_STACK
-                        .lock()
-                        .unwrap()
-                        .push(format!("{}", errmsg));
+                    ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -159,10 +150,7 @@ impl ParseYaml {
                         AlertMessage::warn(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
                     }
                     if !*QUIET_ERRORS_FLAG {
-                        ERROR_LOG_STACK
-                            .lock()
-                            .unwrap()
-                            .push(format!("{}", errmsg));
+                        ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);
@@ -180,10 +168,7 @@ impl ParseYaml {
                         AlertMessage::warn(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
                     }
                     if !*QUIET_ERRORS_FLAG {
-                        ERROR_LOG_STACK
-                            .lock()
-                            .unwrap()
-                            .push(format!("{}", errmsg));
+                        ERROR_LOG_STACK.lock().unwrap().push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -53,8 +53,21 @@ impl ParseYaml {
         exclude_ids: &RuleExclude,
     ) -> io::Result<String> {
         let metadata = fs::metadata(path.as_ref());
-        if metadata.is_err() {}
-
+        if metadata.is_err() {
+            let errmsg = format!(
+                "fail to read metadata of file: {}",
+                path.as_ref().to_path_buf().display(),
+            );
+            if configs::CONFIG.read().unwrap().args.is_present("verbose") {
+                AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
+            }
+            if !*QUIET_ERRORS_FLAG {
+                ERROR_LOG_STACK
+                    .lock()
+                    .unwrap()
+                    .push(format!("{}", errmsg));
+            }
+        }
         let mut yaml_docs = vec![];
         if metadata.unwrap().file_type().is_file() {
             // 拡張子がymlでないファイルは無視
@@ -83,7 +96,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("[WARN] {}", errmsg));
+                        .push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -104,7 +117,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("[WARN] {}", errmsg));
+                        .push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -149,7 +162,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[WARN] {}", errmsg));
+                            .push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);
@@ -170,7 +183,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[WARN] {}", errmsg));
+                            .push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);


### PR DESCRIPTION
fix #311

現状、ルール場所を指定するオプションはディレクトリしか指定できない。

ファイルも指定できるようにする。

両社とも同じオプションにしました。（--rules)

ちょっと、手動テストがまだなのでWIP。