### PR TITLE
auto clear PIVOT_KEYWORD in every unit test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,5 +35,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
-
+        run: cargo test --verbose -- --test-threads=1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose -- -- --test-threads=1
+        run: RUST_TEST_THREADS=1 cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose -- --test-threads=1
+        run: cargo test --verbose -- -- --test-threads=1

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -625,7 +625,6 @@ mod tests {
         }
     }
 
-    #[ignore]
     #[test]
     fn test_insert_message_race_condition() {
         MESSAGES.clear();

--- a/src/detections/pivot.rs
+++ b/src/detections/pivot.rs
@@ -91,9 +91,9 @@ mod tests {
     use crate::detections::pivot::PIVOT_KEYWORD;
     use serde_json;
 
-    //PIVOT_KEYWORDはグローバルなので、他の関数の影響も考慮する必要がある。
     #[test]
     fn insert_pivot_keyword_local_ip4() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -119,6 +119,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_ip4() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -144,6 +145,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_ip_empty() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -169,6 +171,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_local_ip6() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -194,6 +197,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_infomational() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -219,6 +223,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_low() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {
@@ -244,6 +249,7 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_none() {
+        PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
         {


### PR DESCRIPTION
Old code consider programer side effect of PIVOT_KEYWORD global var.
So I add auto clear code. Because I wanna to be miss is off.