### PR TITLE
Fixed update bug when rules repository not exist and rules folder exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -667,8 +667,6 @@ impl App {
             // case of no exist hayabusa-rules repository in rules.
             // execute update because submodule information exists if hayabusa repository exists submodule information.
 
-            self._repo_main_reset_hard(hayabusa_rule_repo.as_ref().unwrap())?;
-
             prev_modified_time = fs::metadata("rules").unwrap().modified().unwrap();
             let rules_path = Path::new("rules");
             if !rules_path.exists() {


### PR DESCRIPTION
Closes #507 

## What Changed

- removed unnecessary hard reset when rules folder not found.