### PR TITLE
Reduce used memory and Skipped rule author, detect counts aggregation when --no-summary option is used

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,8 @@
 - JSON出力のDetailsフィールドをオブジェクト形式で出力するように変更した。 (#773) (@hitenkoku)
 - `build.rs`を削除し、メモリアロケータをmimallocに変更した。Intel系OSでは20-30%の速度向上が見込める。 (#657) (@fukusuket)
 - プロファイルの`%RecordInformation%` エイリアスを `%AllFieldInfo%` に変更した。 AllFieldInfoフィールドをJSONオブジェクト形式で出力するように変更した。 (#750) (@hitenkoku)
+- `--no-summary`  オプションを使用したときに、表示しないルール作者および検知回数の集計を省略した。 (#780) (@hitenkoku)
+- メモリ使用量を少なくし、処理速度を改善した。 (#778) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Changed Details field in JSON output to object. (#773) (@hitenkoku)
 - Removed `build.rs` and changed the memory allocator to mimalloc for a speed increase of 20-30% on Intel-based OSes. (#657) (@fukusuket)
 - Replaced %RecordInformation% alias in profile to %AllFieldInfo%, and changed AllFieldInfo field in JSON output to object. (#750) (@hitenkoku)
+- Skipped rule author, detect counts aggregation when --no-summary option is used. (#780) (@hitenkoku)
+- Reduced Memory usage and improved speed performance. (#778) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "linked-hash-map",
  "lock_api",
  "mimalloc",
+ "nested",
  "num-format",
  "num_cpus",
  "openssl",
@@ -1293,6 +1294,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 
 [[package]]
 name = "num-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ pulldown-cmark = { version = "0.9.*", default-features = false, features = ["sim
 reqwest = {version = "0.11.*", features = ["blocking", "json"]}
 horrorshow = "0.8.*"
 mimalloc = { version = "*", default-features = false }
+nested="*"
 
 [dev-dependencies]
 rand = "0.8.*"

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -377,7 +377,7 @@ fn emit_csv<W: std::io::Write>(
         )
         .ok();
         write_color_buffer(&disp_wtr, get_writable_color(None), " ", true).ok();
-    
+
         println!();
         output_detected_rule_authors(rule_author_counter);
         println!();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -254,9 +254,8 @@ fn emit_csv<W: std::io::Write>(
     let mut timestamps: Vec<i64> = Vec::new();
     let mut plus_header = true;
     let mut detected_record_idset: HashSet<String> = HashSet::new();
-    
-    for time in MESSAGEKEYS.lock().unwrap().iter().sorted_unstable()
-    {
+
+    for time in MESSAGEKEYS.lock().unwrap().iter().sorted_unstable() {
         let multi = message::MESSAGES.get(time).unwrap();
         let (_, detect_infos) = multi.pair();
         timestamps.push(_get_timestamp(time));
@@ -574,7 +573,9 @@ fn _get_serialized_disp_output(data: &LinkedHashMap<String, String>, header: boo
         .has_headers(false)
         .from_writer(vec![]);
 
-    disp_serializer.write_record(ret.iter().collect::<Vec<_>>()).ok();
+    disp_serializer
+        .write_record(ret.iter().collect::<Vec<_>>())
+        .ok();
     String::from_utf8(disp_serializer.into_inner().unwrap_or_default())
         .unwrap_or_default()
         .replace('|', "‖")
@@ -1261,7 +1262,7 @@ fn extract_author_name(yaml_path: &str) -> Nested<String> {
                     tmp[0].to_string()
                 })
                 .collect();
-            let mut ret= Nested::<String>::new();
+            let mut ret = Nested::<String>::new();
             for author in authors_vec.iter() {
                 ret.extend(author.split(';'));
             }
@@ -1276,8 +1277,10 @@ fn extract_author_name(yaml_path: &str) -> Nested<String> {
                                 .replace('\'', "")
                                 .trim()
                                 .to_string()
-                        }).collect::<String>()
-                }).collect();
+                        })
+                        .collect::<String>()
+                })
+                .collect();
         };
     }
     // ここまで来た場合は要素がない場合なので空配列を返す

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -194,7 +194,7 @@ pub fn after_fact(all_record_cnt: usize) {
         displayflag,
         color_map,
         all_record_cnt as u128,
-        PROFILES.to_owned().unwrap_or_default(),
+        PROFILES.as_ref().unwrap(),
     ) {
         fn_emit_csv_err(Box::new(err));
     }
@@ -205,7 +205,7 @@ fn emit_csv<W: std::io::Write>(
     displayflag: bool,
     color_map: HashMap<String, Colors>,
     all_record_cnt: u128,
-    profile: LinkedHashMap<String, String>,
+    profile: &LinkedHashMap<String, String>,
 ) -> io::Result<()> {
     let mut html_output_stock = Nested::<String>::new();
     let html_output_flag = *HTML_REPORT_FLAG;
@@ -275,7 +275,7 @@ fn emit_csv<W: std::io::Write>(
                     write_color_buffer(
                         &disp_wtr,
                         get_writable_color(None),
-                        &_get_serialized_disp_output(&profile, true),
+                        &_get_serialized_disp_output(profile, true),
                         false,
                     )
                     .ok();
@@ -298,7 +298,7 @@ fn emit_csv<W: std::io::Write>(
                 wtr.write_field("{")?;
                 wtr.write_field(&output_json_str(
                     &detect_info.ext_field,
-                    &profile,
+                    profile,
                     jsonl_output_flag,
                 ))?;
                 wtr.write_field("}")?;
@@ -306,7 +306,7 @@ fn emit_csv<W: std::io::Write>(
                 // JSONL output format
                 wtr.write_field(format!(
                     "{{ {} }}",
-                    &output_json_str(&detect_info.ext_field, &profile, jsonl_output_flag)
+                    &output_json_str(&detect_info.ext_field, profile, jsonl_output_flag)
                 ))?;
             } else {
                 // csv output format
@@ -1419,7 +1419,7 @@ mod tests {
                 + test_attack
                 + "\n";
         let mut file: Box<dyn io::Write> = Box::new(File::create("./test_emit_csv.csv").unwrap());
-        assert!(emit_csv(&mut file, false, HashMap::new(), 1, output_profile).is_ok());
+        assert!(emit_csv(&mut file, false, HashMap::new(), 1, &output_profile).is_ok());
         match read_to_string("./test_emit_csv.csv") {
             Err(_) => panic!("Failed to open file."),
             Ok(s) => {

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -193,7 +193,7 @@ pub fn after_fact(all_record_cnt: usize) {
         displayflag,
         color_map,
         all_record_cnt as u128,
-        PROFILES.clone().unwrap_or_default(),
+        PROFILES.to_owned().unwrap_or_default(),
     ) {
         fn_emit_csv_err(Box::new(err));
     }
@@ -254,7 +254,7 @@ fn emit_csv<W: std::io::Write>(
     let mut detected_record_idset: HashSet<String> = HashSet::new();
 
     for (_, time) in message::MESSAGES
-        .clone()
+        .to_owned()
         .into_read_only()
         .keys()
         .sorted()
@@ -328,13 +328,13 @@ fn emit_csv<W: std::io::Write>(
             let mut detect_counts_by_date = detect_counts_by_date_and_level
                 .get(&detect_info.level.to_lowercase())
                 .unwrap_or_else(|| detect_counts_by_date_and_level.get("undefined").unwrap())
-                .clone();
+                .to_owned();
             *detect_counts_by_date
                 .entry(time_str_date.to_string())
                 .or_insert(0) += 1;
             if !detected_rule_files.contains(&detect_info.rulepath) {
-                detected_rule_files.insert(detect_info.rulepath.clone());
-                for author in extract_author_name(detect_info.rulepath.clone()) {
+                detected_rule_files.insert(detect_info.rulepath.to_owned());
+                for author in extract_author_name(detect_info.rulepath.to_owned()) {
                     *rule_author_counter.entry(author).or_insert(1) += 1;
                 }
                 unique_detect_counts_by_level[level_suffix] += 1;
@@ -351,7 +351,7 @@ fn emit_csv<W: std::io::Write>(
                             .get("undefined")
                             .unwrap()
                     })
-                    .clone();
+                    .to_owned();
                 *detect_counts_by_computer
                     .entry(Clone::clone(&detect_info.computername))
                     .or_insert(0) += 1;
@@ -366,9 +366,9 @@ fn emit_csv<W: std::io::Write>(
                         .get("undefined")
                         .unwrap()
                 })
-                .clone();
-            rule_title_path_map.insert(detect_info.ruletitle.clone(), detect_info.rulepath.clone());
-            *detect_counts_by_rules
+                .to_owned();
+                rule_title_path_map.insert(detect_info.ruletitle.to_owned(), detect_info.rulepath.to_owned());
+                *detect_counts_by_rules
                 .entry(Clone::clone(&detect_info.ruletitle))
                 .or_insert(0) += 1;
             detect_counts_by_rule_and_level
@@ -1378,7 +1378,7 @@ mod tests {
                     eventid: test_eventid.to_string(),
                     detail: String::default(),
                     record_information: Option::Some(test_recinfo.to_string()),
-                    ext_field: output_profile.clone(),
+                    ext_field: output_profile.to_owned(),
                 },
                 expect_time,
                 &mut profile_converter,
@@ -1389,7 +1389,7 @@ mod tests {
             "Timestamp,Computer,Channel,Level,EventID,MitreAttack,RecordID,RuleTitle,Details,RecordInformation,RuleFile,EvtxFile,Tags\n"
                 .to_string()
                 + &expect_tz
-                    .clone()
+                    .to_owned()
                     .format("%Y-%m-%d %H:%M:%S%.3f %:z")
                     .to_string()
                 + ","
@@ -1446,7 +1446,7 @@ mod tests {
         let expect_tz = test_timestamp.with_timezone(&Local);
 
         let expect_no_header = expect_tz
-            .clone()
+            .to_owned()
             .format("%Y-%m-%d %H:%M:%S%.3f %:z")
             .to_string()
             + " ‖ "

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -258,7 +258,7 @@ fn emit_csv<W: std::io::Write>(
         .to_owned()
         .into_read_only()
         .keys()
-        .sorted()
+        .sorted_unstable()
         .enumerate()
     {
         let multi = message::MESSAGES.get(time).unwrap();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -368,20 +368,19 @@ fn emit_csv<W: std::io::Write>(
     }
 
     disp_wtr_buf.clear();
-    write_color_buffer(
-        &disp_wtr,
-        get_writable_color(Some(Color::Rgb(0, 255, 0))),
-        "Rule Authors:",
-        false,
-    )
-    .ok();
-    write_color_buffer(&disp_wtr, get_writable_color(None), " ", true).ok();
-
-    println!();
-    output_detected_rule_authors(rule_author_counter);
-    println!();
-
     if !is_no_summary {
+        write_color_buffer(
+            &disp_wtr,
+            get_writable_color(Some(Color::Rgb(0, 255, 0))),
+            "Rule Authors:",
+            false,
+        )
+        .ok();
+        write_color_buffer(&disp_wtr, get_writable_color(None), " ", true).ok();
+    
+        println!();
+        output_detected_rule_authors(rule_author_counter);
+        println!();
         disp_wtr_buf.clear();
         write_color_buffer(
             &disp_wtr,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1,5 +1,5 @@
 use crate::detections::configs::{self, CURRENT_EXE_PATH, TERM_SIZE};
-use crate::detections::message::{self, AlertMessage, LEVEL_ABBR, LEVEL_FULL};
+use crate::detections::message::{self, AlertMessage, LEVEL_ABBR, LEVEL_FULL, MESSAGEKEYS};
 use crate::detections::utils::{self, format_time, get_writable_color, write_color_buffer};
 use crate::options::htmlreport::{self, HTML_REPORT_FLAG};
 use crate::options::profile::PROFILES;
@@ -254,13 +254,8 @@ fn emit_csv<W: std::io::Write>(
     let mut timestamps: Vec<i64> = Vec::new();
     let mut plus_header = true;
     let mut detected_record_idset: HashSet<String> = HashSet::new();
-
-    for (_, time) in message::MESSAGES
-        .to_owned()
-        .into_read_only()
-        .keys()
-        .sorted_unstable()
-        .enumerate()
+    
+    for time in MESSAGEKEYS.lock().unwrap().iter().sorted_unstable()
     {
         let multi = message::MESSAGES.get(time).unwrap();
         let (_, detect_infos) = multi.pair();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -242,10 +242,12 @@ fn emit_csv<W: std::io::Write>(
 
     let levels = Vec::from(["crit", "high", "med ", "low ", "info", "undefined"]);
     // レベル別、日ごとの集計用変数の初期化
-    for level_init in levels {
-        detect_counts_by_date_and_level.insert(level_init.to_string(), HashMap::new());
-        detect_counts_by_computer_and_level.insert(level_init.to_string(), HashMap::new());
-        detect_counts_by_rule_and_level.insert(level_init.to_string(), HashMap::new());
+    if is_no_summary {
+        for level_init in levels {
+            detect_counts_by_date_and_level.insert(level_init.to_string(), HashMap::new());
+            detect_counts_by_computer_and_level.insert(level_init.to_string(), HashMap::new());
+            detect_counts_by_rule_and_level.insert(level_init.to_string(), HashMap::new());
+        }
     }
     if displayflag {
         println!();

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -270,7 +270,7 @@ impl ConfigReader<'_> {
             .help_template("\n\nUSAGE:\n    {usage}\n\nOPTIONS:\n{options}");
         ConfigReader {
             app: build_cmd,
-            args: parse.clone(),
+            args: parse.to_owned(),
             headless_help: String::default(),
             event_timeline_config: load_eventcode_info(
                 utils::check_setting_path(&parse.config, "channel_eid_info.txt", false)

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -333,8 +333,8 @@ impl Detection {
                                         || x.starts_with("attack.s"))
                             })
                             .map(|y| {
-                                let mut replaced_tag = y.replace("attack.", "");
-                                make_ascii_titlecase(&mut replaced_tag)
+                                let replaced_tag = y.replace("attack.", "");
+                                make_ascii_titlecase(&replaced_tag)
                             })
                             .collect();
                         profile_converter.insert("%MitreTags%".to_string(), techniques.join(" ¦ "));
@@ -497,8 +497,8 @@ impl Detection {
                                         || x.starts_with("attack.s"))
                             })
                             .map(|y| {
-                                let mut replaced_tag = y.replace("attack.", "");
-                                make_ascii_titlecase(&mut replaced_tag)
+                                let replaced_tag = y.replace("attack.", "");
+                                make_ascii_titlecase(&replaced_tag)
                             })
                             .collect();
                         profile_converter.insert("%MitreTags%".to_string(), techniques.join(" ¦ "));
@@ -644,7 +644,7 @@ impl Detection {
                 //タイトルに利用するものはascii文字であることを前提として1文字目を大文字にするように変更する
                 let output_str = format!(
                     "{} rules: {}{}",
-                    make_ascii_titlecase(key.clone().as_mut()),
+                    make_ascii_titlecase(key),
                     value,
                     disable_flag
                 );
@@ -678,7 +678,7 @@ impl Detection {
                 };
                 let output_str = format!(
                     "{} rules: {} ({:.2}%){}",
-                    make_ascii_titlecase(key.clone().as_mut()),
+                    make_ascii_titlecase(key),
                     value,
                     rate,
                     deprecated_flag

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -7,6 +7,7 @@ use crate::options::profile::{
 };
 use chrono::{TimeZone, Utc};
 use itertools::Itertools;
+use nested::Nested;
 use termcolor::{BufferWriter, Color, ColorChoice};
 
 use crate::detections::message::{
@@ -632,7 +633,7 @@ impl Detection {
         let mut sorted_ld_rc: Vec<(&String, &u128)> = ld_rc.iter().collect();
         sorted_ld_rc.sort_by(|a, b| a.0.cmp(b.0));
         let args = &configs::CONFIG.read().unwrap().args;
-        let mut html_report_stock = Vec::new();
+        let mut html_report_stock = Nested::<String>::new();
 
         sorted_ld_rc.into_iter().for_each(|(key, value)| {
             if value != &0_u128 {

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -1,11 +1,11 @@
 extern crate lazy_static;
-use hashbrown::HashSet;
 use crate::detections::configs::{self, CURRENT_EXE_PATH};
 use crate::detections::utils::{self, get_serde_number_to_string, write_color_buffer};
 use crate::options::profile::PROFILES;
 use chrono::{DateTime, Local, Utc};
 use dashmap::DashMap;
 use hashbrown::HashMap;
+use hashbrown::HashSet;
 use lazy_static::lazy_static;
 use linked_hash_map::LinkedHashMap;
 use regex::Regex;

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -171,21 +171,20 @@ pub struct TimeFrameInfo {
 
 impl TimeFrameInfo {
     /// timeframeの文字列をパースし、構造体を返す関数
-    pub fn parse_tframe(value: String) -> TimeFrameInfo {
+    pub fn parse_tframe(mut value: String) -> TimeFrameInfo {
         let mut ttype: String = "".to_string();
-        let mut tnum = value.clone();
         if value.contains('s') {
             ttype = "s".to_owned();
-            tnum.retain(|c| c != 's');
+            value.retain(|c| c != 's');
         } else if value.contains('m') {
             ttype = "m".to_owned();
-            tnum.retain(|c| c != 'm');
+            value.retain(|c| c != 'm')
         } else if value.contains('h') {
             ttype = "h".to_owned();
-            tnum.retain(|c| c != 'h');
+            value.retain(|c| c != 'h');
         } else if value.contains('d') {
             ttype = "d".to_owned();
-            tnum.retain(|c| c != 'd');
+            value.retain(|c| c != 'd');
         } else {
             let errmsg = format!("Timeframe is invalid. Input value:{}", value);
             if configs::CONFIG.read().unwrap().args.verbose {
@@ -200,7 +199,7 @@ impl TimeFrameInfo {
         }
         TimeFrameInfo {
             timetype: ttype,
-            timenum: tnum.parse::<i64>(),
+            timenum: value.parse::<i64>(),
         }
     }
 }

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -1,3 +1,4 @@
+use nested::Nested;
 use regex::Regex;
 use std::{cmp::Ordering, collections::VecDeque};
 use yaml_rust::Yaml;
@@ -191,7 +192,7 @@ impl LeafMatcher for AllowlistFileMatcher {
 pub struct DefaultMatcher {
     re: Option<Regex>,
     pipes: Vec<PipeElement>,
-    key_list: Vec<String>,
+    key_list: Nested<String>,
     eqfield_key: Option<String>,
 }
 
@@ -200,7 +201,7 @@ impl DefaultMatcher {
         DefaultMatcher {
             re: Option::None,
             pipes: Vec::new(),
-            key_list: Vec::new(),
+            key_list: Nested::<String>::new(),
             eqfield_key: Option::None,
         }
     }
@@ -238,7 +239,9 @@ impl LeafMatcher for DefaultMatcher {
     }
 
     fn init(&mut self, key_list: &[String], select_value: &Yaml) -> Result<(), Vec<String>> {
-        self.key_list = key_list.to_vec();
+        let mut tmp_key_list = Nested::<String>::new();
+        tmp_key_list.extend(key_list.to_vec());
+        self.key_list = tmp_key_list;
         if select_value.is_null() {
             return Result::Ok(());
         }

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -159,7 +159,7 @@ impl DetectionNode {
             cond_str.to_string()
         } else {
             // conditionが指定されていない場合、selectionが一つだけならそのselectionを採用することにする。
-            let mut keys = self.name_to_selection.keys().clone();
+            let mut keys = self.name_to_selection.keys();
             if keys.len() >= 2 {
                 return Result::Err(vec![
                     "There is no condition node under detection.".to_string()
@@ -291,7 +291,7 @@ impl DetectionNode {
             // 連想配列と配列以外は末端ノード
             Box::new(selectionnodes::LeafSelectionNode::new(
                 key_list,
-                yaml.clone(),
+                yaml.to_owned(),
             ))
         }
     }

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -3,6 +3,7 @@ extern crate regex;
 use chrono::{DateTime, Utc};
 
 use hashbrown::HashMap;
+use nested::Nested;
 use std::{fmt::Debug, sync::Arc, vec};
 
 use yaml_rust::Yaml;
@@ -99,8 +100,8 @@ impl RuleNode {
 }
 
 // RuleNodeのdetectionに定義されているキーの一覧を取得する。
-pub fn get_detection_keys(node: &RuleNode) -> Vec<String> {
-    let mut ret = vec![];
+pub fn get_detection_keys(node: &RuleNode) -> Nested<String> {
+    let mut ret = Nested::<String>::new();
     let detection = &node.detection;
     for key in detection.name_to_selection.keys() {
         let selection = &detection.name_to_selection[key];

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -5,6 +5,7 @@ extern crate regex;
 use crate::detections::configs::{self, CURRENT_EXE_PATH};
 
 use hashbrown::HashMap;
+use nested::Nested;
 use std::path::{Path, PathBuf};
 
 use chrono::Local;
@@ -213,7 +214,7 @@ pub fn create_tokio_runtime() -> Runtime {
 }
 
 // EvtxRecordInfoを作成します。
-pub fn create_rec_info(data: Value, path: String, keys: &[String]) -> EvtxRecordInfo {
+pub fn create_rec_info(data: Value, path: String, keys: &Nested<String>) -> EvtxRecordInfo {
     // 高速化のための処理
 
     // 例えば、Value型から"Event.System.EventID"の値を取得しようとすると、value["Event"]["System"]["EventID"]のように3回アクセスする必要がある。
@@ -222,7 +223,7 @@ pub fn create_rec_info(data: Value, path: String, keys: &[String]) -> EvtxRecord
     // あと、serde_jsonのValueからvalue["Event"]みたいな感じで値を取得する処理がなんか遅いので、そういう意味でも早くなるかも
     // それと、serde_jsonでは内部的に標準ライブラリのhashmapを使用しているが、hashbrownを使った方が早くなるらしい。標準ライブラリがhashbrownを採用したためserde_jsonについても高速化した。
     let mut key_2_values = HashMap::new();
-    for key in keys {
+    for key in keys.iter() {
         let val = get_event_value(key, &data);
         if val.is_none() {
             continue;

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -360,7 +360,7 @@ fn _collect_recordinfo<'a>(
 /**
  * 最初の文字を大文字にする関数
  */
-pub fn make_ascii_titlecase(s: &mut str) -> String {
+pub fn make_ascii_titlecase(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
         None => String::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -888,7 +888,7 @@ impl App {
         let mut key_set = HashSet::new();
         for rule in rules {
             let keys = get_detection_keys(rule);
-            key_set.extend(keys.iter().map(|x|x.to_string()).collect::<Vec<String>>());
+            key_set.extend(keys.iter().map(|x| x.to_string()).collect::<Vec<String>>());
         }
 
         key_set.into_iter().collect::<Nested<String>>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -760,9 +760,7 @@ impl App {
         println!();
         detection.add_aggcondition_msges(&self.rt);
         if !(*METRICS_FLAG || *LOGONSUMMARY_FLAG || *PIVOT_KEYWORD_LIST_FLAG) {
-            println!("dbg after fact start");
             after_fact(total_records);
-            println!("dbg after fact end");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use hayabusa::{detections::configs, timeline::timelines::Timeline};
 use hayabusa::{detections::utils::write_color_buffer, filter};
 use hhmmss::Hhmmss;
 use mimalloc::MiMalloc;
+use nested::Nested;
 use pbr::ProgressBar;
 use serde_json::Value;
 use std::borrow::Borrow;
@@ -65,7 +66,7 @@ fn main() {
 
 pub struct App {
     rt: Runtime,
-    rule_keys: Vec<String>,
+    rule_keys: Nested<String>,
 }
 
 impl Default for App {
@@ -78,7 +79,7 @@ impl App {
     pub fn new() -> App {
         App {
             rt: utils::create_tokio_runtime(),
-            rule_keys: Vec::new(),
+            rule_keys: Nested::<String>::new(),
         }
     }
 
@@ -100,10 +101,11 @@ impl App {
         }
         let analysis_start_time: DateTime<Local> = Local::now();
         if *HTML_REPORT_FLAG {
-            let output_data = vec![format!(
+            let mut output_data = Nested::<String>::new();
+            output_data.extend(vec![format!(
                 "- Start time: {}",
                 analysis_start_time.format("%Y/%m/%d %H:%M")
-            )];
+            )]);
             htmlreport::add_md_data(
                 "General Overview {#general_overview}".to_string(),
                 output_data,
@@ -445,7 +447,8 @@ impl App {
         .ok();
 
         if *HTML_REPORT_FLAG {
-            let output_data = vec![format!("- {}", elapsed_output_str)];
+            let mut output_data = Nested::<String>::new();
+            output_data.extend(vec![format!("- {}", elapsed_output_str)]);
             htmlreport::add_md_data(
                 "General Overview {#general_overview}".to_string(),
                 output_data,
@@ -476,7 +479,8 @@ impl App {
                 .ok();
 
                 if *HTML_REPORT_FLAG {
-                    let output_data = vec![format!("- {}", output_saved_str)];
+                    let mut output_data = Nested::<String>::new();
+                    output_data.extend(vec![format!("- {}", output_saved_str)]);
                     htmlreport::add_md_data(
                         "General Overview {#general_overview}".to_string(),
                         output_data,
@@ -706,10 +710,11 @@ impl App {
         }
 
         if *HTML_REPORT_FLAG {
-            let output_data = vec![
+            let mut output_data = Nested::<String>::new();
+            output_data.extend(vec![
                 format!("- Analyzed event files: {}", evtx_files.len()),
                 format!("- {}", total_size_output),
-            ];
+            ]);
             htmlreport::add_md_data(
                 "General Overview #{general_overview}".to_string(),
                 output_data,
@@ -854,7 +859,7 @@ impl App {
     async fn create_rec_infos(
         records_per_detect: Vec<Value>,
         path: &dyn Display,
-        rule_keys: Vec<String>,
+        rule_keys: Nested<String>,
     ) -> Vec<EvtxRecordInfo> {
         let path = Arc::new(path.to_string());
         let rule_keys = Arc::new(rule_keys);
@@ -879,15 +884,14 @@ impl App {
         ret
     }
 
-    fn get_all_keys(&self, rules: &[RuleNode]) -> Vec<String> {
+    fn get_all_keys(&self, rules: &[RuleNode]) -> Nested<String> {
         let mut key_set = HashSet::new();
         for rule in rules {
             let keys = get_detection_keys(rule);
-            key_set.extend(keys);
+            key_set.extend(keys.iter().map(|x|x.to_string()).collect::<Vec<String>>());
         }
 
-        let ret: Vec<String> = key_set.into_iter().collect();
-        ret
+        key_set.into_iter().collect::<Nested<String>>()
     }
 
     /// target_eventids.txtの設定を元にフィルタする。 trueであれば検知確認対象のEventIDであることを意味する。

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -2,6 +2,7 @@ use hashbrown::HashMap;
 use horrorshow::helper::doctype;
 use horrorshow::prelude::*;
 use lazy_static::lazy_static;
+use nested::Nested;
 use pulldown_cmark::{html, Options, Parser};
 use std::fs::{create_dir, File};
 use std::io::{BufWriter, Write};
@@ -18,8 +19,8 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct HtmlReporter {
-    pub section_order: Vec<String>,
-    pub md_datas: HashMap<String, Vec<String>>,
+    pub section_order: Nested<String>,
+    pub md_datas: HashMap<String, Nested<String>>,
 }
 
 impl HtmlReporter {
@@ -38,18 +39,18 @@ impl HtmlReporter {
         options.insert(Options::ENABLE_HEADING_ATTRIBUTES);
         options.insert(Options::ENABLE_FOOTNOTES);
 
-        let mut md_data = vec![];
-        for section_name in self.section_order {
-            if let Some(v) = self.md_datas.get(&section_name) {
+        let mut md_data = Nested::<String>::new();
+        for section_name in self.section_order.iter() {
+            if let Some(v) = self.md_datas.get(section_name) {
                 md_data.push(format!("## {}\n", &section_name));
                 if v.is_empty() {
-                    md_data.push("not found data.\n".to_string());
+                    md_data.push("not found data.\n");
                 } else {
-                    md_data.push(v.join("\n"));
+                    md_data.push(v.iter().collect::<Vec<&str>>().join("\n"));
                 }
             }
         }
-        let md_str = md_data.join("\n");
+        let md_str = md_data.iter().collect::<Vec<&str>>().join("\n");
         let parser = Parser::new_ext(&md_str, options);
 
         let mut ret = String::new();
@@ -65,25 +66,26 @@ impl Default for HtmlReporter {
 }
 
 /// get html report section data in LinkedHashMap
-fn get_init_md_data_map() -> (Vec<String>, HashMap<String, Vec<String>>) {
+fn get_init_md_data_map() -> (Nested<String>, HashMap<String, Nested<String>>) {
     let mut ret = HashMap::new();
-    let section_order = vec![
+    let mut section_order = Nested::<String>::new();
+    section_order.extend(vec![
         "General Overview {#general_overview}".to_string(),
         "Results Summary {#results_summary}".to_string(),
-    ];
+    ]);
     for section in section_order.iter() {
-        ret.insert(section.to_owned(), vec![]);
+        ret.insert(section.to_owned(), Nested::<String>::new());
     }
 
     (section_order, ret)
 }
 
-pub fn add_md_data(section_name: String, data: Vec<String>) {
+pub fn add_md_data(section_name: String, data: Nested<String>) {
     let mut md_with_section_data = HTML_REPORTER.write().unwrap().md_datas.to_owned();
-    for c in data {
+    for c in data.iter() {
         let entry = md_with_section_data
             .entry(section_name.to_owned())
-            .or_insert(Vec::new());
+            .or_insert(Nested::<String>::new());
         entry.push(c);
     }
     HTML_REPORTER.write().unwrap().md_datas = md_with_section_data;
@@ -126,12 +128,15 @@ pub fn create_html_file(input_html: String, path_str: String) {
 #[cfg(test)]
 mod tests {
 
+    use nested::Nested;
+
     use crate::options::htmlreport::HtmlReporter;
 
     #[test]
     fn test_create_html() {
         let mut html_reporter = HtmlReporter::new();
-        let general_data = vec![
+        let mut general_data = Nested::<String>::new();
+        general_data.extend(vec![
             "- Analyzed event files: 581".to_string(),
             "- Total file size: 148.5 MB".to_string(),
             "- Excluded rules: 12".to_string(),
@@ -144,14 +149,15 @@ mod tests {
             "- Total enabled detection rules: 2933".to_string(),
             "- Elapsed time: 00:00:29.035".to_string(),
             "".to_string(),
-        ];
+        ]);
         html_reporter.md_datas.insert(
             "General Overview {#general_overview}".to_string(),
             general_data.to_owned(),
         );
+        let gen_data = general_data.iter().collect::<Vec<&str>>();
         let general_overview_str = format!(
             "<ul>\n<li>{}</li>\n</ul>",
-            general_data[..general_data.len() - 1]
+            gen_data[..general_data.len() - 1]
                 .join("</li>\n<li>")
                 .replace("- ", "")
         );

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -79,10 +79,10 @@ fn get_init_md_data_map() -> (Vec<String>, HashMap<String, Vec<String>>) {
 }
 
 pub fn add_md_data(section_name: String, data: Vec<String>) {
-    let mut md_with_section_data = HTML_REPORTER.write().unwrap().md_datas.clone();
+    let mut md_with_section_data = HTML_REPORTER.write().unwrap().md_datas.to_owned();
     for c in data {
         let entry = md_with_section_data
-            .entry(section_name.clone())
+            .entry(section_name.to_owned())
             .or_insert(Vec::new());
         entry.push(c);
     }
@@ -147,7 +147,7 @@ mod tests {
         ];
         html_reporter.md_datas.insert(
             "General Overview {#general_overview}".to_string(),
-            general_data.clone(),
+            general_data.to_owned(),
         );
         let general_overview_str = format!(
             "<ul>\n<li>{}</li>\n</ul>",


### PR DESCRIPTION
Closes #778 , Closes #780 

## What Changed

- Reduced used memory by using Nested crate
- Skipped rule author, detect counts aggregation when --no-summary option is used
- Replaced unnecessary clone process 

## Evidence

CPU: Ryzen 5700G
RAM: 16GB
OS: WIndows 11

- `hayabusa.exe -f <evtx-file> --set-default-profile standard -o output.csv` memory usage

|step| prev memory usage| memory usage(prev step diff percent)| improved|
|:---| :---| :---| :---|
| start process | 30% | 31%(-) | -|
| finished analyze | 94%(+64%) | 94%(+63%) | 0%|
| finished output | 97%(+3%) | 94%(0%) | 3%|

- `hayabusa.exe -d ../hayabusa-sample-evtx -o output.csv` result

> Elapsed time: 00:00:11.385
> Saved file: 778test.csv (16.3 MB)

- `hayabusa.exe -d ../hayabusa-sample-evtx  -o output.csv --no-summary` result

> Elapsed time: 00:00:09.237
> Saved file: 778test2.csv (16.3 MB)
