### PR TITLE
fix degrade for pull req #464

### DIFF
--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -116,7 +116,9 @@ impl Message {
             if is_exist_event_key {
                 let hash_value = get_serde_number_to_string(tmp_event_record);
                 if let Some(hash_value) = hash_value {
-                    let hash_value = hash_value.replace(r"(\\a|\\f|\\t|\\n|\\r|\\v)", " ");
+                    // UnicodeのWhitespace characterをそのままCSVに出力すると見難いので、スペースに変換する。なお、先頭と最後のWhitespace characterは単に削除される。
+                    let hash_value: Vec<&str> = hash_value.split_whitespace().collect();
+                    let hash_value = hash_value.join(" ");
                     hash_map.insert(full_target_str.to_string(), hash_value);
                 }
             }

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -54,7 +54,7 @@ pub fn value_to_string(value: &Value) -> Option<String> {
         Value::Null => Option::None,
         Value::Bool(b) => Option::Some(b.to_string()),
         Value::Number(n) => Option::Some(n.to_string()),
-        Value::String(s) => Option::Some(s.to_string()),
+        Value::String(s) => Option::Some(s.trim().to_string()),
         Value::Array(_) => Option::None,
         Value::Object(_) => Option::None,
     }


### PR DESCRIPTION
この(プルリク)[https://github.com/Yamato-Security/hayabusa/pull/464]のデグレを修正します。
CSVに出力される値に関して、改行やタブ文字が削除されるのが本来の動作ですが、削除されない感じになっていました。