### PR TITLE
Fix race condition in insert_message. #639

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "pbr",
  "prettytable-rs",
  "quick-xml",
+ "rand",
  "regex",
  "serde",
  "serde_derive",
@@ -1357,6 +1358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1456,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ num-format = "*"
 [build-dependencies]
 static_vcruntime = "2.*"
 
+[dev-dependencies]
+rand = "0.8.*"
+
 [target.'cfg(windows)'.dependencies]
 is_elevated = "0.1.*"
 


### PR DESCRIPTION
## What Changed
- Fix #639.
- Fixed static variable `MESSAGES` Read/Write operartion to be thread safe in insert_message.
- Add race condition reproduction unit test.
  - Since [it will fail if not run in a single thread,](https://github.com/Yamato-Security/hayabusa/issues/639#issuecomment-1213229674), add ignore attribute by default.

## Evidence
Run the following command 5 times and confirm that the number of detections is the same.
`hayabusa -d ../hayabusa-sample-evtx -o ...`

Attach the command execution results.
[test-results.zip](https://github.com/Yamato-Security/hayabusa/files/9327948/test-results.zip)