### PR TITLE
ルール場所指定オプションでファイルを扱えるようにする

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -55,7 +55,7 @@ fn build_app<'a>() -> ArgMatches<'a> {
 
     let usages = "-d --directory=[DIRECTORY] 'Directory of multiple .evtx files'
     -f --filepath=[FILEPATH] 'File path to one .evtx file'
-    -r --rules=[RULEDIRECTORY] 'Rule file directory (default: ./rules)'
+    -r --rules=[RULEDIRECTORY/RULEFILE] 'Rule file or directory (default: ./rules)'
     -o --output=[CSV_TIMELINE] 'Save the timeline in CSV format. Example: results.csv'
     -v --verbose 'Output verbose information'
     -D --enable-deprecated-rules 'Enable sigma rules marked as deprecated'

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -278,6 +278,22 @@ mod tests {
     use yaml_rust::YamlLoader;
 
     #[test]
+    fn test_read_one_file() {
+        AlertMessage::create_error_log(ERROR_LOG_PATH.to_string());
+
+        let mut yaml = yaml::ParseYaml::new();
+        let exclude_ids = RuleExclude {
+            no_use_rule: HashSet::new(),
+        };
+        let _ = &yaml.read_dir(
+            "test_files/rules/yaml/1.yml".to_string(),
+            &String::default(),
+            &exclude_ids,
+        );
+        assert_eq!(yaml.files.len(), 1);
+    }
+
+    #[test]
     fn test_read_dir_yaml() {
         AlertMessage::create_error_log(ERROR_LOG_PATH.to_string());
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -278,7 +278,7 @@ mod tests {
     use yaml_rust::YamlLoader;
 
     #[test]
-    fn test_read_one_file() {
+    fn test_read_file_yaml() {
         AlertMessage::create_error_log(ERROR_LOG_PATH.to_string());
 
         let mut yaml = yaml::ParseYaml::new();

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -53,8 +53,21 @@ impl ParseYaml {
         exclude_ids: &RuleExclude,
     ) -> io::Result<String> {
         let metadata = fs::metadata(path.as_ref());
-        if metadata.is_err() {}
-
+        if metadata.is_err() {
+            let errmsg = format!(
+                "fail to read metadata of file: {}",
+                path.as_ref().to_path_buf().display(),
+            );
+            if configs::CONFIG.read().unwrap().args.is_present("verbose") {
+                AlertMessage::alert(&mut BufWriter::new(std::io::stderr().lock()), &errmsg)?;
+            }
+            if !*QUIET_ERRORS_FLAG {
+                ERROR_LOG_STACK
+                    .lock()
+                    .unwrap()
+                    .push(format!("{}", errmsg));
+            }
+        }
         let mut yaml_docs = vec![];
         if metadata.unwrap().file_type().is_file() {
             // 拡張子がymlでないファイルは無視
@@ -83,7 +96,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("[WARN] {}", errmsg));
+                        .push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -104,7 +117,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("[WARN] {}", errmsg));
+                        .push(format!("{}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -149,7 +162,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[WARN] {}", errmsg));
+                            .push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);
@@ -170,7 +183,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("[WARN] {}", errmsg));
+                            .push(format!("{}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -65,7 +65,7 @@ impl ParseYaml {
                 ERROR_LOG_STACK
                     .lock()
                     .unwrap()
-                    .push(format!("{}", errmsg));
+                    .push(format!("[ERROR] {}", errmsg));
             }
         }
         let mut yaml_docs = vec![];
@@ -96,7 +96,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("{}", errmsg));
+                        .push(format!("[WARN] {}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -117,7 +117,7 @@ impl ParseYaml {
                     ERROR_LOG_STACK
                         .lock()
                         .unwrap()
-                        .push(format!("{}", errmsg));
+                        .push(format!("[WARN] {}", errmsg));
                 }
                 self.errorrule_count += 1;
                 return io::Result::Ok(String::default());
@@ -162,7 +162,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("{}", errmsg));
+                            .push(format!("[WARN] {}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);
@@ -183,7 +183,7 @@ impl ParseYaml {
                         ERROR_LOG_STACK
                             .lock()
                             .unwrap()
-                            .push(format!("{}", errmsg));
+                            .push(format!("[WARN] {}", errmsg));
                     }
                     self.errorrule_count += 1;
                     return io::Result::Ok(ret);


### PR DESCRIPTION
fix #311

現状、ルール場所を指定するオプションはディレクトリしか指定できない。

ファイルも指定できるようにする。

両方とも同じオプションでできるようにしました。（--rules)
