### PR TITLE
changed output informational level to info

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -142,6 +142,10 @@ fn emit_csv<W: std::io::Write>(
 
     for (time, detect_infos) in messages.iter() {
         for detect_info in detect_infos {
+            let mut level = detect_info.level.to_string();
+            if level == "informational" {
+                level = "info".to_string();
+            }
             if displayflag {
                 let colors = color_map
                     .as_ref()
@@ -160,7 +164,7 @@ fn emit_csv<W: std::io::Write>(
 
                 let dispformat = DisplayFormat {
                     timestamp: &_format_cell(&format_time(time), ColPos::First, colors),
-                    level: &_format_cell(&detect_info.level, ColPos::Other, colors),
+                    level: &_format_cell(&level, ColPos::Other, colors),
                     computer: &_format_cell(&detect_info.computername, ColPos::Other, colors),
                     event_i_d: &_format_cell(&detect_info.eventid, ColPos::Other, colors),
                     rule_title: &_format_cell(&detect_info.alert, ColPos::Other, colors),
@@ -172,7 +176,7 @@ fn emit_csv<W: std::io::Write>(
                 // csv出力時フォーマット
                 wtr.serialize(CsvFormat {
                     timestamp: &format_time(time),
-                    level: &detect_info.level,
+                    level: &level,
                     computer: &detect_info.computername,
                     event_i_d: &detect_info.eventid,
                     mitre_attack: &detect_info.tag_info,


### PR DESCRIPTION
closes #491 

## What Changed

- Changed output level from informational to info
- updated rules submodule

## Evidence

- develop branch 

``` powershell

PS >.\hayabusa.exe -d .\hayabusa-sample-evtx\  -q
...
Analyzing event files: 509
Hayabusa rules: 111
Sigma rules: 2217
Ignored rules: 83
Rule parsing errors: 0
Total enabled detection rules: 2328

Total detections: 14803
Total critical detections: 182
Total high detections: 1881
Total medium detections: 1000
Total low detections: 6303
Total informational detections: 5437
Total undefined detections: 0
Unique detections: 464
Unique critical detections: 32
Unique high detections: 192
Unique medium detections: 131
Unique low detections: 68
Unique informational detections: 41
Unique undefined detections: 0

Elapsed Time: 00:00:29.898

```

- this pull request

``` powershell
PS >.\hayabusa.exe -d .\hayabusa-sample-evtx\  -q
...
2021-11-18 16:43:22.705 +09:00 | PC-01.cybercat.local | 23 | info | Deleted File Archived | C:\Users\pc1-user\AppData\Roaming\Microsoft\Windows\Recent\sysmon.evtx.lnk | Process: C:\Windows\Explorer.EXE | User: CYBERCAT\pc1-user | PID: 3384 | PGUID: 510C1E8A-EF2F-6195-6200-000000000F00

Total detections: 14803
Total critical detections: 182
Total high detections: 1881
Total medium detections: 1000
Total low detections: 6303
Total informational detections: 5437
Total undefined detections: 0
Unique detections: 464
Unique critical detections: 32
Unique high detections: 192
Unique medium detections: 131
Unique low detections: 68
Unique informational detections: 41
Unique undefined detections: 0

Elapsed Time: 00:00:30.340
```