### PR TITLE
fix: Detection result records(crit,med,low level) not colored

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -221,7 +221,7 @@ fn emit_csv<W: std::io::Write>(
                     &disp_wtr,
                     get_writable_color(_get_output_color(
                         &color_map,
-                        LEVEL_ABBR
+                        &LEVEL_FULL
                             .get(&detect_info.level)
                             .unwrap_or(&String::default()),
                     )),

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -221,7 +221,7 @@ fn emit_csv<W: std::io::Write>(
                     &disp_wtr,
                     get_writable_color(_get_output_color(
                         &color_map,
-                        &LEVEL_FULL
+                        LEVEL_FULL
                             .get(&detect_info.level)
                             .unwrap_or(&String::default()),
                     )),


### PR DESCRIPTION
## What Changed
- Fix #662
- Change the source color hashmap LEVEL_ABBR to LEVEL_FULL when output console.

## Evidence
Execute #662 Step to Reproduce and confirm as follows.
- The number of detections (and aggregation) is same as before fix.
- All detection records are colored as follows.
![fix-colored](https://user-images.githubusercontent.com/41001169/185438601-b500a8ab-0ab1-4995-b4ba-359f5d7fdb22.png)

