### PR TITLE
fixed test data to execute coverage tool(llvm-cov)

### DIFF
--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -537,8 +537,8 @@ mod tests {
                     - ホスト アプリケーション
                 ImagePath:
                     min_length: 1234321
-                    regexes: ./../../../rules/config/regex/detectlist_suspicous_services.txt
-                    allowlist: ./../../../rules/config/regex/allowlist_legitimate_services.txt
+                    regexes: rules/config/regex/detectlist_suspicous_services.txt
+                    allowlist: rules/config/regex/allowlist_legitimate_services.txt
         falsepositives:
             - unknown
         level: medium
@@ -1125,7 +1125,7 @@ mod tests {
             selection:
                 EventID: 4103
                 Channel:
-                    - allowlist: ./../../../rules/config/regex/allowlist_legitimate_services.txt
+                    - allowlist: rules/config/regex/allowlist_legitimate_services.txt
         details: 'command=%CommandLine%'
         "#;
 
@@ -1159,7 +1159,7 @@ mod tests {
             selection:
                 EventID: 4103
                 Channel:
-                    - allowlist: ./../../../rules/config/regex/allowlist_legitimate_services.txt
+                    - allowlist: rules/config/regex/allowlist_legitimate_services.txt
         details: 'command=%CommandLine%'
         "#;
 
@@ -1193,7 +1193,7 @@ mod tests {
             selection:
                 EventID: 4103
                 Channel:
-                    - allowlist: ./../../../rules/config/regex/allowlist_legitimate_services.txt
+                    - allowlist: rules/config/regex/allowlist_legitimate_services.txt
         details: 'command=%CommandLine%'
         "#;
 

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn test_check_regex() {
         let regexes: Vec<Regex> =
-            utils::read_txt("./../../../rules/config/regex/detectlist_suspicous_services.txt")
+            utils::read_txt("rules/config/regex/detectlist_suspicous_services.txt")
                 .unwrap()
                 .iter()
                 .map(|regex_str| Regex::new(regex_str).unwrap())
@@ -581,7 +581,7 @@ mod tests {
     fn test_check_allowlist() {
         let commandline = "\"C:\\Program Files\\Google\\Update\\GoogleUpdate.exe\"";
         let allowlist: Vec<Regex> =
-            utils::read_txt("./../../../rules/config/regex/allowlist_legitimate_services.txt")
+            utils::read_txt("rules/config/regex/allowlist_legitimate_services.txt")
                 .unwrap()
                 .iter()
                 .map(|allow_str| Regex::new(allow_str).unwrap())


### PR DESCRIPTION
## What Changed

-fixed test data to execute coverage tool(llvm-cov)

## Evidence

got following llvm-cov coverate result

```bash
> cargo install cargo-llvm-cov
> rustup component add llvm-tools-preview
> cargo llvm-cov
```

![image](https://user-images.githubusercontent.com/2350416/202888672-711765c3-f2bb-47d4-b7c3-926332c3c7b3.png)

