### PR TITLE
changed downcast library from mopa to downcast_rs #447

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +846,7 @@ dependencies = [
  "colored",
  "csv",
  "dotenv",
+ "downcast-rs",
  "evtx",
  "flate2",
  "git2",
@@ -849,7 +856,6 @@ dependencies = [
  "is_elevated",
  "lazy_static",
  "linked-hash-map",
- "mopa",
  "num_cpus",
  "pbr",
  "quick-xml",
@@ -1294,12 +1300,6 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "mopa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915"
 
 [[package]]
 name = "native-tls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ yaml-rust = "0.4.*"
 linked-hash-map = "0.5.*"
 tokio = { version = "1", features = ["full"] }
 num_cpus = "1.13.*"
-mopa = "0.2.*"
+downcast-rs = "1.2.0"
 slack-hook = "0.8"
 dotenv = "0.15.*"
 hhmmss = "*"

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use yaml_rust::Yaml;
 
 use crate::detections::{detection::EvtxRecordInfo, utils};
-use mopa::mopafy;
+use downcast_rs::Downcast;
 
 use lazy_static::lazy_static;
 lazy_static! {
@@ -15,7 +15,7 @@ lazy_static! {
 //
 // 新規にLeafMatcherを実装するクラスを作成した場合、
 // LeafSelectionNodeのget_matchersクラスの戻り値の配列に新規作成したクラスのインスタンスを追加する。
-pub trait LeafMatcher: mopa::Any {
+pub trait LeafMatcher: Downcast {
     /// 指定されたkey_listにマッチするLeafMatcherであるかどうか判定する。
     fn is_target_key(&self, key_list: &[String]) -> bool;
 
@@ -28,7 +28,7 @@ pub trait LeafMatcher: mopa::Any {
     /// ルールファイルの書き方が間違っている等の原因により、正しくルールファイルからパースできない場合、戻り値のResult型でエラーを返してください。
     fn init(&mut self, key_list: &[String], select_value: &Yaml) -> Result<(), Vec<String>>;
 }
-mopafy!(LeafMatcher);
+downcast_rs::impl_downcast!(LeafMatcher);
 
 /// 指定された文字数以上であることをチェックするクラス。
 pub struct MinlengthMatcher {

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -1,13 +1,13 @@
 use crate::detections::{detection::EvtxRecordInfo, utils};
 use crate::filter::FILTER_REGEX;
-use mopa::mopafy;
+use downcast_rs::Downcast;
 use std::{sync::Arc, vec};
 use yaml_rust::Yaml;
 
 use super::matchers;
 
 // Ruleファイルの detection- selection配下のノードはこのtraitを実装する。
-pub trait SelectionNode: mopa::Any {
+pub trait SelectionNode: Downcast {
     // 引数で指定されるイベントログのレコードが、条件に一致するかどうかを判定する
     // このトレイトを実装する構造体毎に適切な判定処理を書く必要がある。
     fn select(&self, event_record: &EvtxRecordInfo) -> bool;
@@ -24,7 +24,7 @@ pub trait SelectionNode: mopa::Any {
     // 子孫ノードを取得する(グラフ理論のdescendantと同じ意味)
     fn get_descendants(&self) -> Vec<&dyn SelectionNode>;
 }
-mopafy!(SelectionNode);
+downcast_rs::impl_downcast!(SelectionNode);
 
 /// detection - selection配下でAND条件を表すノード
 pub struct AndSelectionNode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+extern crate downcast_rs;
 extern crate serde;
 extern crate serde_derive;
 


### PR DESCRIPTION
Closed #447 

##What Changed

- Changed downcast library from mopa to downcast-rs (To reduce clippy warn)

## Evidence

- develop branch

``` powershell
> ./hayabusa.exe -d hayabusa-sample-evtx -o developbranch.csv

Analyzing event files: 509
Hayabusa rules: 67
Sigma rules: 1348
Ignored rules: 83
Rule parsing errors: 0
Total enabled detection rules: 1415

Total detections: 12263
Total critical detections: 109
Total high detections: 1574
Total medium detections: 532
Total low detections: 5239
Total informational detections: 4809
Total undefined detections: 0
Unique detections: 349
Unique critical detections: 29
Unique high detections: 155
Unique medium detections: 95
Unique low detections: 44
Unique informational detections: 26
Unique undefined detections: 0
```

- this pull request ver.
 
```powershell
> ./hayabusa.exe -d hayabusa-sample-evtx -o pr447.csv

Analyzing event files: 509
Sigma rules: 1348
Hayabusa rules: 67
Ignored rules: 83
Rule parsing errors: 0
Total enabled detection rules: 1415

Total detections: 12263
Total critical detections: 109
Total high detections: 1574
Total medium detections: 532
Total low detections: 5239
Total informational detections: 4809
Total undefined detections: 0
Unique detections: 349
Unique critical detections: 29
Unique high detections: 155
Unique medium detections: 95
Unique low detections: 44
Unique informational detections: 26
Unique undefined detections: 0

Elapsed Time: 00:00:38.277
```