### PR TITLE
561 output saving results message

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -19,6 +19,7 @@
 - ロゴの色を変更した (#537) (@hitenkoku)
 - Channelの列にchannel_abbrevations.txtに記載されていないチャンネルも表示するようにした。(#553) (@hitenkoku)
 - `Ignored rules`として集計されていた`Exclude rules`、`Noisy rules`、`Deprecated rules`に分けて表示するようにした。 (#556) (@hitenkoku)
+- `output`オプションが指定されているときに、ファイル出力中のメッセージを表示するようにした。 (#561) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Changed logo color. (#537) (@hitenkoku)
 - Display the original `Channel` name when not specified in `channel_abbrevations.txt`. (#553) (@hitenkoku)
 - Display separately `Ignored rules` to `Exclude rules`, `Noisy rules`, and `Deprecated rules`. (#556) (@hitenkoku)
+- Display results messge when `output` option is set. (#561) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "hayabusa"
-version = "1.3.0-dev"
+version = "1.3.0"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.10.1",
  "bytesize",
  "chrono",
  "clap 2.34.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hayabusa"
-version = "1.3.0-dev"
+version = "1.3.0"
 authors = ["Yamato Security @SecurityYamato"]
 edition = "2021"
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -338,6 +338,11 @@ fn emit_csv<W: std::io::Write>(
     }
     println!();
 
+    disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
+    writeln!(disp_wtr_buf, "Results Summary:");
+    disp_wtr.print(&disp_wtr_buf).ok();
+    println!();
+
     let size = terminal_size();
     let terminal_width = match size {
         Some((Width(w), _)) => w as usize,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -338,8 +338,9 @@ fn emit_csv<W: std::io::Write>(
     }
     println!();
 
+    println!();
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
-    writeln!(disp_wtr_buf, "Results Summary:");
+    writeln!(disp_wtr_buf, "Results Summary:").ok();
     disp_wtr.print(&disp_wtr_buf).ok();
     println!();
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -338,11 +338,10 @@ fn emit_csv<W: std::io::Write>(
     }
     println!();
 
-    println!();
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
+    writeln!(disp_wtr_buf).ok();
     writeln!(disp_wtr_buf, "Results Summary:").ok();
     disp_wtr.print(&disp_wtr_buf).ok();
-    println!();
 
     let size = terminal_size();
     let terminal_width = match size {

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -98,7 +98,7 @@ fn build_app<'a>() -> ArgMatches<'a> {
     --contributors 'Prints the list of contributors.'";
     App::new(&program)
         .about("Hayabusa: Aiming to be the world's greatest Windows event log analysis tool!")
-        .version("1.3.0-dev")
+        .version("1.3.0")
         .author("Yamato Security (https://github.com/Yamato-Security/hayabusa) @SecurityYamato")
         .setting(AppSettings::VersionlessSubcommands)
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,6 +482,10 @@ impl App {
             total_records += cnt_tmp;
             pb.inc();
         }
+        if configs::CONFIG.read().unwrap().args.is_present("output") {
+            println!();
+            println!("Analysis finished. Please wait while the results are being saved.");
+        }
         println!();
         detection.add_aggcondition_msges(&self.rt);
         if !(*STATISTICS_FLAG || *LOGONSUMMARY_FLAG || *PIVOT_KEYWORD_LIST_FLAG) {


### PR DESCRIPTION
Closes #561 

## What Changed

- Added wait message when `output` option is enabled
- Added Result Summary title

## Evidence
- with output option

![image](https://user-images.githubusercontent.com/2350416/171804627-8738be0d-5ccc-4f90-bbeb-db4205bcd8de.png)

- no output option

![image](https://user-images.githubusercontent.com/2350416/171804934-9825302e-3d4c-4d28-9222-6ab534a1ab7c.png)

![image](https://user-images.githubusercontent.com/2350416/171804803-ade2684c-0528-4538-8a65-5199349e1f98.png)

