### PR TITLE
display default channel name if not defined

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,7 @@
 - 新しいロゴに変更した。(#536) (@YamatoSecurity)
 - evtxファイルのファイルサイズの合計を出力するようにした。(#540) (@hitenkoku)
 - ロゴの色を変更した (#537) (@hitenkoku)
+- Channelの列にchannel_abbrevations.txtに記載されていないチャンネルも表示するようにした。(#553) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - New logo. (#536) (@YamatoSecurity)
 - Display total evtx file size. (#540) (@hitenkoku)
 - Changed logo color. (#537) (@hitenkoku)
-- Display `channel` if `channel` in record  is not exist in `channel_abbrevations.txt`. (#553) (@hitenkoku)
+- Display `channel` data when `channel` in record  is not exist in `channel_abbrevations.txt`. (#553) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - New logo. (#536) (@YamatoSecurity)
 - Display total evtx file size. (#540) (@hitenkoku)
 - Changed logo color. (#537) (@hitenkoku)
-- Display `channel` data when `channel` in record  is not exist in `channel_abbrevations.txt`. (#553) (@hitenkoku)
+- Display the original `Channel` name when not specified in `channel_abbrevations.txt`. (#553) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - New logo. (#536) (@YamatoSecurity)
 - Display total evtx file size. (#540) (@hitenkoku)
 - Changed logo color. (#537) (@hitenkoku)
+- Display `channel` if `channel` in record  is not exist in `channel_abbrevations.txt`. (#553) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -531,34 +531,34 @@ CSVファイルとして保存する場合、以下の列が追加されます:
 簡潔に出力するためにChannelの表示を以下のように省略しています。
 `config/channel_abbreviations.txt`の設定ファイルで自由に編集できます。
 
-* `Application` : App
-* `DNS Server` : DNS-Svr
-* `Microsoft-ServiceBus-Client` : SvcBusCli
-* `Microsoft-Windows-CodeIntegrity/Operational` : CodeInteg
-* `Microsoft-Windows-LDAP-Client/Debug` : LDAP-Cli
-* `Microsoft-Windows-AppLocker/MSI and Script` : AppLocker
-* `Microsoft-Windows-AppLocker/EXE and DLL` : AppLocker
-* `Microsoft-Windows-AppLocker/Packaged app-Deployment` : AppLocker
-* `Microsoft-Windows-AppLocker/Packaged app-Execution` : AppLocker
-* `Microsoft-Windows-Bits-Client/Operational` : BitsCli
-* `Microsoft-Windows-DHCP-Server/Operational` : DHCP-Svr
-* `Microsoft-Windows-DriverFrameworks-UserMode/Operational` : DvrFmwk
-* `Microsoft-Windows-NTLM/Operational` : NTLM
-* `Microsoft-Windows-Security-Mitigations/KernelMode` : SecMitigations
-* `Microsoft-Windows-Security-Mitigations/UserMode` : SecMitigations
-* `Microsoft-Windows-SmbClient/Security` : SmbCliSec
-* `Microsoft-Windows-Sysmon/Operational` : Sysmon
-* `Microsoft-Windows-TaskScheduler/Operational` : TaskSch
-* `Microsoft-Windows-PrintService/Admin` : PrintAdm
-* `Microsoft-Windows-PrintService/Operational` : PrintOp
-* `Microsoft-Windows-PowerShell/Operational` : PwSh
-* `Microsoft-Windows-Windows Defender/Operational` : Defender
-* `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall` : Firewall
-* `Microsoft-Windows-WMI-Activity/Operational` : WMI
-* `MSExchange Management` : Exchange
-* `Security` : Sec
-* `System` : Sys
-* `Windows PowerShell` : WinPwSh
+* `App` : `Application`
+* `AppLocker` : `Microsoft-Windows-AppLocker/*`
+* `BitsCli` : `Microsoft-Windows-Bits-Client/Operational`
+* `CodeInteg` : `Microsoft-Windows-CodeIntegrity/Operational`
+* `Defender` : `Microsoft-Windows-Windows Defender/Operational`
+* `DHCP-Svr` : `Microsoft-Windows-DHCP-Server/Operational`
+* `DNS-Svr` : `DNS Server`
+* `DvrFmwk` : `Microsoft-Windows-DriverFrameworks-UserMode/Operational`
+* `Exchange` : `MSExchange Management`
+* `Firewall` : `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall`
+* `KeyMgtSvc` : `Key Management Service`
+* `LDAP-Cli` : `Microsoft-Windows-LDAP-Client/Debug`
+* `NTLM` `Microsoft-Windows-NTLM/Operational`
+* `OpenSSH` : `OpenSSH/Operational`
+* `PrintAdm` : `Microsoft-Windows-PrintService/Admin`
+* `PrintOp` : `Microsoft-Windows-PrintService/Operational`
+* `PwSh` : `Microsoft-Windows-PowerShell/Operational`
+* `PwShClassic` : `Windows PowerShell`
+* `RDP-Client` : `Microsoft-Windows-TerminalServices-RDPClient/Operational`
+* `Sec` : `Security`
+* `SecMitig` : `Microsoft-Windows-Security-Mitigations/*`
+* `SmbCliSec` : `Microsoft-Windows-SmbClient/Security`
+* `SvcBusCli` : `Microsoft-ServiceBus-Client`
+* `Sys` : `System`
+* `Sysmon` : `Microsoft-Windows-Sysmon/Operational`
+* `TaskSch` : `Microsoft-Windows-TaskScheduler/Operational`
+* `WinRM` : `Microsoft-Windows-WinRM/Operational`
+* `WMI` : `Microsoft-Windows-WMI-Activity/Operational`
 
 ## プログレスバー
 

--- a/README.md
+++ b/README.md
@@ -530,34 +530,34 @@ If you want to output all the tags defined in a rule, please specify the `--all-
 In order to save space, we use the following abbreviations when displaying Channel.
 You can freely edit these abbreviations in the `config/channel_abbreviations.txt` configuration file.
 
-* `Application` : App
-* `DNS Server` : DNS-Svr
-* `Microsoft-ServiceBus-Client` : SvcBusCli
-* `Microsoft-Windows-CodeIntegrity/Operational` : CodeInteg
-* `Microsoft-Windows-LDAP-Client/Debug` : LDAP-Cli
-* `Microsoft-Windows-AppLocker/MSI and Script` : AppLocker
-* `Microsoft-Windows-AppLocker/EXE and DLL` : AppLocker
-* `Microsoft-Windows-AppLocker/Packaged app-Deployment` : AppLocker
-* `Microsoft-Windows-AppLocker/Packaged app-Execution` : AppLocker
-* `Microsoft-Windows-Bits-Client/Operational` : BitsCli
-* `Microsoft-Windows-DHCP-Server/Operational` : DHCP-Svr
-* `Microsoft-Windows-DriverFrameworks-UserMode/Operational` : DvrFmwk
-* `Microsoft-Windows-NTLM/Operational` : NTLM
-* `Microsoft-Windows-Security-Mitigations/KernelMode` : SecMitigations
-* `Microsoft-Windows-Security-Mitigations/UserMode` : SecMitigations
-* `Microsoft-Windows-SmbClient/Security` : SmbCliSec
-* `Microsoft-Windows-Sysmon/Operational` : Sysmon
-* `Microsoft-Windows-TaskScheduler/Operational` : TaskSch
-* `Microsoft-Windows-PrintService/Admin` : PrintAdm
-* `Microsoft-Windows-PrintService/Operational` : PrintOp
-* `Microsoft-Windows-PowerShell/Operational` : PwSh
-* `Microsoft-Windows-Windows Defender/Operational` : Defender
-* `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall` : Firewall
-* `Microsoft-Windows-WMI-Activity/Operational` : WMI
-* `MSExchange Management` : Exchange
-* `Security` : Sec
-* `System` : Sys
-* `Windows PowerShell` : WinPwSh
+* `App` : `Application`
+* `AppLocker` : `Microsoft-Windows-AppLocker/*`
+* `BitsCli` : `Microsoft-Windows-Bits-Client/Operational`
+* `CodeInteg` : `Microsoft-Windows-CodeIntegrity/Operational`
+* `Defender` : `Microsoft-Windows-Windows Defender/Operational`
+* `DHCP-Svr` : `Microsoft-Windows-DHCP-Server/Operational`
+* `DNS-Svr` : `DNS Server`
+* `DvrFmwk` : `Microsoft-Windows-DriverFrameworks-UserMode/Operational`
+* `Exchange` : `MSExchange Management`
+* `Firewall` : `Microsoft-Windows-Windows Firewall With Advanced Security/Firewall`
+* `KeyMgtSvc` : `Key Management Service`
+* `LDAP-Cli` : `Microsoft-Windows-LDAP-Client/Debug`
+* `NTLM` `Microsoft-Windows-NTLM/Operational`
+* `OpenSSH` : `OpenSSH/Operational`
+* `PrintAdm` : `Microsoft-Windows-PrintService/Admin`
+* `PrintOp` : `Microsoft-Windows-PrintService/Operational`
+* `PwSh` : `Microsoft-Windows-PowerShell/Operational`
+* `PwShClassic` : `Windows PowerShell`
+* `RDP-Client` : `Microsoft-Windows-TerminalServices-RDPClient/Operational`
+* `Sec` : `Security`
+* `SecMitig` : `Microsoft-Windows-Security-Mitigations/*`
+* `SmbCliSec` : `Microsoft-Windows-SmbClient/Security`
+* `SvcBusCli` : `Microsoft-ServiceBus-Client`
+* `Sys` : `System`
+* `Sysmon` : `Microsoft-Windows-Sysmon/Operational`
+* `TaskSch` : `Microsoft-Windows-TaskScheduler/Operational`
+* `WinRM` : `Microsoft-Windows-WinRM/Operational`
+* `WMI` : `Microsoft-Windows-WMI-Activity/Operational`
 
 ## Progress Bar
 

--- a/config/channel_abbreviations.txt
+++ b/config/channel_abbreviations.txt
@@ -1,6 +1,7 @@
 Channel,Abbreviation
 Application,App
 DNS Server,DNS-Svr
+Key Management Service,KeyMgtSvc
 Microsoft-ServiceBus-Client,SvcBusCli
 Microsoft-Windows-CodeIntegrity/Operational,CodeInteg
 Microsoft-Windows-LDAP-Client/Debug,LDAP-Cli
@@ -12,18 +13,21 @@ Microsoft-Windows-Bits-Client/Operational,BitsCli
 Microsoft-Windows-DHCP-Server/Operational,DHCP-Svr
 Microsoft-Windows-DriverFrameworks-UserMode/Operational,DvrFmwk
 Microsoft-Windows-NTLM/Operational,NTLM
-Microsoft-Windows-Security-Mitigations/KernelMode,SecMitigations
-Microsoft-Windows-Security-Mitigations/UserMode,SecMitigations
+Microsoft-Windows-Security-Mitigations/KernelMode,SecMitig
+Microsoft-Windows-Security-Mitigations/UserMode,SecMitig
 Microsoft-Windows-SmbClient/Security,SmbCliSec
 Microsoft-Windows-Sysmon/Operational,Sysmon
 Microsoft-Windows-TaskScheduler/Operational,TaskSch
+Microsoft-Windows-TerminalServices-RDPClient/Operational,RDP-Client
 Microsoft-Windows-PrintService/Admin,PrintAdm
 Microsoft-Windows-PrintService/Operational,PrintOp
 Microsoft-Windows-PowerShell/Operational,PwSh
 Microsoft-Windows-Windows Defender/Operational,Defender
 Microsoft-Windows-Windows Firewall With Advanced Security/Firewall,Firewall
+Microsoft-Windows-WinRM/Operational,WinRM
 Microsoft-Windows-WMI-Activity/Operational,WMI
 MSExchange Management,Exchange
+OpenSSH/Operational,OpenSSH
 Security,Sec
 System,Sys
-Windows PowerShell,WinPwSh
+Windows PowerShell,PwShClassic

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -238,6 +238,8 @@ impl Detection {
         } else {
             None
         };
+        let ch_str = &get_serde_number_to_string(&record_info.record["Event"]["System"]["Channel"])
+            .unwrap_or_default();
         let detect_info = DetectInfo {
             filepath: record_info.evtx_filepath.to_string(),
             rulepath: rule.rulepath.to_string(),
@@ -247,13 +249,7 @@ impl Detection {
                 .replace('\"', ""),
             eventid: get_serde_number_to_string(&record_info.record["Event"]["System"]["EventID"])
                 .unwrap_or_else(|| "-".to_owned()),
-            channel: CH_CONFIG
-                .get(
-                    &get_serde_number_to_string(&record_info.record["Event"]["System"]["Channel"])
-                        .unwrap_or_default(),
-                )
-                .unwrap_or(&String::default())
-                .to_string(),
+            channel: CH_CONFIG.get(ch_str).unwrap_or(ch_str).to_string(),
             alert: rule.yaml["title"].as_str().unwrap_or("").to_string(),
             detail: String::default(),
             tag_info: tag_info.join(" | "),

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -97,7 +97,7 @@ impl Message {
         Message { map: messages }
     }
 
-    /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。tagではこのHashMapのキーに対応しない出力は出力しないものとする
+    /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。
     /// ex. attack.impact,Impact
     pub fn create_output_filter_config(
         path: &str,


### PR DESCRIPTION
Closes #553 

## What Changed

- Display Channel data (no exist in channel_abbrevations.txt) in `Channel` column.

## Evidence

note: To test removed `Microsoft-Windows-Sysmon/Operational,Sysmon` in channel_abbrevations.txt

[553test.csv](https://github.com/Yamato-Security/hayabusa/files/8810010/553test.csv)
