### PR TITLE
fix: profile option command usage.

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -228,7 +228,7 @@ pub struct Config {
     #[clap(help_heading = Some("FILTERING"), long = "exclude-status", multiple_values = true, value_name = "STATUS")]
     pub exclude_status: Option<Vec<String>>,
 
-    /// Specify output profile (minimal, standard, verbose, all-field-info, all-field-info-verbose, super-verbose, timesketch-minimal, timesketch-verbose)
+    /// Specify output profile (minimal, standard, verbose, all-field-info, etc...)
     #[clap(help_heading = Some("OUTPUT"), short = 'P', long = "profile")]
     pub profile: Option<String>,
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -228,7 +228,7 @@ pub struct Config {
     #[clap(help_heading = Some("FILTERING"), long = "exclude-status", multiple_values = true, value_name = "STATUS")]
     pub exclude_status: Option<Vec<String>>,
 
-    /// Specify output profile (minimal, standard, verbose, verbose-all-field-info, verbose-details-and-all-field-info)
+    /// Specify output profile (minimal, standard, verbose, all-field-info, all-field-info-verbose, super-verbose, timesketch-minimal, timesketch-verbose)
     #[clap(help_heading = Some("OUTPUT"), short = 'P', long = "profile")]
     pub profile: Option<String>,
 


### PR DESCRIPTION
## What Changed
- Fix profile option command usage
  - because **verbose-all-field-info**, **verbose-details-and-all-field-info** could not be set.

## Evidence
<img width="1440" alt="スクリーンショット 2022-10-14 1 44 20" src="https://user-images.githubusercontent.com/41001169/195656382-459d237e-0044-436f-a334-a1ca686584fa.png">


But above usage is too long ... ? 😅  Is it better to omit ?