### PR TITLE
evtx files with different extension option( --add-file-extentions)

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -30,6 +30,8 @@ lazy_static! {
     pub static ref IDS_REGEX: Regex =
         Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
     pub static ref TERM_SIZE: Option<(Width, Height)> = terminal_size();
+    pub static ref TARGET_EXTENSIONS: HashSet<String> =
+        get_target_extensions(CONFIG.read().unwrap().args.add_file_extentions.as_ref());
 }
 
 pub struct ConfigReader<'a> {
@@ -205,6 +207,10 @@ pub struct Config {
     /// Print the list of contributors
     #[clap(long)]
     pub contributors: bool,
+
+    /// Specify target file extension expclude evtx (ex: evtx_data)
+    #[clap(long = "add-file-extensions", multiple_values = true)]
+    pub add_file_extentions: Option<Vec<String>>,
 }
 
 impl ConfigReader<'_> {
@@ -451,6 +457,14 @@ pub fn load_pivot_keywords(path: &str) {
             .fields
             .insert(map[1].to_string());
     });
+}
+
+/// --add-file-extensionsで追加された拡張子から、調査対象ファイルの拡張子セットを返す関数
+pub fn get_target_extensions(arg: Option<&Vec<String>>) -> HashSet<String> {
+    let mut target_file_extensions: HashSet<String> =
+        arg.unwrap_or(&Vec::new()).iter().cloned().collect();
+    target_file_extensions.insert(String::from("evtx"));
+    target_file_extensions
 }
 
 #[derive(Debug, Clone)]

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -538,6 +538,7 @@ fn load_eventcode_info(path: &str) -> EventInfoConfig {
 mod tests {
     use crate::detections::configs;
     use chrono::{DateTime, Utc};
+    use hashbrown::HashSet;
 
     //     #[test]
     //     #[ignore]
@@ -580,5 +581,27 @@ mod tests {
 
         assert!(time_filter.is_target(&start_time));
         assert!(time_filter.is_target(&end_time));
+    }
+
+    #[test]
+    fn test_get_target_extensions() {
+        let data = vec!["evtx_data".to_string(), "evtx_stars".to_string()];
+        let arg = Some(&data);
+        let ret = configs::get_target_extensions(arg);
+        let expect:HashSet<&str> = HashSet::from(["evtx", "evtx_data", "evtx_stars"]);
+        assert_eq!(ret.len(), expect.len());
+        for contents in expect.iter() {
+            assert!(ret.contains(&contents.to_string()));
+        }
+    }
+
+    #[test]
+    fn no_target_extensions() {
+        let ret = configs::get_target_extensions(None);
+        let expect:HashSet<&str> = HashSet::from(["evtx"]);
+        assert_eq!(ret.len(), expect.len());
+        for contents in expect.iter() {
+            assert!(ret.contains(&contents.to_string()));
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Datelike, Local, TimeZone};
 use evtx::{EvtxParser, ParserSettings};
 use git2::Repository;
 use hashbrown::{HashMap, HashSet};
-use hayabusa::detections::configs::{load_pivot_keywords, TargetEventTime};
+use hayabusa::detections::configs::{load_pivot_keywords, TargetEventTime, TARGET_EXTENSIONS};
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
 use hayabusa::detections::pivot::PivotKeyword;
 use hayabusa::detections::pivot::PIVOT_KEYWORD;
@@ -186,6 +186,7 @@ impl App {
             .ok();
             println!();
         }
+
         if configs::CONFIG.read().unwrap().args.live_analysis {
             let live_analysis_list = self.collect_liveanalysis_files();
             if live_analysis_list.is_none() {
@@ -193,15 +194,20 @@ impl App {
             }
             self.analysis_files(live_analysis_list.unwrap(), &time_filter);
         } else if let Some(filepath) = &configs::CONFIG.read().unwrap().args.filepath {
-            if filepath.extension().unwrap_or_else(|| OsStr::new(".")) != "evtx"
-                || filepath
-                    .as_path()
-                    .file_stem()
+            if TARGET_EXTENSIONS.contains(
+                filepath
+                    .extension()
                     .unwrap_or_else(|| OsStr::new("."))
                     .to_str()
-                    .unwrap()
-                    .trim()
-                    .starts_with('.')
+                    .unwrap(),
+            ) || filepath
+                .as_path()
+                .file_stem()
+                .unwrap_or_else(|| OsStr::new("."))
+                .to_str()
+                .unwrap()
+                .trim()
+                .starts_with('.')
             {
                 AlertMessage::alert(
                     "--filepath only accepts .evtx files. Hidden files are ignored.",
@@ -397,18 +403,19 @@ impl App {
                     ret.extend(subdir_ret);
                     Option::Some(())
                 });
-            } else {
-                let path_str = path.to_str().unwrap_or("");
-                if path_str.ends_with(".evtx")
-                    && !Path::new(path_str)
-                        .file_stem()
-                        .unwrap_or_else(|| OsStr::new("."))
-                        .to_str()
-                        .unwrap()
-                        .starts_with('.')
-                {
-                    ret.push(path);
-                }
+            } else if TARGET_EXTENSIONS.contains(
+                path.extension()
+                    .unwrap_or_else(|| OsStr::new(""))
+                    .to_str()
+                    .unwrap(),
+            ) && !path
+                .file_stem()
+                .unwrap_or_else(|| OsStr::new("."))
+                .to_str()
+                .unwrap()
+                .starts_with('.')
+            {
+                ret.push(path);
             }
         }
 


### PR DESCRIPTION
Closes #586 

## What Changed

- Added `--add-file-extensions` option

## Evidence

``` powershell
PS >ls .\test_files\evtx\ -Recurse

    Directory: ...\hayabusa\test_files\evtx

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          2021/12/25     9:26                sub
-a---          2021/12/25     9:26              0 test.txt
-a---          2021/12/25     9:26              0 test1.evtx
-a---          2021/12/25     9:26              0 test2.evtx_data
-a---          2021/12/25     9:26              0 test3.evtx_stars

    Directory: ...\test_files\evtx\sub

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          2021/12/25     9:26              0 test.txt
-a---          2021/12/25     9:26              0 test2.evtx
-a---          2021/12/25     9:26              0 testtest4.evtx
```

- no option(evtx only)

```
>.\hayabusa.exe -d .\test_files\evtx\ -q
Analyzing event files: 3
Total file size: 0 B

...
```

- with option (evtx and evtx_data)

```
>.\hayabusa.exe -d .\test_files\evtx\ --add-file-extensions evtx_data -q
Analyzing event files: 4
Total file size: 0 B

...
```

- with multi option (evtx and evtx_data and evtx_stars)

```
>.\hayabusa.exe -d .\test_files\evtx\ --add-file-extensions evtx_data evtx_stars -q
Analyzing event files: 5
Total file size: 0 B

Loading detections rules. Please wait.
```