### PR TITLE
removed csv quote when output result to stdout #381

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -4,6 +4,7 @@ use crate::detections::print::AlertMessage;
 use crate::detections::utils;
 use chrono::{DateTime, Local, TimeZone, Utc};
 use colored::*;
+use csv::QuoteStyle;
 use hashbrown::HashMap;
 use serde::Serialize;
 use std::error::Error;
@@ -117,6 +118,8 @@ fn emit_csv<W: std::io::Write>(
     let mut wtr;
     if displayflag {
         wtr = csv::WriterBuilder::new()
+            .double_quote(false)
+            .quote_style(QuoteStyle::Never)
             .delimiter(b'|')
             .from_writer(writer);
     } else {


### PR DESCRIPTION
closes #381 

## evidence

- removed csv encode in stdout 
```
>./hayabusa.exe -d .\hayabusa-sample-evtx\ -r ..\hayabusa-rules\
...
2021-10-28 22:41:21.325 +09:00 | FS03.offsec.lan | 1 | high | Process Creation Sysmon Rule Alert | Rule: technique_id=T1059,technique_name=Command-Line Interface  :  Command: "cmd.exe"  :  Path: C:\Windows\System32\cmd.exe  :  User: NT AUTHORITY\SYSTEM  :  Parent Command: C:\Windows\System32\spoolsv.exe
...
2021-11-18 16:42:54.822 +09:00 | PC-01.cybercat.local | 1 | high | Process Creation Sysmon Rule Alert | Rule: technique_id=T1218.004,technique_name=InstallUtil  :  Command: C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe  /logfile= /LogToConsole=false /U C:\Users\pc1-user\Desktop\zoom-update.exe  :  Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe  :  User: CYBERCAT\pc1-user  :  Parent Command: "C:\Windows\system32\cmd.exe" 
```

- output csv case

```
> ./hayabusa.exe -d .\hayabusa-sample-evtx\ -r ..\hayabusa-rules\ -o csvoutput.csv
... 
2021-11-18 16:42:54.822 +09:00,PC-01.cybercat.local,1,high,Process Creation Sysmon Rule Alert,"Rule: technique_id=T1218.004,technique_name=InstallUtil  :  Command: C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe  /logfile= /LogToConsole=false /U C:\Users\pc1-user\Desktop\zoom-update.exe  :  Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe  :  User: CYBERCAT\pc1-user  :  Parent Command: ""C:\Windows\system32\cmd.exe"" ",..\hayabusa-rules\hayabusa\sysmon\alerts\1_ProcessCreationSysmonAlert.yml,.\hayabusa-sample-evtx\YamatoSecurity\T1218.004_Signed Binary Proxy Execution InstallUtil\sysmon.evtx

```