### PR TITLE
level_tuning.txtのパスを./rules/configに移動

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -320,7 +320,7 @@ USAGE:
     -s --statistics 'イベント ID の統計情報を表示する。'
     -q --quiet 'Quietモード。起動バナーを表示しない。'
     -Q --quiet-errors 'Quiet errorsモード。エラーログを保存しない。'
-    --level-tuning <LEVEL_TUNING_FILE> 'ルールlevelのチューニング [default: ./config/level_tuning.txt]'
+    --level-tuning <LEVEL_TUNING_FILE> 'ルールlevelのチューニング [default: ./rules/config/level_tuning.txt]'
     -p --pivot-keywords-list 'ピボットキーワードの一覧作成。'
     --contributors 'コントリビュータの一覧表示。'
 ```
@@ -560,10 +560,10 @@ Hayabusaルールは、Windowsのイベントログ解析専用に設計され�
 ## 検知レベルのlevelチューニング
 
 Hayabusaルール、Sigmaルールはそれぞれの作者が検知した際のリスクレベルを決めています。
-ユーザが独自のリスクレベルに設定するには`./config/level_tuning.txt`に変換情報を書き、`hayabusa.exe --level-tuning`を実行することでルールファイルが書き換えられます。
+ユーザが独自のリスクレベルに設定するには`./rules/config/level_tuning.txt`に変換情報を書き、`hayabusa.exe --level-tuning`を実行することでルールファイルが書き換えられます。
 ルールファイルが直接書き換えられることに注意して使用してください。
 
-`./config/level_tuning.txt`の例:
+`./rules/config/level_tuning.txt`の例:
 ```
 id,new_level
 00000000-0000-0000-0000-000000000000,informational # sample level tuning line

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ USAGE:
     -s --statistics 'Prints statistics of event IDs.'
     -q --quiet 'Quiet mode. Do not display the launch banner.'
     -Q --quiet-errors 'Quiet errors mode. Do not save error logs.'
-    --level-tuning <LEVEL_TUNING_FILE> 'Tune the rule level [default: ./config/level_tuning.txt]'
+    --level-tuning <LEVEL_TUNING_FILE> 'Tune the rule level [default: ./rules/config/level_tuning.txt]'
     -p --pivot-keywords-list 'Create a list of pivot keywords.'
     --contributors 'Prints the list of contributors.'
 ```
@@ -552,10 +552,10 @@ You can also add a rule ID to `rules/config/noisy_rules.txt` in order to ignore 
 
 Hayabusa and Sigma rule authors will determine the risk level of the alert when writing their rules.
 However, the actual risk level will differ between environments.
-You can tune the risk level of the rules by adding them to `./config/level_tuning.txt` and executing `hayabusa.exe --level-tuning` which will update the `level` line in the rule file.
+You can tune the risk level of the rules by adding them to `./rules/config/level_tuning.txt` and executing `hayabusa.exe --level-tuning` which will update the `level` line in the rule file.
 Please note that the rule file will be updated directly.
 
-`./config/level_tuning.txt` sample line:
+`./rules/config/level_tuning.txt` sample line:
 
 ```
 id,new_level

--- a/config/level_tuning.txt
+++ b/config/level_tuning.txt
@@ -1,7 +1,0 @@
-id,new_level
-00000000-0000-0000-0000-000000000000,informational # sample level tuning line
-fdb62a13-9a81-4e5c-a38f-ea93a16f6d7c,medium # "Encoded FromBase64String". Originally critical.
-61a7697c-cb79-42a8-a2ff-5f0cdfae0130,high # "CobaltStrike Service Installations in Registry". Originally critical.
-36803969-5421-41ec-b92f-8500f79c23b0,low # "Detects persistence registry keys". Originally critical. Changed to low due to a high possibility of false positives.
-06d71506-7beb-4f22-8888-e2e5e2ca7fd8,medium # "Mimikatz Use". Originally critical. Rule creates tons of false positives so lowered to medium.
-dae8171c-5ec6-4396-b210-8466585b53e9,medium # "SCM Database Privileged Operation"

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -102,7 +102,7 @@ fn build_app<'a>() -> ArgMatches<'a> {
         .arg(
             // TODO: When update claps to 3.x, these can write in usage texts...
             Arg::from_usage("--level-tuning=[LEVEL_TUNING_FILE] 'Adjust rule level.'")
-                .default_value("./config/level_tuning.txt"),
+                .default_value("./rules/config/level_tuning.txt"),
         )
         .usage(usages)
         .args_from_usage(usages)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -19,10 +19,16 @@ pub struct RuleExclude {
     pub no_use_rule: HashSet<String>,
 }
 
+impl RuleExclude {
+    pub fn default() -> RuleExclude {
+        RuleExclude {
+            no_use_rule: HashSet::new(),
+        }
+    }
+}
+
 pub fn exclude_ids() -> RuleExclude {
-    let mut exclude_ids = RuleExclude {
-        no_use_rule: HashSet::new(),
-    };
+    let mut exclude_ids = RuleExclude::default();
 
     if !configs::CONFIG
         .read()

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ impl App {
                 .unwrap()
                 .args
                 .value_of("level-tuning")
-                .unwrap_or("./config/level_tuning.txt")
+                .unwrap_or("./rules/config/level_tuning.txt")
                 .to_string();
 
             if Path::new(&level_tuning_config_path).exists() {
@@ -253,7 +253,7 @@ impl App {
             } else {
                 AlertMessage::alert(
                     &mut BufWriter::new(std::io::stderr().lock()),
-                    "Need rule_levels.txt file to use --level-tuning option [default: ./config/level_tuning.txt]",
+                    "Need rule_levels.txt file to use --level-tuning option [default: ./rules/config/level_tuning.txt]",
                 )
                 .ok();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -775,9 +775,7 @@ impl App {
             .read_dir(
                 rule_folder_path,
                 "INFORMATIONAL",
-                &filter::RuleExclude {
-                    no_use_rule: HashSet::new(),
-                },
+                &filter::RuleExclude::default(),
             )
             .ok();
 

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -1,5 +1,5 @@
 use crate::detections::{configs, utils};
-use crate::filter;
+use crate::filter::RuleExclude;
 use crate::yaml::ParseYaml;
 use std::collections::HashMap;
 use std::fs::{self, File};
@@ -45,8 +45,9 @@ impl LevelTuning {
 
         // Read Rule files
         let mut rulefile_loader = ParseYaml::new();
+        //noisy rules and exclude rules treats as update target
         let result_readdir =
-            rulefile_loader.read_dir(rules_path, "informational", &filter::exclude_ids());
+            rulefile_loader.read_dir(rules_path, "informational", &RuleExclude::default());
         if result_readdir.is_err() {
             return Result::Err(format!("{}", result_readdir.unwrap_err()));
         }

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -99,9 +99,6 @@ impl LevelTuning {
 #[cfg(test)]
 mod tests {
 
-    // use crate::{filter::RuleExclude, yaml};
-    // use hashbrown::HashSet;
-
     use super::*;
 
     #[test]

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -290,9 +290,7 @@ mod tests {
         AlertMessage::create_error_log(ERROR_LOG_PATH.to_string());
 
         let mut yaml = yaml::ParseYaml::new();
-        let exclude_ids = RuleExclude {
-            no_use_rule: HashSet::new(),
-        };
+        let exclude_ids = RuleExclude::default();
         let _ = &yaml.read_dir(
             "test_files/rules/yaml/1.yml",
             &String::default(),
@@ -401,9 +399,7 @@ mod tests {
 
         let mut yaml = yaml::ParseYaml::new();
         let path = Path::new("test_files/rules/yaml");
-        let exclude_ids = RuleExclude {
-            no_use_rule: HashSet::new(),
-        };
+        let exclude_ids = RuleExclude::default();
         yaml.read_dir(path, "", &exclude_ids).unwrap();
         assert_eq!(yaml.ignorerule_count, 0);
     }
@@ -411,9 +407,7 @@ mod tests {
     fn test_exclude_deprecated_rules_file() {
         let mut yaml = yaml::ParseYaml::new();
         let path = Path::new("test_files/rules/deprecated");
-        let exclude_ids = RuleExclude {
-            no_use_rule: HashSet::new(),
-        };
+        let exclude_ids = RuleExclude::default();
         yaml.read_dir(path, "", &exclude_ids).unwrap();
         assert_eq!(yaml.ignorerule_count, 1);
     }


### PR DESCRIPTION
Closes #511 
<img width="1027" alt="Screen Shot 2022-04-20 at 10 15 22" src="https://user-images.githubusercontent.com/71482215/164127554-456a638e-70b5-4dd6-89ba-d4a6bce6c553.png">

簡単な修正なので、こちらでやってみましたが、なぜか最後のルールだけレベルが変わりませんでした。（バグ？）
"SCM Database Privileged Operation" (dae8171c-5ec6-4396-b210-8466585b53e9)がmediumに変わるはずですが、criticalのままです。
使ったlevel_tuning.txtを添付しました。確認をお願いできますか？
[level_tuning.txt](https://github.com/Yamato-Security/hayabusa/files/8517424/level_tuning.txt)

```
grep -r dae8171c-5ec6-4396-b210-8466585b53e9 ./rules/sigma
./rules/sigma/builtin/security/win_scm_database_privileged_operation.yml:id: dae8171c-5ec6-4396-b210-8466585b53e9
```
grepしたら問題なくルールが出てきますし、中身を確認したら特に異常な書き方でもないので、なぜこのルールだけチューニングできないのかな？