### PR TITLE
fix: add file existing check when -f option specified. issue #664

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,14 @@ impl App {
             }
             self.analysis_files(live_analysis_list.unwrap(), &time_filter);
         } else if let Some(filepath) = &configs::CONFIG.read().unwrap().args.filepath {
+            if !filepath.exists() {
+                AlertMessage::alert(&format!(
+                    " The file {} does not exist. Please specify a valid file path.",
+                    filepath.as_os_str().to_str().unwrap()
+                ))
+                .ok();
+                return;
+            }
             if !TARGET_EXTENSIONS.contains(
                 filepath
                     .extension()


### PR DESCRIPTION
## What Changed
- Fix #664
- Add file existing check when -f option specified.

## Evidence
Execute #664 Step to Reproduce and confirm that Hayabusa not crash and print message as follows.
![not-exist-evtx-checked](https://user-images.githubusercontent.com/41001169/185457946-257ed3ea-ee9b-4bbc-93e9-010d1c7da517.png)


