### PR TITLE
fix: add check if it is executed with admin privileges when -u option.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,9 @@ impl App {
         }
 
         if configs::CONFIG.read().unwrap().args.update_rules {
+            if !self.can_update_rules() {
+                return;
+            }
             // エラーが出た場合はインターネット接続がそもそもできないなどの問題点もあるためエラー等の出力は行わない
             let latest_version_data = if let Ok(data) = Update::get_latest_hayabusa_version() {
                 data
@@ -534,6 +537,24 @@ impl App {
                     .to_string(),
             )
         }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn can_update_rules(&self) -> bool {
+        true
+    }
+
+    #[cfg(target_os = "windows")]
+    fn can_update_rules(&self) -> bool {
+        if is_elevated() {
+            AlertMessage::alert(
+                "-u / --update-rules needs to be run as non-Administrator on Windows.",
+            )
+            .ok();
+            println!();
+            return false;
+        }
+        true
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## What Changed
- fix: #758 
- add check if it is executed with admin privileges when --update-rules option is specified.
  - because [by default, git denies access to the owner's .git repository by a user other than the current user](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory)

## Evidence
### Test 1
#### Environment 
- Windows Server 2016 Datacenter
- AWS
#### Screenshot
update-rules print error message  as follows when admin privileges.
![fix-errormsg](https://user-images.githubusercontent.com/41001169/196844356-6e5569a9-5aa4-41dc-b566-fe3e7687a7e6.png)

update-rules success as follows when current user.
![fix-success](https://user-images.githubusercontent.com/41001169/196844382-628c3922-591a-43bf-80ea-d4709a2edee7.png)


### Test 2 
#### Environment 
- macOS Monterey version 12.6
- MacBook Air (M1, 2020)

### Console output
update-rules success as follows on mac.
```
% ./hayabusa-dev -u

╔╗ ╔╦═══╦╗  ╔╦═══╦══╗╔╗ ╔╦═══╦═══╗
║║ ║║╔═╗║╚╗╔╝║╔═╗║╔╗║║║ ║║╔═╗║╔═╗║
║╚═╝║║ ║╠╗╚╝╔╣║ ║║╚╝╚╣║ ║║╚══╣║ ║║
║╔═╗║╚═╝║╚╗╔╝║╚═╝║╔═╗║║ ║╠══╗║╚═╝║
║║ ║║╔═╗║ ║║ ║╔═╗║╚═╝║╚═╝║╚═╝║╔═╗║
╚╝ ╚╩╝ ╚╝ ╚╝ ╚╝ ╚╩═══╩═══╩═══╩╝ ╚╝
   by Yamato Security

 - Vulnerable Driver Load By Name (Modified: 2022/10/17 | Path: rules/sigma/sysmon/driver_load/driver_load_vuln_drivers_names.yml)
 - MSI Installation From Suspicious Locations (Modified: 2022/10/18 | Path: rules/sigma/builtin/application/win_msi_install_from_susp_locations.yml)
 - CurrentVersion Autorun Keys Modification (Modified: 2022/10/18 | Path: rules/sigma/builtin/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml)
 - Abusing Azure Browser SSO (Modified: 2022/10/18 | Path: rules/sigma/sysmon/image_load/image_load_abusing_azure_browser_sso.yml)
 - CurrentVersion Autorun Keys Modification (Modified: 2022/10/18 | Path: rules/sigma/sysmon/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml)
 - Event Log Svc Stopped (Modified: 2022/05/21 | Path: rules/hayabusa/builtin/System/Sys_6006_Info_EventLogSvcStopped.yml)
 - Renamed Binary (Modified: 2022/10/17 | Path: rules/sigma/builtin/process_creation/proc_creation_win_renamed_binary.yml)
 - Renamed Binary (Modified: 2022/10/17 | Path: rules/sigma/sysmon/process_creation/proc_creation_win_renamed_binary.yml)
 - Use Short Name Path in Command Line (Modified: 2022/10/19 | Path: rules/sigma/sysmon/process_creation/proc_creation_win_ntfs_short_name_path_use_cli.yml)
 - Delete Rule in Windows Firewall with Advanced Security (Modified: 2022/10/18 | Path: rules/sigma/builtin/firewall_as/win_firewall_as_delete_rule.yml)
 - Use Short Name Path in Command Line (Modified: 2022/10/19 | Path: rules/sigma/builtin/process_creation/proc_creation_win_ntfs_short_name_path_use_cli.yml)
 - Rare GrantedAccess Flags on LSASS Access (Modified: 2022/10/19 | Path: rules/sigma/sysmon/process_access/proc_access_win_rare_proc_access_lsass.yml)

Updated Hayabusa rules: 1
Updated Sigma rules: 11
Rules updated successfully.
```
I would appreciate it if you could review🙏