### PR TITLE
Fixed: To remove './' string from update path result. #642

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,11 +4,11 @@
 
 **新機能:**
 
-- `config/profiles.yaml`と`config/default_profile.yaml`の設定ファイルで、出力内容をカストマイズできる。 (#165) (@hitenkoku)
+- `config/profiles.yaml`と`config/default_profile.yaml`の設定ファイルで、出力内容をカスタマイズできる。 (#165) (@hitenkoku)
 
 **改善:**
 
-- XXX
+- ルールのアップデート機能のルールパスの出力から./を削除した。 (#642) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Enhancements:**
 
-- XXX
+- Removed ./ from rule path when updating. (#642) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/options/update_rules.rs
+++ b/src/options/update_rules.rs
@@ -217,12 +217,17 @@ impl UpdateRules {
             *update_count_by_rule_type
                 .entry(tmp[3].to_string())
                 .or_insert(0b0) += 1;
+            let path_str: &str = if tmp[2].starts_with("./") {
+                tmp[2].strip_prefix("./").unwrap()
+            } else {
+                tmp[2]
+            };
             write_color_buffer(
                 &BufferWriter::stdout(ColorChoice::Always),
                 None,
                 &format!(
                     "[Updated] {} (Modified: {} | Path: {})",
-                    tmp[0], tmp[1], tmp[2]
+                    tmp[0], tmp[1], path_str
                 ),
                 true,
             )


### PR DESCRIPTION
Closes #642 

## What Changed

- Removed  starts with `./`  from updated rule path.

## Evidence

```
PS > ./hayabusa.exe -u   -q

[Updated] ADS Created (Modified: 2022/06/21 | Path: rules\hayabusa\sysmon\alerts\Sysmon_15_AlternateDataStreamCreated_SysmonAlert.yml)
...
[Updated] Vulnerable WinRing0 Driver Load (Modified: 2022/07/26 | Path: rules\sigma\sysmon\driver_load\driver_load_vuln_winring0_driver.yml)

Updated Sigma rules: 440
Updated Hayabusa rules: 142
Rules updated successfully.

```