### PR TITLE
Feature/improve parallel processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
  "hhmmss",
  "hyper",
  "is_elevated",
+ "itertools",
  "krapslog",
  "lazy_static",
  "linked-hash-map",
@@ -874,6 +875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5299060ff5db63e788015dcb9525ad9b84f4fd9717ed2cbdeba5018cbf42f9b5"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +693,7 @@ dependencies = [
  "clap 3.2.8",
  "crossbeam-utils",
  "csv",
+ "dashmap",
  "downcast-rs",
  "evtx",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "*"
 dashmap = "*"
 clap = { version = "3.*", features = ["derive", "cargo"]}
 evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dashmap = "*"
 clap = { version = "3.*", features = ["derive", "cargo"]}
 evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"]}
 quick-xml = {version = "0.*", features = ["serialize"] }

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -205,7 +205,7 @@ fn emit_csv<W: std::io::Write>(
 
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
 
-    let messages = print::MESSAGES.lock().unwrap();
+    let messages = &print::MESSAGES;
     // level is devided by "Critical","High","Medium","Low","Informational","Undefined".
     let mut total_detect_counts_by_level: Vec<u128> = vec![0; 6];
     let mut unique_detect_counts_by_level: Vec<u128> = vec![0; 6];
@@ -242,8 +242,8 @@ fn emit_csv<W: std::io::Write>(
     let mut timestamps: Vec<i64> = Vec::new();
     let mut plus_header = true;
     let mut detected_record_idset: HashSet<String> = HashSet::new();
-    let detect_union = messages.iter();
-    for (time, detect_infos) in detect_union {
+    for multi in messages.iter() {
+        let (time, detect_infos) = multi.pair();
         timestamps.push(_get_timestamp(time));
         for detect_info in detect_infos {
             detected_record_idset.insert(format!("{}_{}", time, detect_info.eventid));
@@ -704,7 +704,7 @@ mod tests {
     use crate::afterfact::emit_csv;
     use crate::afterfact::format_time;
     use crate::detections::print;
-    use crate::detections::print::{DetectInfo, Message};
+    use crate::detections::print::{DetectInfo};
     use chrono::{Local, TimeZone, Utc};
     use hashbrown::HashMap;
     use serde_json::Value;
@@ -720,7 +720,7 @@ mod tests {
     }
 
     fn test_emit_csv_output() {
-        let mock_ch_filter = Message::create_output_filter_config(
+        let mock_ch_filter = print::create_output_filter_config(
             "rules/config/channel_abbreviations.txt",
             true,
             false,
@@ -737,7 +737,7 @@ mod tests {
         let test_recinfo = "record_infoinfo11";
         let test_record_id = "11111";
         {
-            let mut messages = print::MESSAGES.lock().unwrap();
+            let messages = &print::MESSAGES;
             messages.clear();
             let val = r##"
                 {
@@ -754,7 +754,7 @@ mod tests {
                 }
             "##;
             let event: Value = serde_json::from_str(val).unwrap();
-            messages.insert(
+            print::insert(
                 &event,
                 output.to_string(),
                 DetectInfo {

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1,7 +1,7 @@
 use crate::detections::configs;
 use crate::detections::configs::{CURRENT_EXE_PATH, TERM_SIZE};
-use crate::detections::print;
-use crate::detections::print::{AlertMessage, IS_HIDE_RECORD_ID};
+use crate::detections::message::{self};
+use crate::detections::message::{AlertMessage, IS_HIDE_RECORD_ID};
 use crate::detections::utils;
 use crate::detections::utils::{get_writable_color, write_color_buffer};
 use bytesize::ByteSize;
@@ -205,7 +205,6 @@ fn emit_csv<W: std::io::Write>(
 
     disp_wtr_buf.set_color(ColorSpec::new().set_fg(None)).ok();
 
-    let messages = &print::MESSAGES;
     // level is devided by "Critical","High","Medium","Low","Informational","Undefined".
     let mut total_detect_counts_by_level: Vec<u128> = vec![0; 6];
     let mut unique_detect_counts_by_level: Vec<u128> = vec![0; 6];
@@ -242,7 +241,7 @@ fn emit_csv<W: std::io::Write>(
     let mut timestamps: Vec<i64> = Vec::new();
     let mut plus_header = true;
     let mut detected_record_idset: HashSet<String> = HashSet::new();
-    for multi in messages.iter() {
+    for multi in message::MESSAGES.iter() {
         let (time, detect_infos) = multi.pair();
         timestamps.push(_get_timestamp(time));
         for detect_info in detect_infos {
@@ -703,8 +702,8 @@ mod tests {
     use crate::afterfact::_get_serialized_disp_output;
     use crate::afterfact::emit_csv;
     use crate::afterfact::format_time;
-    use crate::detections::print;
-    use crate::detections::print::{DetectInfo};
+    use crate::detections::message;
+    use crate::detections::message::DetectInfo;
     use chrono::{Local, TimeZone, Utc};
     use hashbrown::HashMap;
     use serde_json::Value;
@@ -720,7 +719,7 @@ mod tests {
     }
 
     fn test_emit_csv_output() {
-        let mock_ch_filter = print::create_output_filter_config(
+        let mock_ch_filter = message::create_output_filter_config(
             "rules/config/channel_abbreviations.txt",
             true,
             false,
@@ -737,7 +736,7 @@ mod tests {
         let test_recinfo = "record_infoinfo11";
         let test_record_id = "11111";
         {
-            let messages = &print::MESSAGES;
+            let messages = &message::MESSAGES;
             messages.clear();
             let val = r##"
                 {
@@ -754,7 +753,7 @@ mod tests {
                 }
             "##;
             let event: Value = serde_json::from_str(val).unwrap();
-            print::insert(
+            message::insert(
                 &event,
                 output.to_string(),
                 DetectInfo {

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -9,11 +9,13 @@ use chrono::{DateTime, Local, TimeZone, Utc};
 use csv::QuoteStyle;
 use hashbrown::HashMap;
 use hashbrown::HashSet;
+use itertools::Itertools;
 use krapslog::{build_sparkline, build_time_markers};
 use lazy_static::lazy_static;
 use serde::Serialize;
 use std::cmp::min;
 use std::error::Error;
+use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
 use std::io;
@@ -241,8 +243,9 @@ fn emit_csv<W: std::io::Write>(
     let mut timestamps: Vec<i64> = Vec::new();
     let mut plus_header = true;
     let mut detected_record_idset: HashSet<String> = HashSet::new();
-    for multi in message::MESSAGES.iter() {
-        let (time, detect_infos) = multi.pair();
+    for time in message::MESSAGES.clone().into_read_only().keys().sorted() {
+        let multi = message::MESSAGES.get(time).unwrap();
+        let (_, detect_infos) = multi.pair();
         timestamps.push(_get_timestamp(time));
         for detect_info in detect_infos {
             detected_record_idset.insert(format!("{}_{}", time, detect_info.eventid));

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1,6 +1,6 @@
+use crate::detections::message::AlertMessage;
 use crate::detections::pivot::PivotKeyword;
 use crate::detections::pivot::PIVOT_KEYWORD;
-use crate::detections::print::AlertMessage;
 use crate::detections::utils;
 use chrono::{DateTime, Utc};
 use clap::{App, CommandFactory, Parser};

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -8,7 +8,7 @@ use crate::detections::pivot::insert_pivot_keyword;
 use crate::detections::print::AlertMessage;
 use crate::detections::print::DetectInfo;
 use crate::detections::print::ERROR_LOG_STACK;
-use crate::detections::print::MESSAGES;
+use crate::detections::print;
 use crate::detections::print::{CH_CONFIG, DEFAULT_DETAILS, IS_HIDE_RECORD_ID, TAGS_CONFIG};
 use crate::detections::print::{
     LOGONSUMMARY_FLAG, PIVOT_KEYWORD_LIST_FLAG, QUIET_ERRORS_FLAG, STATISTICS_FLAG,
@@ -268,7 +268,7 @@ impl Detection {
             record_information: opt_record_info,
             record_id: rec_id,
         };
-        MESSAGES.lock().unwrap().insert(
+        print::insert(
             &record_info.record,
             rule.yaml["details"]
                 .as_str()
@@ -312,10 +312,7 @@ impl Detection {
             record_id: rec_id,
         };
 
-        MESSAGES
-            .lock()
-            .unwrap()
-            .insert_message(detect_info, agg_result.start_timedate)
+        print::insert_message(detect_info, agg_result.start_timedate)
     }
 
     ///aggregation conditionのcount部分の検知出力文の文字列を返す関数

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -4,15 +4,14 @@ use crate::detections::configs;
 use crate::detections::utils::write_color_buffer;
 use termcolor::{BufferWriter, Color, ColorChoice};
 
-use crate::detections::pivot::insert_pivot_keyword;
-use crate::detections::print::AlertMessage;
-use crate::detections::print::DetectInfo;
-use crate::detections::print::ERROR_LOG_STACK;
-use crate::detections::print;
-use crate::detections::print::{CH_CONFIG, DEFAULT_DETAILS, IS_HIDE_RECORD_ID, TAGS_CONFIG};
-use crate::detections::print::{
+use crate::detections::message::AlertMessage;
+use crate::detections::message::DetectInfo;
+use crate::detections::message::ERROR_LOG_STACK;
+use crate::detections::message::{CH_CONFIG, DEFAULT_DETAILS, IS_HIDE_RECORD_ID, TAGS_CONFIG};
+use crate::detections::message::{
     LOGONSUMMARY_FLAG, PIVOT_KEYWORD_LIST_FLAG, QUIET_ERRORS_FLAG, STATISTICS_FLAG,
 };
+use crate::detections::pivot::insert_pivot_keyword;
 use crate::detections::rule;
 use crate::detections::rule::AggResult;
 use crate::detections::rule::RuleNode;
@@ -26,6 +25,8 @@ use std::fmt::Write;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::{runtime::Runtime, spawn, task::JoinHandle};
+
+use super::message;
 
 // イベントファイルの1レコード分の情報を保持する構造体
 #[derive(Clone, Debug)]
@@ -268,7 +269,7 @@ impl Detection {
             record_information: opt_record_info,
             record_id: rec_id,
         };
-        print::insert(
+        message::insert(
             &record_info.record,
             rule.yaml["details"]
                 .as_str()
@@ -312,7 +313,7 @@ impl Detection {
             record_id: rec_id,
         };
 
-        print::insert_message(detect_info, agg_result.start_timedate)
+        message::insert_message(detect_info, agg_result.start_timedate)
     }
 
     ///aggregation conditionのcount部分の検知出力文の文字列を返す関数

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -81,7 +81,6 @@ lazy_static! {
     ));
 }
 
-///----------------------start for struct MESSAGE------------------------------
 /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。
 /// ex. attack.impact,Impact
 pub fn create_output_filter_config(
@@ -268,8 +267,6 @@ pub fn get_default_details(filepath: &str) -> HashMap<String, String> {
         }
     }
 }
-
-///----------------------end for struct MESSAGE------------------------------
 
 impl AlertMessage {
     ///対象のディレクトリが存在することを確認後、最初の定型文を追加して、ファイルのbufwriterを返す関数

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -37,7 +37,7 @@ pub struct DetectInfo {
 pub struct AlertMessage {}
 
 lazy_static! {
-    #[derive(Debug)]
+    #[derive(Debug,PartialEq, Eq, Ord, PartialOrd)]
     pub static ref MESSAGES: DashMap<DateTime<Utc>, Vec<DetectInfo>> = DashMap::new();
     pub static ref ALIASREGEX: Regex = Regex::new(r"%[a-zA-Z0-9-_\[\]]+%").unwrap();
     pub static ref SUFFIXREGEX: Regex = Regex::new(r"\[([0-9]+)\]").unwrap();

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -68,17 +68,16 @@ lazy_static! {
     pub static ref PIVOT_KEYWORD_LIST_FLAG: bool =
         configs::CONFIG.read().unwrap().args.pivot_keywords_list;
     pub static ref IS_HIDE_RECORD_ID: bool = configs::CONFIG.read().unwrap().args.hide_record_id;
-    pub static ref DEFAULT_DETAILS: HashMap<String, String> =
-        get_default_details(&format!(
-            "{}/default_details.txt",
-            configs::CONFIG
-                .read()
-                .unwrap()
-                .args
-                .config
-                .as_path()
-                .display()
-        ));
+    pub static ref DEFAULT_DETAILS: HashMap<String, String> = get_default_details(&format!(
+        "{}/default_details.txt",
+        configs::CONFIG
+            .read()
+            .unwrap()
+            .args
+            .config
+            .as_path()
+            .display()
+    ));
 }
 
 /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。
@@ -322,8 +321,8 @@ impl AlertMessage {
 
 #[cfg(test)]
 mod tests {
-    use crate::detections::print::{DetectInfo, MESSAGES, insert, parse_message};
-    use crate::detections::print::{AlertMessage};
+    use crate::detections::message::AlertMessage;
+    use crate::detections::message::{insert, parse_message, DetectInfo, MESSAGES};
     use hashbrown::HashMap;
     use serde_json::Value;
 
@@ -684,8 +683,7 @@ mod tests {
     #[test]
     /// test of loading output filter config by output_tag.txt
     fn test_load_output_tag() {
-        let actual =
-            create_output_filter_config("test_files/config/output_tag.txt", true, false);
+        let actual = create_output_filter_config("test_files/config/output_tag.txt", true, false);
         let expected: HashMap<String, String> = HashMap::from([
             ("attack.impact".to_string(), "Impact".to_string()),
             ("xxx".to_string(), "yyy".to_string()),
@@ -696,8 +694,7 @@ mod tests {
     #[test]
     /// test of loading pass by output_tag.txt
     fn test_no_load_output_tag() {
-        let actual =
-            create_output_filter_config("test_files/config/output_tag.txt", true, true);
+        let actual = create_output_filter_config("test_files/config/output_tag.txt", true, true);
         let expected: HashMap<String, String> = HashMap::new();
         _check_hashmap_element(&expected, actual);
     }
@@ -705,11 +702,8 @@ mod tests {
     #[test]
     /// loading test to channel_abbrevations.txt
     fn test_load_abbrevations() {
-        let actual = create_output_filter_config(
-            "test_files/config/channel_abbreviations.txt",
-            false,
-            true,
-        );
+        let actual =
+            create_output_filter_config("test_files/config/channel_abbreviations.txt", false, true);
         let actual2 = create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             false,

--- a/src/detections/mod.rs
+++ b/src/detections/mod.rs
@@ -1,6 +1,6 @@
 pub mod configs;
 pub mod detection;
+pub mod message;
 pub mod pivot;
-pub mod print;
 pub mod rule;
 pub mod utils;

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -1,9 +1,9 @@
 use crate::detections::configs;
+use crate::detections::print;
 use crate::detections::print::AlertMessage;
 use crate::detections::print::ERROR_LOG_STACK;
 use crate::detections::print::QUIET_ERRORS_FLAG;
 use crate::detections::rule::AggResult;
-use crate::detections::rule::Message;
 use crate::detections::rule::RuleNode;
 use chrono::{DateTime, TimeZone, Utc};
 use hashbrown::HashMap;
@@ -33,7 +33,7 @@ pub fn count(rule: &mut RuleNode, record: &Value) {
         rule,
         key,
         field_value,
-        Message::get_event_time(record).unwrap_or(default_time),
+        print::get_event_time(record).unwrap_or(default_time),
     );
 }
 

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -1,8 +1,8 @@
 use crate::detections::configs;
-use crate::detections::print;
-use crate::detections::print::AlertMessage;
-use crate::detections::print::ERROR_LOG_STACK;
-use crate::detections::print::QUIET_ERRORS_FLAG;
+use crate::detections::message;
+use crate::detections::message::AlertMessage;
+use crate::detections::message::ERROR_LOG_STACK;
+use crate::detections::message::QUIET_ERRORS_FLAG;
 use crate::detections::rule::AggResult;
 use crate::detections::rule::RuleNode;
 use chrono::{DateTime, TimeZone, Utc};
@@ -33,7 +33,7 @@ pub fn count(rule: &mut RuleNode, record: &Value) {
         rule,
         key,
         field_value,
-        print::get_event_time(record).unwrap_or(default_time),
+        message::get_event_time(record).unwrap_or(default_time),
     );
 }
 

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -1,5 +1,4 @@
 extern crate regex;
-use crate::detections::print::Message;
 
 use chrono::{DateTime, Utc};
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,7 +1,7 @@
 use crate::detections::configs;
-use crate::detections::print::AlertMessage;
-use crate::detections::print::ERROR_LOG_STACK;
-use crate::detections::print::QUIET_ERRORS_FLAG;
+use crate::detections::message::AlertMessage;
+use crate::detections::message::ERROR_LOG_STACK;
+use crate::detections::message::QUIET_ERRORS_FLAG;
 use hashbrown::HashMap;
 use regex::Regex;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,12 @@ use hashbrown::{HashMap, HashSet};
 use hayabusa::detections::configs::CURRENT_EXE_PATH;
 use hayabusa::detections::configs::{load_pivot_keywords, TargetEventTime, TARGET_EXTENSIONS};
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
-use hayabusa::detections::pivot::PivotKeyword;
-use hayabusa::detections::pivot::PIVOT_KEYWORD;
-use hayabusa::detections::print::{
+use hayabusa::detections::message::{
     AlertMessage, ERROR_LOG_PATH, ERROR_LOG_STACK, LOGONSUMMARY_FLAG, PIVOT_KEYWORD_LIST_FLAG,
     QUIET_ERRORS_FLAG, STATISTICS_FLAG,
 };
+use hayabusa::detections::pivot::PivotKeyword;
+use hayabusa::detections::pivot::PIVOT_KEYWORD;
 use hayabusa::detections::rule::{get_detection_keys, RuleNode};
 use hayabusa::omikuji::Omikuji;
 use hayabusa::options::{level_tuning::LevelTuning, update_rules::UpdateRules};

--- a/src/options/update_rules.rs
+++ b/src/options/update_rules.rs
@@ -1,4 +1,4 @@
-use crate::detections::print::AlertMessage;
+use crate::detections::message::AlertMessage;
 use crate::detections::utils::write_color_buffer;
 use crate::filter;
 use crate::yaml::ParseYaml;

--- a/src/timeline/statistics.rs
+++ b/src/timeline/statistics.rs
@@ -1,4 +1,4 @@
-use crate::detections::print::{LOGONSUMMARY_FLAG, STATISTICS_FLAG};
+use crate::detections::message::{LOGONSUMMARY_FLAG, STATISTICS_FLAG};
 use crate::detections::{detection::EvtxRecordInfo, utils};
 use hashbrown::HashMap;
 

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -1,4 +1,4 @@
-use crate::detections::print::{LOGONSUMMARY_FLAG, STATISTICS_FLAG};
+use crate::detections::message::{LOGONSUMMARY_FLAG, STATISTICS_FLAG};
 use crate::detections::{configs::CONFIG, detection::EvtxRecordInfo};
 use prettytable::{Cell, Row, Table};
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -3,8 +3,8 @@ extern crate yaml_rust;
 
 use crate::detections::configs;
 use crate::detections::configs::EXCLUDE_STATUS;
-use crate::detections::print::AlertMessage;
-use crate::detections::print::{ERROR_LOG_STACK, QUIET_ERRORS_FLAG};
+use crate::detections::message::AlertMessage;
+use crate::detections::message::{ERROR_LOG_STACK, QUIET_ERRORS_FLAG};
 use crate::filter::RuleExclude;
 use hashbrown::HashMap;
 use std::ffi::OsStr;
@@ -316,8 +316,8 @@ impl ParseYaml {
 #[cfg(test)]
 mod tests {
 
-    use crate::detections::print::AlertMessage;
-    use crate::detections::print::ERROR_LOG_PATH;
+    use crate::detections::message::AlertMessage;
+    use crate::detections::message::ERROR_LOG_PATH;
     use crate::filter;
     use crate::yaml;
     use crate::yaml::RuleExclude;


### PR DESCRIPTION
fix #479.

DashMapという並列HashMapを使うと、

私の環境では、2割以上、早くなりました。

実装するにあたって、
Message構造体をなくして、グローバルに直にMESSAGEを定義しています。
なぜそうしているかというと、早い話、速度が出ないからです。
セグメントごとに所有権を持ってスレッドに渡しているのに、それらをラップして一つの所有権にしてしまうので、
速度が出ないです。

そのため、いろいろMessageのメソッドになっていましたが、トップにじかに書いています。

あと、ファイル名の名前が分かりずらいと感じだので、変更しました。print.rsをmessage.rsに変えました。
message::insertとかになるので、この方が分かりやすいかなと。


DashMapを使うにあたって、
test_create_and_append_messageというテストを動くように書けないので、消しました。
DashMapの方のmemberを文字列として取得したいが、privateなので、できませんでした。
https://github.com/Yamato-Security/hayabusa/commit/7fcb3496b3279775161c86a0c8589da5f688c3c1
こんな感じで試行錯誤したけど、無理でした。
derive記述でもダメでした。