### PR TITLE
fixed pivot-keywords-list short option

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -386,7 +386,7 @@ macOSの環境設定から「セキュリティとプライバシー」を開き
 * デフォルト: ファストフォレンジックタイムラインの作成。
 * `--level-tuning`: アラート`level`のカスタムチューニング
 * `-L, --logon-summary`: ログオンイベントのサマリを出力する。
-* `-P, --pivot-keywords-list`: ピボットする不審なキーワードのリスト作成。 
+* `-p, --pivot-keywords-list`: ピボットする不審なキーワードのリスト作成。
 * `-M, --metrics`: イベントIDに基づくイベントの合計と割合の集計を出力する。
 * `--set-default-profile`: デフォルトプロファイルを変更する。
 * `-u, --update`: GitHubの[hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules)リポジトリにある最新のルールに同期させる。

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ You should now be able to run hayabusa.
 * default: Create a fast forensics timeline.
 * `--level-tuning`: Custom tune the alerts' `level`.
 * `-L, --logon-summary`: Print a summary of logon events.
-* `-P, --pivot-keywords-list`: Print a list of suspicious keywords to pivot on.
+* `-p, --pivot-keywords-list`: Print a list of suspicious keywords to pivot on.
 * `-M, --metrics`: Print metrics of the number and percentage of events based on Event ID.
 * `--set-default-profile`: Change the default profile.
 * `-u, --update`: Sync the rules to the latest rules in the [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) GitHub repository.


### PR DESCRIPTION
## What Changed

- fixed pivot-keywords-list short option (wrong: `-P` -> correct: `-p`) in readme.
