### PR TITLE
enhancement output saved file size

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 - Clap Crateパッケージの更新 (#413) (@hitenkoku)
 - オプションの指定がないときに、`--help`と同じ画面出力を行うように変更した。(#387) (@hitenkoku)
 - ルール内に`details`フィールドがないときに、`rules/config/default_details.txt`に設定されたデフォルトの出力を行えるようにした。 (#359) (@hitenkoku)
+- `output` オプションで指定されファイルのサイズを出力するようにした。 (#595) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Updated clap crate package to version 3. (#413) (@hitnekoku)
 - Updated the default usage and help menu. (#387) (@hitenkoku)
 - Added default details output based on `rules/config/default_details.txt` when no `details` field in a rule is specified. (i.e. Sigma rules) (#359) (@hitenkoku)
-- Added saved file size output which is specified `output` option. (#595) (@hitenkoku)
+- Added saved file size output when `output` is specified. (#595) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated clap crate package to version 3. (#413) (@hitnekoku)
 - Updated the default usage and help menu. (#387) (@hitenkoku)
 - Added default details output based on `rules/config/default_details.txt` when no `details` field in a rule is specified. (i.e. Sigma rules) (#359) (@hitenkoku)
+- Added saved file size output which is specified `output` option. (#595) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -21,14 +21,14 @@
 
 # Hayabusa について
 
-Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)グループによって作られた**Windowsイベントログのファストフォレンジックタイムライン生成**および**スレットハンティングツール**です。 Hayabusaは日本語で[「ハヤブサ」](https://en.wikipedia.org/wiki/Peregrine_falcon)を意味し、ハヤブサが世界で最も速く、狩猟(hunting)に優れ、とても訓練しやすい動物であることから選ばれました。[Rust](https://www.rust-lang.org/) で開発され、マルチスレッドに対応し、可能な限り高速に動作するよう配慮されています。[Sigma](https://github.com/SigmaHQ/Sigma)ルールをHayabusaルール形式に変換する[ツール](https://github.com/Yamato-Security/hayabusa-rules/tree/main/tools/sigmac)も提供しています。Hayabusaの検知ルールもSigmaと同様にYML形式であり、カスタマイズ性や拡張性に優れます。稼働中のシステムで実行してライブ調査することも、複数のシステムからログを収集してオフライン調査することも可能です。(※現時点では、リアルタイムアラートや定期的なスキャンには対応していません。) 出力は一つのCSVタイムラインにまとめられ、Excel、[Timeline Explorer](https://ericzimmerman.github.io/#!index.md)、[Elastic Stack](doc/ElasticStackImport/ElasticStackImport-Japanese.md)等で簡単に分析できるようになります。
+Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)グループによって作られた**Windowsイベントログのファストフォレンジックタイムライン生成**および**スレットハンティングツール**です。 Hayabusaは日本語で[「ハヤブサ」](https://en.wikipedia.org/wiki/Peregrine_falcon)を意味し、ハヤブサが世界で最も速く、狩猟(hunting)に優れ、とても訓練しやすい動物であることから選ばれました。[Rust](https://www.rust-lang.org/) で開発され、マルチスレッドに対応し、可能な限り高速に動作するよう配慮されています。[Sigma](https://github.com/SigmaHQ/Sigma)ルールをHayabusaルール形式に変換する[ツール](https://github.com/Yamato-Security/hayabusa-rules/tree/main/tools/sigmac)も提供しています。Hayabusaの検知ルールもSigmaと同様にYML形式であり、カスタマイズ性や拡張性に優れます。稼働中のシステムで実行してライブ調査することも、複数のシステムからログを収集してオフライン調査することも可能です。また、 [Velociraptor](https://docs.velociraptor.app/)と[Hayabusa artifact](https://docs.velociraptor.app/exchange/artifacts/pages/windows.eventlogs.hayabusa/)を用いることで企業向けの広範囲なスレットハンティングとインシデントレスポンスにも活用できます。出力は一つのCSVタイムラインにまとめられ、Excel、[Timeline Explorer](https://ericzimmerman.github.io/#!index.md)、[Elastic Stack](doc/ElasticStackImport/ElasticStackImport-Japanese.md)等で簡単に分析できるようになります。
 
 ## 目次
 
 - [Hayabusa について](#hayabusa-について)
   - [目次](#目次)
   - [主な目的](#主な目的)
-    - [スレット(脅威)ハンティング](#スレット脅威ハンティング)
+    - [スレット(脅威)ハンティングと企業向けの広範囲なDFIR](#スレット脅威ハンティングと企業向けの広範囲なdfir)
     - [フォレンジックタイムラインの高速生成](#フォレンジックタイムラインの高速生成)
 - [スクリーンショット](#スクリーンショット)
   - [起動画面](#起動画面)
@@ -41,7 +41,6 @@ Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)�
   - [Elastic Stackダッシュボードでの解析](#elastic-stackダッシュボードでの解析)
 - [タイムラインのサンプル結果](#タイムラインのサンプル結果)
 - [特徴＆機能](#特徴機能)
-- [予定されている機能](#予定されている機能)
 - [ダウンロード](#ダウンロード)
 - [Gitクローン](#gitクローン)
 - [アドバンス: ソースコードからのコンパイル（任意）](#アドバンス-ソースコードからのコンパイル任意)
@@ -87,9 +86,11 @@ Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)�
 
 ## 主な目的
 
-### スレット(脅威)ハンティング
+### スレット(脅威)ハンティングと企業向けの広範囲なDFIR
 
-Hayabusaには現在、2300以上のSigmaルールと130以上のHayabusa検知ルールがあり、定期的にルールが追加されています。 最終的な目標はインシデントレスポンスや定期的なスレットハンティングのために、HayabusaエージェントをすべてのWindows端末にインストールして、中央サーバーにアラートを返す仕組みを作ることです。
+Hayabusaには現在、2300以上のSigmaルールと130以上のHayabusa検知ルールがあり、定期的にルールが追加されています。
+[Velociraptor](https://docs.velociraptor.app/)の[Hayabusa artifact](https://docs.velociraptor.app/exchange/artifacts/pages/windows.eventlogs.hayabusa/)を用いることで企業向けの広範囲なスレットハンティングだけでなくDFIR(デジタルフォレンジックとインシデントレスポンス)にも無料で利用することが可能です。この2つのオープンソースを組み合わせることで、SIEMが設定されていない環境でも実質的に遡及してSIEMを再現することができます。具体的な方法は[Eric Cupuano](https://twitter.com/eric_capuano)の[こちら](https://www.youtube.com/watch?v=Q1IoGX--814)の動画で学ぶことができます。
+ 最終的な目標はインシデントレスポンスや定期的なスレットハンティングのために、HayabusaエージェントをすべてのWindows端末にインストールして、中央サーバーにアラートを返す仕組みを作ることです。
 
 ### フォレンジックタイムラインの高速生成
 
@@ -97,7 +98,7 @@ Windowsのイベントログは、
   1）解析が困難なデータ形式であること
   2）データの大半がノイズであり調査に有用でないこと
 から、従来は非常に長い時間と手間がかかる解析作業となっていました。 Hayabusa は、有用なデータのみを抽出し、専門的なトレーニングを受けた分析者だけでなく、Windowsのシステム管理者であれば誰でも利用できる読みやすい形式で提示することを主な目的としています。
-[Evtx Explorer](https://ericzimmerman.github.io/#!index.md)や[Event Log Explorer](https://eventlogxp.com/)のような深掘り分析を行うツールの代替ではなく、分析者が20%の時間で80%の作業を行えるようにすることを目的としています。
+Hayabusaは従来のWindowsイベントログ分析解析と比較して、分析者が20%の時間で80%の作業を行えるようにすることを目指しています。
 
 # スクリーンショット
 
@@ -160,11 +161,7 @@ CSVのタイムラインをElastic Stackにインポートする方法は[こち
 * イベントログから不審なユーザやファイルを素早く特定するためのピボットキーワードの一覧作成。
 * 詳細な調査のために全フィールド情報の出力。
 * 成功と失敗したユーザログオンの要約。
-
-# 予定されている機能
-
-* すべてのエンドポイントでの企業全体のスレットハンティング。
-* MITRE ATT&CKのヒートマップ生成機能。
+* [Velociraptor](https://docs.velociraptor.app/)と組み合わせた企業向けの広範囲なすべてのエンドポイントに対するスレットハンティングとDFIR。
 
 # ダウンロード
 
@@ -728,6 +725,7 @@ Windows機での悪性な活動を検知する為には、デフォルトのロ�
 
 ## 英語
 
+* 2022/06/19 [VelociraptorチュートリアルとHayabusaの統合方法](https://www.youtube.com/watch?v=Q1IoGX--814) by [Eric Cupuano](https://twitter.com/eric_capuano)
 * 2022/01/24 [Hayabusa結果をneo4jで可視化する方法](https://www.youtube.com/watch?v=7sQqz2ek-ko) by Matthew Seyer ([@forensic_matt](https://twitter.com/forensic_matt))
 
 ## 日本語

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 
 # About Hayabusa
 
-Hayabusa is a **Windows event log fast forensics timeline generator** and **threat hunting tool** created by the [Yamato Security](https://yamatosecurity.connpass.com/) group in Japan. Hayabusa means ["peregrine falcon"](https://en.wikipedia.org/wiki/Peregrine_falcon") in Japanese and was chosen as peregrine falcons are the fastest animal in the world, great at hunting and highly trainable. It is written in [Rust](https://www.rust-lang.org/) and supports multi-threading in order to be as fast as possible. We have provided a [tool](https://github.com/Yamato-Security/hayabusa-rules/tree/main/tools/sigmac) to convert [sigma](https://github.com/SigmaHQ/sigma) rules into hayabusa rule format. The hayabusa detection rules are based on sigma rules, written in YML in order to be as easily customizable and extensible as possible. It can be run either on running systems for live analysis or by gathering logs from multiple systems for offline analysis. (At the moment, it does not support real-time alerting or periodic scans.) The output will be consolidated into a single CSV timeline for easy analysis in Excel, [Timeline Explorer](https://ericzimmerman.github.io/#!index.md), or [Elastic Stack](doc/ElasticStackImport/ElasticStackImport-English.md).
+Hayabusa is a **Windows event log fast forensics timeline generator** and **threat hunting tool** created by the [Yamato Security](https://yamatosecurity.connpass.com/) group in Japan. Hayabusa means ["peregrine falcon"](https://en.wikipedia.org/wiki/Peregrine_falcon") in Japanese and was chosen as peregrine falcons are the fastest animal in the world, great at hunting and highly trainable. It is written in [Rust](https://www.rust-lang.org/) and supports multi-threading in order to be as fast as possible. We have provided a [tool](https://github.com/Yamato-Security/hayabusa-rules/tree/main/tools/sigmac) to convert [Sigma](https://github.com/SigmaHQ/sigma) rules into Hayabusa rule format. The Sigma-compatible Hayabusa detection rules are written in YML in order to be as easily customizable and extensible as possible. Hayabusa can be run either on single running systems for live analysis, by gathering logs from single or multiple systems for offline analysis, or by running the [Hayabusa artifact](https://docs.velociraptor.app/exchange/artifacts/pages/windows.eventlogs.hayabusa/) with [Velociraptor](https://docs.velociraptor.app/) for enterprise-wide threat hunting and incident response. The output will be consolidated into a single CSV timeline for easy analysis in Excel, [Timeline Explorer](https://ericzimmerman.github.io/#!index.md), or [Elastic Stack](doc/ElasticStackImport/ElasticStackImport-English.md).
 
 ## Table of Contents
 
 - [About Hayabusa](#about-hayabusa)
   - [Table of Contents](#table-of-contents)
   - [Main Goals](#main-goals)
-    - [Threat Hunting](#threat-hunting)
+    - [Threat Hunting and Enterprise-wide DFIR](#threat-hunting-and-enterprise-wide-dfir)
     - [Fast Forensics Timeline Generation](#fast-forensics-timeline-generation)
 - [Screenshots](#screenshots)
   - [Startup](#startup)
@@ -40,7 +40,6 @@ Hayabusa is a **Windows event log fast forensics timeline generator** and **thre
   - [Analysis with the Elastic Stack Dashboard](#analysis-with-the-elastic-stack-dashboard)
 - [Analyzing Sample Timeline Results](#analyzing-sample-timeline-results)
 - [Features](#features)
-- [Planned Features](#planned-features)
 - [Downloads](#downloads)
 - [Git cloning](#git-cloning)
 - [Advanced: Compiling From Source (Optional)](#advanced-compiling-from-source-optional)
@@ -86,14 +85,14 @@ Hayabusa is a **Windows event log fast forensics timeline generator** and **thre
 
 ## Main Goals
 
-### Threat Hunting
+### Threat Hunting and Enterprise-wide DFIR
 
-Hayabusa currently has over 2300 sigma rules and over 130 hayabusa rules with more rules being added regularly. The ultimate goal is to be able to push out hayabusa agents to all Windows endpoints after an incident or for periodic threat hunting and have them alert back to a central server.
+Hayabusa currently has over 2400 Sigma rules and over 130 Hayabusa built-in detection rules with more rules being added regularly. It can be used for enterprise-wide proactive threat hunting as well as DFIR (Digital Forensics and Incident Response) for free with [Velociraptor](https://docs.velociraptor.app/)'s [Hayabusa artifact](https://docs.velociraptor.app/exchange/artifacts/pages/windows.eventlogs.hayabusa/). By combining these two open-source tools, you can essentially retroactively reproduce a SIEM when there is no SIEM setup in the environment. You can learn about how to do this by watching [Eric Cupuano](https://twitter.com/eric_capuano)'s Velociraptor walkthrough [here](https://www.youtube.com/watch?v=Q1IoGX--814).
 
 ### Fast Forensics Timeline Generation
 
-Windows event log analysis has traditionally been a very long and tedious process because Windows event logs are 1) in a data format that is hard to analyze and 2) the majority of data is noise and not useful for investigations. Hayabusa's main goal is to extract out only useful data and present it in an easy-to-read format that is usable not only by professionally trained analysts but any Windows system administrator.
-Hayabusa is not intended to be a replacement for tools like [Evtx Explorer](https://ericzimmerman.github.io/#!index.md) or [Event Log Explorer](https://eventlogxp.com/) for more deep-dive analysis but is intended for letting analysts get 80% of their work done in 20% of the time. 
+Windows event log analysis has traditionally been a very long and tedious process because Windows event logs are 1) in a data format that is hard to analyze and 2) the majority of data is noise and not useful for investigations. Hayabusa's goal is to extract out only useful data and present it in a concise as possible easy-to-read format that is usable not only by professionally trained analysts but any Windows system administrator.
+Hayabusa hopes to let analysts get 80% of their work done in 20% of the time when compared to traditional Windows event log analysis.
 
 # Screenshots
 
@@ -155,15 +154,11 @@ You can learn how to import CSV files into Elastic Stack [here](doc/ElasticStack
 * Create a list of unique pivot keywords to quickly identify abnormal users, hostnames, processes, etc... as well as correlate events.
 * Output all fields for more thorough investigations.
 * Successful and failed logon summary.
-
-# Planned Features
-
-* Enterprise-wide hunting on all endpoints.
-* MITRE ATT&CK heatmap generation.
+* Enterprise-wide threat hunting and DFIR on all endpoints with [Velociraptor](https://docs.velociraptor.app/).
 
 # Downloads
 
-Please download the latest stable version of hayabusa with compiled binaries or the source code from the [Releases](https://github.com/Yamato-Security/hayabusa/releases) page.
+Please download the latest stable version of Hayabusa with compiled binaries or compile the source code from the [Releases](https://github.com/Yamato-Security/hayabusa/releases) page.
 
 # Git cloning
 
@@ -188,7 +183,7 @@ If the update fails, you may need to rename the `rules` folder and try again.
 >> Caution: When updating, rules and config files in the `rules` folder are replaced with the latest rules and config files in the [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) repository. 
 >> Any changes you make to existing files will be overwritten, so we recommend that you make backups of any files that you edit before updating.
 >> If you are performing level tuning with `--level-tuning`, please re-tune your rule files after each update. 
->> If you add new rules inside of the `rules` folder, they will **not** be overwritten or deleted when updating.
+>> If you add **new** rules inside of the `rules` folder, they will **not** be overwritten or deleted when updating.
 
 # Advanced: Compiling From Source (Optional)
 
@@ -726,6 +721,7 @@ To create the most forensic evidence and detect with the highest accuracy, you n
 
 ## English
 
+* 2022/06/19 [Velociraptor Walkthrough and Hayabusa Integration](https://www.youtube.com/watch?v=Q1IoGX--814) by [Eric Cupuano](https://twitter.com/eric_capuano)
 * 2022/01/24 [Graphing Hayabusa results in neo4j](https://www.youtube.com/watch?v=7sQqz2ek-ko) by Matthew Seyer ([@forensic_matt](https://twitter.com/forensic_matt))
 
 ## Japanese

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -3,7 +3,7 @@ use crate::detections::configs::TERM_SIZE;
 use crate::detections::print;
 use crate::detections::print::{AlertMessage, IS_HIDE_RECORD_ID};
 use crate::detections::utils;
-use crate::detections::utils::write_color_buffer;
+use crate::detections::utils::{write_color_buffer, get_writable_color};
 use bytesize::ByteSize;
 use chrono::{DateTime, Local, TimeZone, Utc};
 use csv::QuoteStyle;
@@ -379,11 +379,9 @@ fn emit_csv<W: std::io::Write>(
         }
     };
 
-    disp_wtr_buf.clear();
-    disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
-    writeln!(disp_wtr_buf, "Results Summary:").ok();
-    disp_wtr.print(&disp_wtr_buf).ok();
-
+    disp_wtr_buf.clear(); 
+    write_color_buffer(disp_wtr, get_writable_color(Color::Green), "Results Summary:").ok();
+    
     let terminal_width = match *TERM_SIZE {
         Some((Width(w), _)) => w as usize,
         None => 100,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -381,8 +381,8 @@ fn emit_csv<W: std::io::Write>(
 
     disp_wtr_buf.clear();
     write_color_buffer(
-        disp_wtr,
-        get_writable_color(Color::Green),
+        &disp_wtr,
+        get_writable_color(Some(Color::Green)),
         "Results Summary:",
     )
     .ok();
@@ -403,10 +403,21 @@ fn emit_csv<W: std::io::Write>(
     } else {
         (reducted_record_cnt as f64) / (all_record_cnt as f64) * 100.0
     };
-    println!("Total events: {}", all_record_cnt);
+    write_color_buffer(
+        &disp_wtr,
+        get_writable_color(None),
+        &format!("Total events: {}", all_record_cnt),
+    )
+    .ok();
+    write_color_buffer(
+        &disp_wtr,
+        get_writable_color(None),
+        &format!("Data reduction: {} events ({:.2}%)",
+        reducted_record_cnt, reducted_percent),
+    )
+    .ok();
     println!(
-        "Data reduction: {} events ({:.2}%)",
-        reducted_record_cnt, reducted_percent
+        
     );
     println!();
 
@@ -505,7 +516,7 @@ fn _print_unique_results(
 
     // output total results
     write_color_buffer(
-        BufferWriter::stdout(ColorChoice::Always),
+        &BufferWriter::stdout(ColorChoice::Always),
         None,
         &format!(
             "{} {}: {}",
@@ -525,7 +536,7 @@ fn _print_unique_results(
             head_word, level_name, tail_word, counts_by_level[i]
         );
         write_color_buffer(
-            BufferWriter::stdout(ColorChoice::Always),
+            &BufferWriter::stdout(ColorChoice::Always),
             _get_output_color(color_map, level_name),
             &output_raw_str,
         )

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -14,11 +14,11 @@ use lazy_static::lazy_static;
 use serde::Serialize;
 use std::cmp::min;
 use std::error::Error;
+use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::BufWriter;
 use std::io::Write;
-use std::fs;
 use std::process;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 use terminal_size::Width;
@@ -364,12 +364,20 @@ fn emit_csv<W: std::io::Write>(
     if let Some(path) = output_path {
         if let Ok(metadata) = fs::metadata(path) {
             println!(
-                "Saved file: {} ({})", configs::CONFIG.read().unwrap().args.output.as_ref().unwrap().display(), ByteSize::b(metadata.len()).to_string_as(false)
+                "Saved file: {} ({})",
+                configs::CONFIG
+                    .read()
+                    .unwrap()
+                    .args
+                    .output
+                    .as_ref()
+                    .unwrap()
+                    .display(),
+                ByteSize::b(metadata.len()).to_string_as(false)
             );
             println!();
         }
     };
-
 
     disp_wtr_buf.clear();
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -3,7 +3,7 @@ use crate::detections::configs::TERM_SIZE;
 use crate::detections::print;
 use crate::detections::print::{AlertMessage, IS_HIDE_RECORD_ID};
 use crate::detections::utils;
-use crate::detections::utils::{write_color_buffer, get_writable_color};
+use crate::detections::utils::{get_writable_color, write_color_buffer};
 use bytesize::ByteSize;
 use chrono::{DateTime, Local, TimeZone, Utc};
 use csv::QuoteStyle;
@@ -379,9 +379,14 @@ fn emit_csv<W: std::io::Write>(
         }
     };
 
-    disp_wtr_buf.clear(); 
-    write_color_buffer(disp_wtr, get_writable_color(Color::Green), "Results Summary:").ok();
-    
+    disp_wtr_buf.clear();
+    write_color_buffer(
+        disp_wtr,
+        get_writable_color(Color::Green),
+        "Results Summary:",
+    )
+    .ok();
+
     let terminal_width = match *TERM_SIZE {
         Some((Width(w), _)) => w as usize,
         None => 100,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -412,13 +412,13 @@ fn emit_csv<W: std::io::Write>(
     write_color_buffer(
         &disp_wtr,
         get_writable_color(None),
-        &format!("Data reduction: {} events ({:.2}%)",
-        reducted_record_cnt, reducted_percent),
+        &format!(
+            "Data reduction: {} events ({:.2}%)",
+            reducted_record_cnt, reducted_percent
+        ),
     )
     .ok();
-    println!(
-        
-    );
+    println!();
     println!();
 
     _print_unique_results(

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -4,6 +4,7 @@ use crate::detections::print;
 use crate::detections::print::{AlertMessage, IS_HIDE_RECORD_ID};
 use crate::detections::utils;
 use crate::detections::utils::write_color_buffer;
+use bytesize::ByteSize;
 use chrono::{DateTime, Local, TimeZone, Utc};
 use csv::QuoteStyle;
 use hashbrown::HashMap;
@@ -17,6 +18,7 @@ use std::fs::File;
 use std::io;
 use std::io::BufWriter;
 use std::io::Write;
+use std::fs;
 use std::process;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 use terminal_size::Width;
@@ -357,6 +359,17 @@ fn emit_csv<W: std::io::Write>(
     } else {
         wtr.flush()?;
     }
+
+    let output_path = configs::CONFIG.read().unwrap().args.output.clone();
+    if let Some(path) = output_path {
+        if let Ok(metadata) = fs::metadata(path) {
+            println!(
+                "Saved file: {} ({})", configs::CONFIG.read().unwrap().args.output.as_ref().unwrap().display(), ByteSize::b(metadata.len()).to_string_as(false)
+            );
+            println!();
+        }
+    };
+
 
     disp_wtr_buf.clear();
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -324,7 +324,7 @@ impl AlertMessage {
     /// ERRORメッセージを表示する関数
     pub fn alert(contents: &str) -> io::Result<()> {
         write_color_buffer(
-            BufferWriter::stderr(ColorChoice::Always),
+            &BufferWriter::stderr(ColorChoice::Always),
             None,
             &format!("[ERROR] {}", contents),
         )
@@ -333,7 +333,7 @@ impl AlertMessage {
     /// WARNメッセージを表示する関数
     pub fn warn(contents: &str) -> io::Result<()> {
         write_color_buffer(
-            BufferWriter::stderr(ColorChoice::Always),
+            &BufferWriter::stderr(ColorChoice::Always),
             None,
             &format!("[WARN] {}", contents),
         )

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -242,7 +242,7 @@ pub fn create_rec_info(data: Value, path: String, keys: &[String]) -> EvtxRecord
  * 標準出力のカラー出力設定を指定した値に変更し画面出力を行う関数
  */
 pub fn write_color_buffer(
-    wtr: BufferWriter,
+    wtr: &BufferWriter,
     color: Option<Color>,
     output_str: &str,
 ) -> io::Result<()> {
@@ -253,11 +253,11 @@ pub fn write_color_buffer(
 }
 
 /// no-colorのオプションの指定があるかを確認し、指定されている場合はNoneをかえし、指定されていない場合は引数で指定されたColorをSomeでラップして返す関数
-pub fn get_writable_color(color: Color) -> Option<Color> {
+pub fn get_writable_color(color: Option<Color>) -> Option<Color> {
     if configs::CONFIG.read().unwrap().args.no_color {
         None
     } else {
-        Some(color)
+        color
     }
 }
 

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -252,6 +252,15 @@ pub fn write_color_buffer(
     wtr.print(&buf)
 }
 
+/// no-colorのオプションの指定があるかを確認し、指定されている場合はNoneをかえし、指定されていない場合は引数で指定されたColorをSomeでラップして返す関数
+pub fn get_writable_color(color: Color) -> Option<Color> {
+    if configs::CONFIG.read().unwrap().args.no_color {
+        None
+    } else {
+        Some(color)
+    }
+}
+
 /**
  * CSVのrecord infoカラムに出力する文字列を作る
  */

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ impl App {
                 Ok(output) => {
                     if output != "You currently have the latest rules." {
                         write_color_buffer(
-                            BufferWriter::stdout(ColorChoice::Always),
+                            &BufferWriter::stdout(ColorChoice::Always),
                             None,
                             "Rules updated successfully.",
                         )
@@ -170,7 +170,7 @@ impl App {
 
         if *STATISTICS_FLAG {
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 "Generating Event ID Statistics",
             )
@@ -179,7 +179,7 @@ impl App {
         }
         if *LOGONSUMMARY_FLAG {
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 "Generating Logons Summary",
             )
@@ -262,7 +262,7 @@ impl App {
             return;
         } else {
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 &configs::CONFIG.read().unwrap().headless_help,
             )
@@ -274,7 +274,7 @@ impl App {
         let analysis_duration = analysis_end_time.signed_duration_since(analysis_start_time);
         println!();
         write_color_buffer(
-            BufferWriter::stdout(ColorChoice::Always),
+            &BufferWriter::stdout(ColorChoice::Always),
             None,
             &format!("Elapsed Time: {}", &analysis_duration.hhmmssxxx()),
         )
@@ -329,15 +329,15 @@ impl App {
                     )
                     .ok();
                 });
-                write_color_buffer(BufferWriter::stdout(ColorChoice::Always), None, &output).ok();
+                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &output).ok();
             } else {
                 //標準出力の場合
                 let output = "The following pivot keywords were found:".to_string();
-                write_color_buffer(BufferWriter::stdout(ColorChoice::Always), None, &output).ok();
+                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &output).ok();
 
                 pivot_key_unions.iter().for_each(|(key, pivot_keyword)| {
                     write_color_buffer(
-                        BufferWriter::stdout(ColorChoice::Always),
+                        &BufferWriter::stdout(ColorChoice::Always),
                         None,
                         &create_output(String::default(), key, pivot_keyword),
                     )
@@ -425,7 +425,7 @@ impl App {
     fn print_contributors(&self) {
         match fs::read_to_string("./contributors.txt") {
             Ok(contents) => {
-                write_color_buffer(BufferWriter::stdout(ColorChoice::Always), None, &contents).ok();
+                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &contents).ok();
             }
             Err(err) => {
                 AlertMessage::alert(&format!("{}", err)).ok();
@@ -441,7 +441,7 @@ impl App {
             .min_level
             .to_uppercase();
         write_color_buffer(
-            BufferWriter::stdout(ColorChoice::Always),
+            &BufferWriter::stdout(ColorChoice::Always),
             None,
             &format!("Analyzing event files: {:?}", evtx_files.len()),
         )
@@ -667,7 +667,7 @@ impl App {
             Some(Color::Green)
         };
         write_color_buffer(
-            BufferWriter::stdout(ColorChoice::Always),
+            &BufferWriter::stdout(ColorChoice::Always),
             output_color,
             &content,
         )
@@ -686,7 +686,7 @@ impl App {
             None => {}
             Some(path) => {
                 let content = fs::read_to_string(path).unwrap_or_default();
-                write_color_buffer(BufferWriter::stdout(ColorChoice::Always), None, &content).ok();
+                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &content).ok();
             }
         }
     }
@@ -700,7 +700,7 @@ impl App {
         let hayabusa_rule_repo = Repository::open(Path::new("rules"));
         if hayabusa_repo.is_err() && hayabusa_rule_repo.is_err() {
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 "Attempting to git clone the hayabusa-rules repository into the rules folder.",
             )
@@ -879,7 +879,7 @@ impl App {
                 .entry(tmp[3].to_string())
                 .or_insert(0b0) += 1;
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 &format!(
                     "[Updated] {} (Modified: {} | Path: {})",
@@ -896,7 +896,7 @@ impl App {
             Ok("Rule updated".to_string())
         } else {
             write_color_buffer(
-                BufferWriter::stdout(ColorChoice::Always),
+                &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 "You currently have the latest rules.",
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,7 +425,8 @@ impl App {
     fn print_contributors(&self) {
         match fs::read_to_string("./contributors.txt") {
             Ok(contents) => {
-                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &contents).ok();
+                write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, &contents)
+                    .ok();
             }
             Err(err) => {
                 AlertMessage::alert(&format!("{}", err)).ok();

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -59,7 +59,7 @@ impl LevelTuning {
         for (path, rule) in rulefile_loader.files {
             if let Some(new_level) = tuning_map.get(rule["id"].as_str().unwrap()) {
                 write_color_buffer(
-                    BufferWriter::stdout(ColorChoice::Always),
+                    &BufferWriter::stdout(ColorChoice::Always),
                     None,
                     &format!("path: {}", path),
                 )
@@ -94,7 +94,7 @@ impl LevelTuning {
                 file.write_all(content.as_bytes()).unwrap();
                 file.flush().unwrap();
                 write_color_buffer(
-                    BufferWriter::stdout(ColorChoice::Always),
+                    &BufferWriter::stdout(ColorChoice::Always),
                     None,
                     &format!(
                         "level: {} -> {}",

--- a/test_files/rules/yaml/exclude1.yml
+++ b/test_files/rules/yaml/exclude1.yml
@@ -1,5 +1,5 @@
-title: Sysmon Check command lines
-id : 4fe151c2-ecf9-4fae-95ae-b88ec9c2fca6
+title: Excluded Rule Test 1
+id : 00000000-0000-0000-0000-000000000000
 description: hogehoge
 enabled: true
 author: Yea

--- a/test_files/rules/yaml/exclude2.yml
+++ b/test_files/rules/yaml/exclude2.yml
@@ -1,13 +1,10 @@
-title: Possible Exploitation of Exchange RCE CVE-2021-42321
-author: Florian Roth, @testanull
+title: Excluded Rule 2
 date: 2021/11/18
-description: Detects log entries that appear in exploitation attempts against MS Exchange
-  RCE CVE-2021-42321
 detection:
   condition: 'Cmdlet failed. Cmdlet Get-App, '
 falsepositives:
 - Unknown, please report false positives via https://github.com/SigmaHQ/sigma/issues
-id: c92f1896-d1d2-43c3-92d5-7a5b35c217bb
+id: 00000000-0000-0000-0000-000000000000
 level: critical
 logsource:
   product: windows
@@ -15,7 +12,4 @@ logsource:
 references:
 - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-42321
 status: experimental
-tags:
-- attack.lateral_movement
-- attack.t1210
 ruletype: SIGMA

--- a/test_files/rules/yaml/exclude3.yml
+++ b/test_files/rules/yaml/exclude3.yml
@@ -1,8 +1,5 @@
-title: Hidden Local User Creation
-author: Christian Burkard
+title: Excluded Rule 3
 date: 2021/05/03
-description: Detects the creation of a local hidden user account which should not
-  happen for event ID 4720.
 detection:
   SELECTION_1:
     EventID: 4720
@@ -14,7 +11,7 @@ falsepositives:
 fields:
 - EventCode
 - AccountName
-id: 7b449a5e-1db5-4dd0-a2dc-4e3a67282538
+id: 00000000-0000-0000-0000-000000000000
 level: high
 logsource:
   product: windows
@@ -22,7 +19,4 @@ logsource:
 references:
 - https://twitter.com/SBousseaden/status/1387743867663958021
 status: experimental
-tags:
-- attack.persistence
-- attack.t1136.001
 ruletype: SIGMA

--- a/test_files/rules/yaml/exclude4.yml
+++ b/test_files/rules/yaml/exclude4.yml
@@ -1,8 +1,5 @@
-title: User Added to Local Administrators
-author: Florian Roth
+title: Excluded Rule 4
 date: 2017/03/14
-description: This rule triggers on user accounts that are added to the local Administrators
-  group, which could be legitimate activity or a sign of privilege escalation activity
 detection:
   SELECTION_1:
     EventID: 4732
@@ -13,18 +10,11 @@ detection:
   SELECTION_4:
     SubjectUserName: '*$'
   condition: ((SELECTION_1 and (SELECTION_2 or SELECTION_3)) and  not (SELECTION_4))
-falsepositives:
-- Legitimate administrative activity
-id: c265cf08-3f99-46c1-8d59-328247057d57
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows
   service: security
 modified: 2021/07/07
 status: stable
-tags:
-- attack.privilege_escalation
-- attack.t1078
-- attack.persistence
-- attack.t1098
 ruletype: SIGMA

--- a/test_files/rules/yaml/exclude5.yml
+++ b/test_files/rules/yaml/exclude5.yml
@@ -1,9 +1,5 @@
-title: Local User Creation
-author: Patrick Bareiss
+title: Excluded Rule 5
 date: 2019/04/18
-description: Detects local user creation on windows servers, which shouldn't happen
-  in an Active Directory environment. Apply this Sigma Use Case on your windows server
-  logs and not on your DC logs.
 detection:
   SELECTION_1:
     EventID: 4720
@@ -15,7 +11,7 @@ fields:
 - EventCode
 - AccountName
 - AccountDomain
-id: 66b6be3d-55d0-4f47-9855-d69df21740ea
+id: 00000000-0000-0000-0000-000000000000
 level: low
 logsource:
   product: windows
@@ -24,8 +20,4 @@ modified: 2020/08/23
 references:
 - https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/
 status: experimental
-tags:
-- attack.persistence
-- attack.t1136
-- attack.t1136.001
 ruletype: SIGMA

--- a/test_files/rules/yaml/noisy1.yml
+++ b/test_files/rules/yaml/noisy1.yml
@@ -1,7 +1,5 @@
-title: WMI Event Subscription
-author: Tom Ueltschi (@c_APT_ure)
+title: Noisy Rule Test1
 date: 2019/01/12
-description: Detects creation of WMI event subscription persistence method
 detection:
   SELECTION_1:
     EventID: 19
@@ -12,7 +10,7 @@ detection:
   condition: (SELECTION_1 or SELECTION_2 or SELECTION_3)
 falsepositives:
 - exclude legitimate (vetted) use of WMI event subscription in your network
-id: 0f06a3a5-6a09-413f-8743-e6cf35561297
+id: 0090ea60-f4a2-43a8-8657-3a9a4ddcf547
 level: high
 logsource:
   category: wmi_event

--- a/test_files/rules/yaml/noisy2.yml
+++ b/test_files/rules/yaml/noisy2.yml
@@ -1,9 +1,6 @@
-title: Rare Schtasks Creations
-author: Florian Roth
+title: Noisy Rule Test2
 date: 2017/03/23
-description: Detects rare scheduled tasks creations that only appear a few times per
-  time frame and could reveal password dumpers, backdoor installs or other types of
-  malicious code
+description: excluded rule
 detection:
   SELECTION_1:
     EventID: 4698
@@ -11,21 +8,6 @@ detection:
 falsepositives:
 - Software installation
 - Software updates
-id: b0d77106-7bb0-41fe-bd94-d1752164d066
+id: 8b8db936-172e-4bb7-9f84-ccc954d51d93
 level: low
-logsource:
-  definition: The Advanced Audit Policy setting Object Access > Audit Other Object
-    Access Events has to be configured to allow this detection (not in the baseline
-    recommendations by Microsoft). We also recommend extracting the Command field
-    from the embedded XML in the event data.
-  product: windows
-  service: security
-status: experimental
-tags:
-- attack.execution
-- attack.privilege_escalation
-- attack.persistence
-- attack.t1053
-- car.2013-08-001
-- attack.t1053.005
 ruletype: SIGMA

--- a/test_files/rules/yaml/noisy3.yml
+++ b/test_files/rules/yaml/noisy3.yml
@@ -1,26 +1,13 @@
-title: Rare Service Installs
-author: Florian Roth
+title: Noisy Rule Test 3
 date: 2017/03/08
-description: Detects rare service installs that only appear a few times per time frame
-  and could reveal password dumpers, backdoor installs or other types of malicious
-  services
 detection:
   SELECTION_1:
     EventID: 7045
   condition: SELECTION_1 | count() by ServiceFileName < 5
-falsepositives:
-- Software installation
-- Software updates
-id: 66bfef30-22a5-4fcd-ad44-8d81e60922ae
+id: 1703ba97-b2c2-4071-a241-a16d017d25d3
 level: low
 logsource:
   product: windows
   service: system
 status: experimental
-tags:
-- attack.persistence
-- attack.privilege_escalation
-- attack.t1050
-- car.2013-09-005
-- attack.t1543.003
 ruletype: SIGMA

--- a/test_files/rules/yaml/noisy4.yml
+++ b/test_files/rules/yaml/noisy4.yml
@@ -1,8 +1,5 @@
-title: Failed Logins with Different Accounts from Single Source System
-author: Florian Roth
+title: Noisy Rule Test 4
 date: 2017/01/10
-description: Detects suspicious failed logins with different user accounts from a
-  single source system
 detection:
   SELECTION_1:
     EventID: 529
@@ -14,20 +11,11 @@ detection:
     WorkstationName: '*'
   condition: ((SELECTION_1 or SELECTION_2) and SELECTION_3 and SELECTION_4) | count(TargetUserName)
     by WorkstationName > 3
-falsepositives:
-- Terminal servers
-- Jump servers
-- Other multiuser systems like Citrix server farms
-- Workstations with frequently changing users
-id: e98374a6-e2d9-4076-9b5c-11bdb2569995
+id: 9f5663ce-6205-4753-b486-fb8498d1fae5
 level: medium
 logsource:
   product: windows
   service: security
 modified: 2021/09/21
 status: experimental
-tags:
-- attack.persistence
-- attack.privilege_escalation
-- attack.t1078
 ruletype: SIGMA

--- a/test_files/rules/yaml/noisy5.yml
+++ b/test_files/rules/yaml/noisy5.yml
@@ -1,8 +1,5 @@
-title: Failed Logins with Different Accounts from Single Source System
-author: Florian Roth
+title: Noisy Rule Test 5
 date: 2017/01/10
-description: Detects suspicious failed logins with different user accounts from a
-  single source system
 detection:
   SELECTION_1:
     EventID: 4776
@@ -12,23 +9,11 @@ detection:
     Workstation: '*'
   condition: (SELECTION_1 and SELECTION_2 and SELECTION_3) | count(TargetUserName)
     by Workstation > 3
-falsepositives:
-- Terminal servers
-- Jump servers
-- Other multiuser systems like Citrix server farms
-- Workstations with frequently changing users
-id: 6309ffc4-8fa2-47cf-96b8-a2f72e58e538
+id: 3546ce10-19b4-4c4c-9658-f4f3b5d27ae9
 level: medium
 logsource:
   product: windows
   service: security
 modified: 2021/09/21
-related:
-- id: e98374a6-e2d9-4076-9b5c-11bdb2569995
-  type: derived
 status: experimental
-tags:
-- attack.persistence
-- attack.privilege_escalation
-- attack.t1078
 ruletype: SIGMA


### PR DESCRIPTION
## What Changed

- Added saved file size output which is specified `output` option.

## Evidence

```
                     
PS >./hayabusa.exe -d .\hayabusa-sample-evtx\ -o 595.csv -q
Analyzing event files: 509
Total file size: 131.9 MB

Loading detections rules. Please wait.

Excluded rules: 59
Noisy rules: 5
Rule parsing error rules: 0

Deprecated rules: 0 (0.00%)
Experimental rules: 1574 (61.58%)
Stable rules: 212 (8.29%)
Test rules: 770 (30.13%)

Hayabusa rules: 134
Sigma rules: 2422
Total enabled detection rules: 2556

...

Analysis finished. Please wait while the results are being saved.

Saved file: 595.csv (23.3 MB)

Results Summary:
...
```