### PR TITLE
remove codegen-units 1

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,7 +10,6 @@
 
 - 実行時のメモリ利用率を表示する機能を追加した。`--debug`オプションで利用可能。 (#788) (@fukusuket)
 - Clap Crateパッケージの更新。更新の関係で`--visualize-timeline` のショートオプションの`-V`を`-T`に変更した。 (#725) (@YamatoSecurity)
-- バイナリの最適化を行うことで、バイナリサイズを圧縮し、処理時間もわずかに向上した。 (#824) (@YamatoSecurity)
 - 速度とメモリ使用の最適化。 (#787) (@fukusuket)
 - 新たなパイプキーワード(`|endswithfield`)に対応した。 (#740) (@hach1yon)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - Added `--debug` option to display memory utilization at runtime. (#788) (@fukusuket)
 - Updated clap crate package to version 4 and changed the `--visualize-timeline` short option `-V` to `-T`. (#725) (@YamatoSecurity)
-- By optimizating binary, binary size is compressed and processing time is slightly improved. (#824) (@YamatoSecurity)
 - Optimized speed and memory usage. (#787) (@fukusuket)
 - Added a new pipe keyword. (`|endswithfield`) (#740) (@hach1yon)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,3 @@ openssl = { version = "*", features = ["vendored"] }  #vendored is needed to com
 [profile.release]
 lto = true
 strip = "symbols"
-codegen-units = 1


### PR DESCRIPTION
codegen-units=1を追加すると、コンパイルの並行処理が無くなるので、コンパイルがより最適化されるはずですが、-100kbのファイルサイズ以外はあまり変わらなくて、コンパイル時間が長くなっているので、CI/CDテスト等が遅くならないようにデフォルトの設定に戻したいです。リリース時だけローカル環境でcodegen-units=1の設定してバイナリをコンパイルします。