### PR TITLE
fix: change TAGS_CONFIG.values iterator to vec

### DIFF
--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -260,7 +260,7 @@ impl Detection {
         let level = rule.yaml["level"].as_str().unwrap_or("-").to_string();
 
         let mut profile_converter: HashMap<String, Profile> = HashMap::new();
-        let mut tags_config_values = TAGS_CONFIG.values();
+        let tags_config_values: Vec<&String> = TAGS_CONFIG.values().collect();
         for (key, profile) in PROFILES.as_ref().unwrap().iter() {
             match profile {
                 Timestamp(_) => {
@@ -344,7 +344,7 @@ impl Detection {
                     let tactics = CompactString::from(
                         &tag_info
                             .iter()
-                            .filter(|x| tags_config_values.contains(&x.to_string()))
+                            .filter(|x| tags_config_values.contains(&&x.to_string()))
                             .join(" ¦ "),
                     );
 
@@ -355,7 +355,7 @@ impl Detection {
                         &tag_info
                             .iter()
                             .filter(|x| {
-                                !tags_config_values.contains(&x.to_string())
+                                !tags_config_values.contains(&&x.to_string())
                                     && (x.starts_with("attack.t")
                                         || x.starts_with("attack.g")
                                         || x.starts_with("attack.s"))
@@ -471,7 +471,7 @@ impl Detection {
 
         let mut profile_converter: HashMap<String, Profile> = HashMap::new();
         let level = rule.yaml["level"].as_str().unwrap_or("-").to_string();
-        let mut tags_config_values = TAGS_CONFIG.values();
+        let tags_config_values: Vec<&String> = TAGS_CONFIG.values().collect();
 
         for (key, profile) in PROFILES.as_ref().unwrap().iter() {
             match profile {
@@ -538,7 +538,7 @@ impl Detection {
                     let tactics = CompactString::from(
                         &tag_info
                             .iter()
-                            .filter(|x| tags_config_values.contains(&x.to_string()))
+                            .filter(|x| tags_config_values.contains(&&x.to_string()))
                             .join(" ¦ "),
                     );
                     profile_converter.insert(key.to_string(), MitreTactics(tactics));
@@ -548,7 +548,7 @@ impl Detection {
                         &tag_info
                             .iter()
                             .filter(|x| {
-                                !tags_config_values.contains(&x.to_string())
+                                !tags_config_values.contains(&&x.to_string())
                                     && (x.starts_with("attack.t")
                                         || x.starts_with("attack.g")
                                         || x.starts_with("attack.s"))
@@ -566,7 +566,7 @@ impl Detection {
                         &tag_info
                             .iter()
                             .filter(|x| {
-                                !(tags_config_values.contains(&x.to_string())
+                                !(tags_config_values.contains(&&x.to_string())
                                     || x.starts_with("attack.t")
                                     || x.starts_with("attack.g")
                                     || x.starts_with("attack.s"))


### PR DESCRIPTION
## What Changed

- Fix #807
- Changed `TAGS_CONFIG.values()`(iterator) to `TAGS_CONFIG.values().collect()`(vector)
  - because the iterator is exhausted when [Itertools::contains()](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.contains) is executed.
    - then returns false on the second  [Itertools::contains()](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.contains) execution, even if there is a value.

## Evidence
### Test1
The number of detections before and after  is the same as shown below.

before fix 
```
Results Summary:

Events with hits / Total events: 19,566 / 47,458 (Data reduction: 27,892 events (58.77%))

Total | Unique detections: 32,743 | 588
Total | Unique critical detections: 47 (0.14%) | 19 (3.23%)
Total | Unique high detections: 6,237 (19.05%) | 265 (45.07%)
Total | Unique medium detections: 1,585 (4.84%) | 176 (29.93%)
Total | Unique low detections: 6,626 (20.24%) | 75 (12.76%)
Total | Unique informational detections: 18,248 (55.73%) | 53 (9.01%)
```

after fix.
```
Results Summary:

Events with hits / Total events: 19,566 / 47,458 (Data reduction: 27,892 events (58.77%))

Total | Unique detections: 32,743 | 588
Total | Unique critical detections: 47 (0.14%) | 19 (3.23%)
Total | Unique high detections: 6,237 (19.05%) | 265 (45.07%)
Total | Unique medium detections: 1,585 (4.84%) | 176 (29.93%)
Total | Unique low detections: 6,626 (20.24%) | 75 (12.76%)
Total | Unique informational detections: 18,248 (55.73%) | 53 (9.01%)

```

### Test2
Execute the following command and the file size does not change 5 times.
1. `.\hayabusa.exe -d C:\tmp\hayabusa-sample-evtx\ -o 1.csv -P super-verbose`
2. ↑repeat 5 times.(change only file name)
3. compare output file size.

then output  is as follows
![test](https://user-images.githubusercontent.com/41001169/202721614-8b559bbf-c178-4e5c-adb4-e042d268b888.png)


### Test3
Execute with rule which has `%MitreTags%`・`%MitreTactics%`・`%OtherTag%` data.
- ` .\hayabusa -d C:\tmp\hayabusa-sample-evtx\ -o output.csv -P super-verbose -r .\rules\sigma\sysmon\process_creation\proc_creation_win_cmstp_com_object_access.yml`


```
〇proc_creation_win_cmstp_com_object_access.yml
title: CMSTP UAC Bypass via COM Object Access
ruletype: Sigma
...
tags:
- attack.execution
- attack.defense_evasion
- attack.privilege_escalation
- attack.t1548.002
- attack.t1218.003
- attack.g0069
- car.2019-04-001
```
then `%MitreTags%`・`%MitreTactics%`・`%OtherTag%` fields converted correctly.
![output](https://user-images.githubusercontent.com/41001169/202722732-7edc50be-75e6-4365-a5dc-2e0c800e05b6.png)
