### PR TITLE
[Bugfix] exculde load yml in git folder#472

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -154,6 +154,11 @@ impl ParseYaml {
                     return io::Result::Ok(ret);
                 }
 
+                // ignore if yml file in .git folder.
+                if path.to_str().unwrap().contains("/.git/") {
+                    return io::Result::Ok(ret);
+                }
+
                 // 個別のファイルの読み込みは即終了としない。
                 let read_content = self.read_file(path);
                 if read_content.is_err() {


### PR DESCRIPTION
fixed #472

## What Changed

- fixed 


## Evidence


- add  ignore.yml in test_files/yaml/rule/.git folder
``` powershell
PS >ls -Recurse test_files/rules/yaml

    Directory: ...\test_files\rules\yaml

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          2022/03/30    20:56                .git
-a---          2021/12/25     9:26            408 1.yml
-a---          2021/12/25     9:26            411 error.yml
-a---          2021/12/25     9:26            451 exclude1.yml
-a---          2021/12/25     9:26            688 exclude2.yml
-a---          2021/12/25     9:26            661 exclude3.yml
-a---          2021/12/25     9:26            845 exclude4.yml
-a---          2021/12/25     9:26            837 exclude5.yml
-a---          2021/12/25     9:26            635 noisy1.yml
-a---          2021/12/25     9:26           1001 noisy2.yml
-a---          2021/12/25     9:26            681 noisy3.yml
-a---          2021/12/25     9:26            911 noisy4.yml
-a---          2021/12/25     9:26            923 noisy5.yml

    Directory: ...test_files\rules\yaml\.git

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          2021/12/25     9:26            408 ignore.yml

```

- check rules in test_files/rules/yaml (13 yml files include .git folder but 1 yml file  exclude load in .git folder. (expected behavior)

```powershell
PS >.\hayabusa.exe -d .\hayabusa-sample-evtx\ -r .\test_files\rules\yaml  -q

Analyzing event files: 509
Other rules: 2
Ignored rules: 10
Rule parsing errors: 1
Total enabled detection rules: 2
```