### PR TITLE
fix readme typo

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -60,6 +60,7 @@ Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)�
   - [macOSでのコンパイルの注意点](#macosでのコンパイルの注意点)
   - [Linuxでのコンパイルの注意点](#linuxでのコンパイルの注意点)
   - [LinuxのMUSLバイナリのクロスコンパイル](#linuxのmuslバイナリのクロスコンパイル)
+- [Hayabusaの実行](#hayabusaの実行)
   - [注意: アンチウィルス/EDRの誤検知と遅い初回実行](#注意-アンチウィルスedrの誤検知と遅い初回実行)
   - [Windows](#windows)
   - [Linux](#linux)
@@ -311,7 +312,7 @@ cargo build --release --target=x86_64-unknown-linux-musl
 MUSLバイナリは`./target/x86_64-unknown-linux-musl/release/`ディレクトリ配下に作成されます。
 MUSLバイナリはGNUバイナリより約15％遅いですが、より多くのLinuxバージョンとディストロで実行できます。
 
-****# Hayabusaの実行
+# Hayabusaの実行
 
 ## 注意: アンチウィルス/EDRの誤検知と遅い初回実行
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -60,8 +60,6 @@ Hayabusaは、日本の[Yamato Security](https://yamatosecurity.connpass.com/)�
   - [macOSでのコンパイルの注意点](#macosでのコンパイルの注意点)
   - [Linuxでのコンパイルの注意点](#linuxでのコンパイルの注意点)
   - [LinuxのMUSLバイナリのクロスコンパイル](#linuxのmuslバイナリのクロスコンパイル)
-  - [Linuxでのコンパイルの注意点](#linuxでのコンパイルの注意点-1)
-- [Hayabusaの実行](#hayabusaの実行)
   - [注意: アンチウィルス/EDRの誤検知と遅い初回実行](#注意-アンチウィルスedrの誤検知と遅い初回実行)
   - [Windows](#windows)
   - [Linux](#linux)
@@ -313,10 +311,7 @@ cargo build --release --target=x86_64-unknown-linux-musl
 MUSLバイナリは`./target/x86_64-unknown-linux-musl/release/`ディレクトリ配下に作成されます。
 MUSLバイナリはGNUバイナリより約15％遅いですが、より多くのLinuxバージョンとディストロで実行できます。
 
-## Linuxでのコンパイルの注意点
-
-
-# Hayabusaの実行
+****# Hayabusaの実行
 
 ## 注意: アンチウィルス/EDRの誤検知と遅い初回実行
 
@@ -709,7 +704,7 @@ Hayabusaの`config/profiles.yaml`設定ファイルでは、５つのプロフ�
 
 * `crit`: `critical`
 * `high`: `high`
-* `med `: `med`
+* `med `: `medium`
 * `low `: `low`
 * `info`: `informational`
 
@@ -974,7 +969,7 @@ Windows機での悪性な活動を検知する為には、デフォルトのロ�
 
 どのような形でも構いませんので、ご協力をお願いします。プルリクエスト、ルール作成、evtxログのサンプルなどがベストですが、機能リクエスト、バグの通知なども大歓迎です。
 
-少なくとも、私たちのツールを気に入っていただけたなら、Githubで星を付けて、あなたのサポートを表明してください。
+少なくとも、私たちのツールを気に入っていただけたなら、GitHubで星を付けて、あなたのサポートを表明してください。
 
 # バグの報告
 

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ In order to save space, we use the following abbrevations when displaying the al
 
 * `crit`: `critical`
 * `high`: `high`
-* `med `: `med`
+* `med `: `medium`
 * `low `: `low`
 * `info`: `informational`
 
@@ -967,7 +967,7 @@ To create the most forensic evidence and detect with the highest accuracy, you n
 
 We would love any form of contribution. Pull requests, rule creation and sample evtx logs are the best but feature requests, notifying us of bugs, etc... are also very welcome.
 
-At the least, if you like our tool then please give us a star on Github and show your support!
+At the least, if you like our tool then please give us a star on GitHub and show your support!
 
 # Bug Submission
 


### PR DESCRIPTION
## What Changed

- Fixed typo 
  -  `med` -> `medium`
  - remove unnecessary section
