### PR TITLE
fix update rules spacing

### DIFF
--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -245,8 +245,8 @@ impl Update {
                 true,
             )
             .ok();
-            println!();
         }
+        println!();
         for (key, value) in &update_count_by_rule_type {
             println!("Updated {} rules: {}", key, value);
         }


### PR DESCRIPTION
ルールの間に改行を入れるとルール一覧が長くなるので、戻しました。
これで問題ないと思います。