### PR TITLE
change tool chain to stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           components: rustfmt
           override: true


### PR DESCRIPTION
## What Changed

- changed toolchain rust and cargo which is used in github actions from nightly to stable .