### PR TITLE
fix: downgrade `mimalloc_rust` version because of performance issue.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "04d1c67deb83e6b75fa4fe3309e09cfeade12e7721d95322af500d3814ea60c9"
 dependencies = [
  "cc",
  "cty",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "9b2374e2999959a7b583e1811a1ddbf1d3a4b9496eceb9746f1192a59d871eca"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ num-format = "*"
 comfy-table = "6.*"
 pulldown-cmark = { version = "0.9.*", default-features = false, features = ["simd"] }
 horrorshow = "0.8.*"
-mimalloc = { version = "*", default-features = false }
-libmimalloc-sys = { version = "*",  features = ["extended"] }
+mimalloc = { version = "=0.1.32", default-features = false }
+libmimalloc-sys = { version = "=0.1.28",  features = ["extended"] }
 nested="*"
 compact_str = "0.6.*"
 ureq = "*"


### PR DESCRIPTION
I don't know if it's a `mimalloc_rust` problem or a `mimalloc` problem, the speed is degraded as shown in the benchmark results below.(On the other hand, memory usage seems to have improved a little? ... 🤔)

## What Changed
- Downgrade `mimalloc_rust`/`libmimalloc-sys` versions. 
  - because latest `mimallc_rust(v0.1.34)` seems to have some performance issue.

## Evidence
### Environment
- OS: Windows 10 Home edition
- Hard: Memory 16GB , Core 8, SSD, laptop

### Benchmark
I ran a benchmark using [this procedure(6.1GB evtx)](https://github.com/Yamato-Security/hayabusa/issues/778#issuecomment-1296504766) and the results were as follows.

|Version| Elapsed time | Memory(peak) | Events with hits / Total events | Output file size(bytes)|
|-------| ------------ | --------|--------|--------|
| 2.1.0 | 00:13:51.232 | 5.0 GiB | 1,593,660 / 4,817,181 | 575217451| 
| [This PR](https://github.com/Yamato-Security/hayabusa/commit/9adb3436fb052e5e5c4df5fdcebdc8521ed0ea15) | 00:13:33.355 | 5.4 GiB | 1,593,660 / 4,817,181 | 575217451| 

#### Console output

2.1.0
```
Results Summary:

Events with hits / Total events: 1,593,660 / 4,817,181 (Data reduction: 3,223,521 events (66.92%))

Total | Unique detections: 1,627,378 | 148
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 12,044 (0.74%) | 20 (13.51%)
Total | Unique medium detections: 11,267 (0.69%) | 38 (25.68%)
Total | Unique low detections: 1,053,568 (64.74%) | 40 (27.03%)
Total | Unique informational detections: 550,499 (33.83%) | 50 (33.78%)
...
Saved file: 2.csv (575.2 MB)
Elapsed time: 00:13:51.232
Rule Parse Processing Time: 00:00:20.664
Analysis Processing Time: 00:13:09.427
Output Processing Time: 00:00:21.139

Memory usage stats:
heap stats:    peak      total      freed    current       unit      count
  reserved:    5.0 GiB    5.0 GiB   83.0 MiB    4.9 GiB
 committed:    4.6 GiB   67.4 GiB   63.0 GiB    4.4 GiB
```

[This PR](https://github.com/Yamato-Security/hayabusa/commit/9adb3436fb052e5e5c4df5fdcebdc8521ed0ea15)
```
Results Summary:

Events with hits / Total events: 1,593,660 / 4,817,181 (Data reduction: 3,223,521 events (66.92%))

Total | Unique detections: 1,627,378 | 148
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 12,044 (0.74%) | 20 (13.51%)
Total | Unique medium detections: 11,267 (0.69%) | 38 (25.68%)
Total | Unique low detections: 1,053,568 (64.74%) | 40 (27.03%)
Total | Unique informational detections: 550,499 (33.83%) | 50 (33.78%)
...
Saved file: 1.csv (575.2 MB)
Elapsed time: 00:13:33.355
Rule Parse Processing Time: 00:00:19.576
Analysis Processing Time: 00:12:52.228
Output Processing Time: 00:00:21.548

Memory usage stats:
heap stats:    peak      total      freed    current       unit      count
  reserved:    5.4 GiB    5.4 GiB   56.0 MiB    5.3 GiB                        not all freed!
 committed:    4.7 GiB    6.2 GiB    1.5 GiB    4.6 GiB                        not all freed!

```