### PR TITLE
Removed `HBFI-` prefix

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,7 @@
 - JSON出力のDetailsフィールドをオブジェクト形式で出力するように変更した。 (#773) (@hitenkoku)
 - `build.rs`を削除し、メモリアロケータをmimallocに変更した。Intel系OSでは20-30%の速度向上が見込める。 (#657) (@fukusuket)
 - プロファイルの`%RecordInformation%` エイリアスを `%AllFieldInfo%` に変更した。 AllFieldInfoフィールドをJSONオブジェクト形式で出力するように変更した。 (#750) (@hitenkoku)
+- AllFieldInfoフィールドのJSONオブジェクト内で利用していたHBFI-プレフィックスを廃止した。 (#791) (@hitenkoku)
 - `--no-summary`  オプションを使用したときに、表示しないルール作者および検知回数の集計を省略した。 (#780) (@hitenkoku)
 - メモリ使用量を少なくし、処理速度を改善した。 (#778) (@hitenkoku)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Changed Details field in JSON output to an object. (#773) (@hitenkoku)
 - Removed `build.rs` and changed the memory allocator to mimalloc for a speed increase of 20-30% on Intel-based OSes. (#657) (@fukusuket)
 - Replaced `%RecordInformation%` alias in output profiles to `%AllFieldInfo%`, and changed the `AllFieldInfo` field in JSON output to an object. (#750) (@hitenkoku)
+- Removed `HBFI-` prefix in `AllFieldInfo` field of json output. (#791) (@hitenkoku)
 - Don't display result summary, etc... when `--no-summary` option is used. (This is good to use when using as a Velociraptor agent, etc... It will usually be 10% faster.) (#780) (@hitenkoku)
 - Reduced memory usage and improved speed performance. (#778) (@hitenkoku)
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1264,8 +1264,7 @@ fn extract_author_name(yaml_path: &str) -> Nested<String> {
                     r.split('/')
                         .map(|p| {
                             p.to_string()
-                                .replace('"', "")
-                                .replace('\'', "")
+                                .replace(['"','\''], "")
                                 .trim()
                                 .to_string()
                         })

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1262,12 +1262,7 @@ fn extract_author_name(yaml_path: &str) -> Nested<String> {
                 .iter()
                 .map(|r| {
                     r.split('/')
-                        .map(|p| {
-                            p.to_string()
-                                .replace(['"','\''], "")
-                                .trim()
-                                .to_string()
-                        })
+                        .map(|p| p.to_string().replace(['"', '\''], "").trim().to_string())
                         .collect::<String>()
                 })
                 .collect();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1085,18 +1085,13 @@ fn output_json_str(
                 } else {
                     false
                 };
-                let prefix_flag = output_value_fmt.contains("%AllFieldInfo%");
                 if (value_idx < stocked_value.len() - 1 && stocked_value[value_idx + 1].is_empty())
                     || is_remain_split_stock
                 {
                     // 次の要素を確認して、存在しないもしくは、キーが入っているとなった場合現在ストックしている内容が出力していいことが確定するので出力処理を行う
                     let output_tmp = format!("{}: {}", tmp, output_value_stock);
                     let output: Vec<&str> = output_tmp.split(": ").collect();
-                    let key = if prefix_flag {
-                        format!("HBFI-{}", _convert_valid_json_str(&[output[0]], false))
-                    } else {
-                        _convert_valid_json_str(&[output[0]], false)
-                    };
+                    let key = _convert_valid_json_str(&[output[0]], false);
                     let fmted_val = _convert_valid_json_str(&output, false);
                     output_stock.push(format!(
                         "{},",
@@ -1115,11 +1110,7 @@ fn output_json_str(
                 if value_idx == stocked_value.len() - 1 {
                     let output_tmp = format!("{}: {}", tmp, output_value_stock);
                     let output: Vec<&str> = output_tmp.split(": ").collect();
-                    let key = if prefix_flag {
-                        format!("HBFI-{}", _convert_valid_json_str(&[output[0]], false))
-                    } else {
-                        _convert_valid_json_str(&[output[0]], false)
-                    };
+                    let key = _convert_valid_json_str(&[output[0]], false);
                     let fmted_val = _convert_valid_json_str(&output, false);
                     output_stock.push(_create_json_output_format(
                         &key,

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -337,9 +337,7 @@ impl ConditionCompiler {
     }
 
     /// OperandContainerの中身をパースする。現状はNotをパースするためだけに存在している。
-    fn parse_operand_container(
-        parent_token: ConditionToken,
-    ) -> Result<ConditionToken, String> {
+    fn parse_operand_container(parent_token: ConditionToken) -> Result<ConditionToken, String> {
         if let ConditionToken::OperandContainer(sub_tokens) = parent_token {
             // 現状ではNOTの場合は、「not」と「notで修飾されるselectionノードの名前」の2つ入っているはず
             // NOTが無い場合、「selectionノードの名前」の一つしか入っていないはず。

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -144,7 +144,7 @@ impl ConditionCompiler {
 
         let parsed = self.parse(tokens)?;
 
-        self.to_selectnode(parsed, name_2_node)
+        Self::to_selectnode(parsed, name_2_node)
     }
 
     /// 構文解析を実行する。
@@ -158,7 +158,7 @@ impl ConditionCompiler {
         let tokens = self.parse_and_or_operator(tokens)?;
 
         // OperandContainerトークンの中身をパースする。(現状、Notを解析するためだけにある。将来的に修飾するキーワードが増えたらここを変える。)
-        let token = self.parse_operand_container(tokens)?;
+        let token = Self::parse_operand_container(tokens)?;
 
         // 括弧で囲まれている部分を探して、もしあればその部分を再帰的に構文解析します。
         self.parse_rest_parenthesis(token)
@@ -338,7 +338,6 @@ impl ConditionCompiler {
 
     /// OperandContainerの中身をパースする。現状はNotをパースするためだけに存在している。
     fn parse_operand_container(
-        &self,
         parent_token: ConditionToken,
     ) -> Result<ConditionToken, String> {
         if let ConditionToken::OperandContainer(sub_tokens) = parent_token {
@@ -393,7 +392,7 @@ impl ConditionCompiler {
 
             let mut new_sub_tokens = vec![];
             for sub_token in sub_tokens {
-                let new_sub_token = self.parse_operand_container(sub_token)?;
+                let new_sub_token = Self::parse_operand_container(sub_token)?;
                 new_sub_tokens.push(new_sub_token);
             }
 
@@ -403,7 +402,6 @@ impl ConditionCompiler {
 
     /// ConditionTokenからSelectionNodeトレイトを実装した構造体に変換します。
     fn to_selectnode(
-        &self,
         token: ConditionToken,
         name_2_node: &HashMap<String, Arc<Box<dyn SelectionNode>>>,
     ) -> Result<Box<dyn SelectionNode>, String> {
@@ -425,7 +423,7 @@ impl ConditionCompiler {
         if let ConditionToken::AndContainer(sub_tokens) = token {
             let mut select_and_node = AndSelectionNode::new();
             for sub_token in sub_tokens.into_iter() {
-                let sub_node = self.to_selectnode(sub_token, name_2_node)?;
+                let sub_node = Self::to_selectnode(sub_token, name_2_node)?;
                 select_and_node.child_nodes.push(sub_node);
             }
             return Result::Ok(Box::new(select_and_node));
@@ -435,7 +433,7 @@ impl ConditionCompiler {
         if let ConditionToken::OrContainer(sub_tokens) = token {
             let mut select_or_node = OrSelectionNode::new();
             for sub_token in sub_tokens.into_iter() {
-                let sub_node = self.to_selectnode(sub_token, name_2_node)?;
+                let sub_node = Self::to_selectnode(sub_token, name_2_node)?;
                 select_or_node.child_nodes.push(sub_node);
             }
             return Result::Ok(Box::new(select_or_node));
@@ -448,7 +446,7 @@ impl ConditionCompiler {
             }
 
             let select_sub_node =
-                self.to_selectnode(sub_tokens.into_iter().next().unwrap(), name_2_node)?;
+                Self::to_selectnode(sub_tokens.into_iter().next().unwrap(), name_2_node)?;
             let select_not_node = NotSelectionNode::new(select_sub_node);
             return Result::Ok(Box::new(select_not_node));
         }

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -44,7 +44,7 @@ pub fn countup(
     field_value: String,
     record_time_value: DateTime<Utc>,
 ) {
-    let value_map = rule.countdata.entry(key).or_insert(Vec::new());
+    let value_map = rule.countdata.entry(key).or_default();
     value_map.push(AggRecordTimeInfo {
         field_record_value: field_value,
         record_time: record_time_value,

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -257,12 +257,11 @@ impl DetectionNode {
 
     /// selectionをパースします。
     fn parse_selection(&self, selection_yaml: &Yaml) -> Option<Box<dyn SelectionNode>> {
-        Option::Some(self.parse_selection_recursively(vec![], selection_yaml))
+        Option::Some(Self::parse_selection_recursively(vec![], selection_yaml))
     }
 
     /// selectionをパースします。
     fn parse_selection_recursively(
-        &self,
         key_list: Vec<String>,
         yaml: &Yaml,
     ) -> Box<dyn SelectionNode> {
@@ -275,7 +274,7 @@ impl DetectionNode {
                 let child_yaml = yaml_hash.get(hash_key).unwrap();
                 let mut child_key_list = key_list.clone();
                 child_key_list.push(hash_key.as_str().unwrap().to_string());
-                let child_node = self.parse_selection_recursively(child_key_list, child_yaml);
+                let child_node = Self::parse_selection_recursively(child_key_list, child_yaml);
                 and_node.child_nodes.push(child_node);
             });
             Box::new(and_node)
@@ -283,7 +282,7 @@ impl DetectionNode {
             // 配列はOR条件と解釈する。
             let mut or_node = selectionnodes::OrSelectionNode::new();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
-                let child_node = self.parse_selection_recursively(key_list.clone(), child_yaml);
+                let child_node = Self::parse_selection_recursively(key_list.clone(), child_yaml);
                 or_node.child_nodes.push(child_node);
             });
 

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -261,10 +261,7 @@ impl DetectionNode {
     }
 
     /// selectionをパースします。
-    fn parse_selection_recursively(
-        key_list: Vec<String>,
-        yaml: &Yaml,
-    ) -> Box<dyn SelectionNode> {
+    fn parse_selection_recursively(key_list: Vec<String>, yaml: &Yaml) -> Box<dyn SelectionNode> {
         if yaml.as_hash().is_some() {
             // 連想配列はAND条件と解釈する
             let yaml_hash = yaml.as_hash().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,7 @@ impl App {
             }
             self.analysis_files(vec![PathBuf::from(filepath)], &time_filter);
         } else if let Some(directory) = &configs::CONFIG.read().unwrap().args.directory {
-            let evtx_files = self.collect_evtxfiles(directory.as_os_str().to_str().unwrap());
+            let evtx_files = Self::collect_evtxfiles(directory.as_os_str().to_str().unwrap());
             if evtx_files.is_empty() {
                 AlertMessage::alert("No .evtx files were found.").ok();
                 return;
@@ -598,7 +598,7 @@ impl App {
         if is_elevated() {
             let log_dir = env::var("windir").expect("windir is not found");
             let evtx_files =
-                self.collect_evtxfiles(&[log_dir, "System32\\winevt\\Logs".to_string()].join("/"));
+                Self::collect_evtxfiles(&[log_dir, "System32\\winevt\\Logs".to_string()].join("/"));
             if evtx_files.is_empty() {
                 AlertMessage::alert("No .evtx files were found.").ok();
                 return None;
@@ -612,7 +612,7 @@ impl App {
         }
     }
 
-    fn collect_evtxfiles(&self, dirpath: &str) -> Vec<PathBuf> {
+    fn collect_evtxfiles(dirpath: &str) -> Vec<PathBuf> {
         let entries = fs::read_dir(dirpath);
         if entries.is_err() {
             let errmsg = format!("{}", entries.unwrap_err());
@@ -637,7 +637,7 @@ impl App {
             let path = e.unwrap().path();
             if path.is_dir() {
                 path.to_str().map(|path_str| {
-                    let subdir_ret = self.collect_evtxfiles(path_str);
+                    let subdir_ret = Self::collect_evtxfiles(path_str);
                     ret.extend(subdir_ret);
                     Option::Some(())
                 });
@@ -1005,8 +1005,7 @@ mod tests {
 
     #[test]
     fn test_collect_evtxfiles() {
-        let app = App::new();
-        let files = app.collect_evtxfiles("test_files/evtx");
+        let files = App::collect_evtxfiles("test_files/evtx");
         assert_eq!(3, files.len());
 
         files.iter().for_each(|file| {

--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -223,7 +223,7 @@ impl Update {
         let mut latest_update_date = Local.timestamp(0, 0);
         for diff_key in diff {
             let tmp: Vec<&str> = diff_key.split('|').collect();
-            let file_modified_date = fs::metadata(&tmp[2]).unwrap().modified().unwrap();
+            let file_modified_date = fs::metadata(tmp[2]).unwrap().modified().unwrap();
 
             let dt_local: DateTime<Local> = file_modified_date.into();
 


### PR DESCRIPTION
## What Changed

- Removed `HBFI-` prefix in AllFieldInfo field in json/jsonl output.
- updated changelog
- updated rules

## Evidence

```
>./791.exe -f ..\hayabusa-sample-evtx\DeepBlueCLI\disablestop-eventlog.evtx --set-default-profile all-field-info -o 791.json -j
...
>cat 791.json
{
    "Timestamp": "2019-04-28 06:04:25.733 +09:00",
    "Computer": "DESKTOP-JR78RLP",
    "Channel": "Sys",
    "EventID": 104,
    "Level": "high",
    "RecordID": 9252,
    "RuleTitle": "Log File Cleared",
    "AllFieldInfo": {
        "BackupPath": "",
        "Channel": "System",
        "SubjectDomainName": "DESKTOP-JR78RLP",
        "SubjectUserName": "jwrig"
    },
    "RuleFile": "Sys_104_High_SysLogCleared.yml",
    "EvtxFile": "..\\hayabusa-sample-evtx\\DeepBlueCLI\\disablestop-eventlog.evtx"
}
{
    "Timestamp": "2019-04-28 06:04:32.373 +09:00",
    "Computer": "DESKTOP-JR78RLP",
    "Channel": "Sys",
    "EventID": 7040,
    "Level": "med",
    "RecordID": 9253,
    "RuleTitle": "Event Log Service Startup Type Changed To Disabled",
    "AllFieldInfo": {
        "param1": "Windows Event Log",
        "param2": "auto start",
        "param3": "disabled",
        "param4": "EventLog"
    },
    "RuleFile": "Sys_7040_Med_EventLogServiceStartupDisabled.yml",
    "EvtxFile": "..\\hayabusa-sample-evtx\\DeepBlueCLI\\disablestop-eventlog.evtx"
}
```
