### PR TITLE
update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,9 @@ checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -597,8 +594,8 @@ dependencies = [
 
 [[package]]
 name = "evtx"
-version = "0.8.3"
-source = "git+https://github.com/Yamato-Security/hayabusa-evtx.git?rev=5b0884d#5b0884dbc05a9dfd68d78063f9401eac14eea076"
+version = "0.8.2"
+source = "git+https://github.com/Yamato-Security/hayabusa-evtx.git?rev=95b1c6a#95b1c6a1eebe6e2dc7be896974e92e912ddb6780"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -612,7 +609,7 @@ dependencies = [
  "indoc",
  "jemallocator",
  "log",
- "quick-xml 0.25.0",
+ "quick-xml",
  "rayon",
  "rpmalloc",
  "serde",
@@ -828,7 +825,7 @@ dependencies = [
  "openssl",
  "pbr",
  "pulldown-cmark",
- "quick-xml 0.23.1",
+ "quick-xml",
  "rand",
  "regex",
  "reqwest",
@@ -1280,12 +1277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,12 +1289,12 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "cc2a6559322ec7c5b7188ac5ca85865b187a46b03d30b00f0c0e3549eecadb1e"
 dependencies = [
  "arrayvec",
- "itoa 0.4.8",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -1540,15 +1531,6 @@ checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e21a144a0ffb5fad7b464babcdab934a325ad69b7c0373bcfef5cbd9799ca9"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1847,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa 1.0.4",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 itertools = "*"
 dashmap = "*"
 clap = { version = "3.*", features = ["derive", "cargo"]}
-evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"] , rev = "5b0884d" } #0.8.3
+evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"] , rev = "95b1c6a" } #0.8.2. Using the older version as the newer versions won't compile on windows 32-bit.
 quick-xml = {version = "0.23.*", features = ["serialize"] }
 serde = { version = "1.*", features = ["derive"] }
 serde_json = { version = "1.0"}


### PR DESCRIPTION
evtx 0.8.3はWindows 32ビットではコンパイルできないので、quick-xml 0.23を使うevtx 0.8.2に落としました。
hayabusa-evtx は様々なcross compileをしていますが、cross は現在なぜかwindows 32ビットに対応していないようで、そもそも32-bitバイナリをコンパイルしていませんでした。(evtx crateも同じように32ビットチェックをしているはずだけど、実は失敗しています。evtx crateツールのevtxdumpもwin 32bitでビルドエラーになっていました。)

問題は上流のquick-xml crateにありそうなので、取り敢えずそちらに連絡してみます。直るまではquick-xml 0.23を使いましょう。