### PR TITLE
remove yaml ignore check#271

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -416,7 +416,26 @@ mod tests {
             .datetime_from_str("1996-02-27T01:05:01Z", "%Y-%m-%dT%H:%M:%SZ")
             .unwrap();
         let expect_tz = expect_time.with_timezone(&Local);
-        let expect = "Timestamp|Computer|EventID|Level|RuleTitle|Details\n".to_string()
+        let expect_header = "Timestamp|Computer|EventID|Level|RuleTitle|Details\n";
+        let expect_colored = expect_header.to_string()
+            + &get_white_color_string(
+                &expect_tz
+                    .clone()
+                    .format("%Y-%m-%d %H:%M:%S%.3f %:z")
+                    .to_string(),
+            )
+            + " | "
+            + &get_white_color_string(test_computername)
+            + " | "
+            + &get_white_color_string(test_eventid)
+            + " | "
+            + &get_white_color_string(test_level)
+            + " | "
+            + &get_white_color_string(test_title)
+            + " | "
+            + &get_white_color_string(output)
+            + "\n";
+        let expect_nocoloed = expect_header.to_string()
             + &expect_tz
                 .clone()
                 .format("%Y-%m-%d %H:%M:%S%.3f %:z")
@@ -438,9 +457,16 @@ mod tests {
         match read_to_string("./test_emit_csv_display.txt") {
             Err(_) => panic!("Failed to open file."),
             Ok(s) => {
-                assert_eq!(s, expect);
+                assert!(s == expect_colored || s == expect_nocoloed);
             }
         };
         assert!(remove_file("./test_emit_csv_display.txt").is_ok());
+    }
+
+    fn get_white_color_string(target: &str) -> String {
+        let white_color_header = "\u{1b}[38;2;255;255;255m";
+        let white_color_footer = "\u{1b}[0m";
+
+        return white_color_header.to_owned() + target + white_color_footer;
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -124,29 +124,6 @@ impl ParseYaml {
         let files: Vec<(String, Yaml)> = yaml_docs
             .into_iter()
             .filter_map(|(filepath, yaml_doc)| {
-                self.rulecounter.insert(
-                    yaml_doc["ruletype"].as_str().unwrap_or("Other").to_string(),
-                    self.rulecounter
-                        .get(&yaml_doc["ruletype"].as_str().unwrap_or("Other").to_string())
-                        .unwrap_or(&0)
-                        + 1,
-                );
-
-                if configs::CONFIG.read().unwrap().args.is_present("verbose") {
-                    println!("Loaded yml file path: {}", filepath);
-                }
-                // 指定されたレベルより低いルールは無視する
-                let doc_level = &yaml_doc["level"]
-                    .as_str()
-                    .unwrap_or("informational")
-                    .to_string()
-                    .to_uppercase();
-                let doc_level_num = configs::LEVELMAP.get(doc_level).unwrap_or(&1);
-                let args_level_num = configs::LEVELMAP.get(level).unwrap_or(&1);
-                if doc_level_num < args_level_num {
-                    return Option::None;
-                }
-
                 //除外されたルールは無視する
                 let rule_id = &yaml_doc["id"].as_str();
                 if rule_id.is_some() {
@@ -160,6 +137,30 @@ impl ParseYaml {
                             return Option::None;
                         }
                     }
+                }
+
+                self.rulecounter.insert(
+                    yaml_doc["ruletype"].as_str().unwrap_or("Other").to_string(),
+                    self.rulecounter
+                        .get(&yaml_doc["ruletype"].as_str().unwrap_or("Other").to_string())
+                        .unwrap_or(&0)
+                        + 1,
+                );
+
+                if configs::CONFIG.read().unwrap().args.is_present("verbose") {
+                    println!("Loaded yml file path: {}", filepath);
+                }
+
+                // 指定されたレベルより低いルールは無視する
+                let doc_level = &yaml_doc["level"]
+                    .as_str()
+                    .unwrap_or("informational")
+                    .to_string()
+                    .to_uppercase();
+                let doc_level_num = configs::LEVELMAP.get(doc_level).unwrap_or(&1);
+                let args_level_num = configs::LEVELMAP.get(level).unwrap_or(&1);
+                if doc_level_num < args_level_num {
+                    return Option::None;
                 }
 
                 if !configs::CONFIG

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -124,11 +124,6 @@ impl ParseYaml {
         let files: Vec<(String, Yaml)> = yaml_docs
             .into_iter()
             .filter_map(|(filepath, yaml_doc)| {
-                // ignoreフラグがONになっているルールは無視する。
-                if yaml_doc["ignore"].as_bool().unwrap_or(false) {
-                    self.ignorerule_count += 1;
-                    return Option::None;
-                }
                 self.rulecounter.insert(
                     yaml_doc["ruletype"].as_str().unwrap_or("Other").to_string(),
                     self.rulecounter


### PR DESCRIPTION
Closes #271

yamlのignore部分をチェックする処理はfilterのexculde idで対応することになったため削除。
exclude idの対象になっているルールのチェックの処理を読み込み時の一番最初にもっていく形に変更しました。

これによる処理の出力等に変更はありません