### PR TITLE
Bug/ Fixed error when target environment is not installed vcc redistribute package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slack-hook",
+ "static_vcruntime",
  "tokio 1.16.0",
  "yaml-rust",
 ]
@@ -1988,6 +1989,12 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "static_vcruntime"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c15d6fe7210ea80c578b53855615fdea0188e1630b6d9c377e1b2f2c098fa"
 
 [[package]]
 name = "stdweb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4.*"
 
 [target.'cfg(windows)'.dependencies]
 is_elevated = "0.1.2"
+static_vcruntime = "1.5.*"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate serde;
 extern crate serde_derive;
+extern crate static_vcruntime;
 
 use chrono::Datelike;
 use chrono::{DateTime, Local};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 extern crate serde;
 extern crate serde_derive;
+
+#[cfg(target_os = "windows")]
 extern crate static_vcruntime;
 
 use chrono::Datelike;


### PR DESCRIPTION
Fixed #404 

## What Changed
- add crate static_vcruntime to reduce error when target environment  is not installed Visual C++ Redistribute Package