### PR TITLE
Fixed unwrap error when geoip field was not found in ext_field

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1144,11 +1144,8 @@ fn output_json_str(
     let valid_key_add_to_details: Vec<&str> = key_add_to_details
         .iter()
         .filter(|target_key| {
-            ext_field_map
-                .get(&CompactString::from(**target_key))
-                .unwrap()
-                .to_value()
-                != "-"
+            let target = ext_field_map.get(&CompactString::from(**target_key));
+            target.is_some() && target.unwrap().to_value() != "-"
         })
         .copied()
         .collect();


### PR DESCRIPTION

## What Changed

- Fixed unwrap error when geoip field was not found in ext_field

## Evidence

- main branch -> ref: https://github.com/Yamato-Security/hayabusa/issues/905#issue-1570931245

- this pull request
```
> ./test.exe json-timeline -d ../hayabusa-sample-evtx -o test.json

...
Analyzing event files: 582
Total file size: 148.5 MB

Loading detections rules. Please wait.

Excluded rules: 15
Noisy rules: 7 (Disabled)

Experimental rules: 1690 (49.69%)
Stable rules: 220 (6.47%)
Test rules: 1491 (43.84%)

Hayabusa rules: 148
Sigma rules: 3253
Total enabled detection rules: 3401

Scanning in progress. Please wait.

582 / 582 [=====================================================================================================================================================================================================================] 100.00 %

Analysis finished. Please wait while the results are being saved.

Rule Authors:

...
Results Summary:

Events with hits / Total events: 19,601 / 76,974 (Data reduction: 57,373 events (74.54%))

Total | Unique detections: 32,452 | 606
Total | Unique critical detections: 46 (0.14%) | 18 (2.97%)
Total | Unique high detections: 6,268 (19.31%) | 275 (45.38%)
Total | Unique medium detections: 1,635 (5.04%) | 187 (30.86%)
Total | Unique low detections: 6,372 (19.64%) | 73 (12.05%)
Total | Unique informational detections: 18,131 (55.87%) | 53 (8.75%)

Dates with most total detections:
critical: 2019-07-19 (15), high: 2016-09-20 (3,645), medium: 2021-04-22 (198), low: 2016-09-20 (3,724), informational: 2016-08-19 (2,105)

Top 5 computers with most unique detections:
critical: MSEDGEWIN10 (6), IEWIN7 (3), FS03.offsec.lan (2), rootdc1.offsec.lan (2), srvdefender01.offsec.lan (2)
high: MSEDGEWIN10 (122), IEWIN7 (73), fs03vuln.offsec.lan (31), FS03.offsec.lan (30), IE10Win7 (23)
medium: MSEDGEWIN10 (68), IEWIN7 (43), FS03.offsec.lan (17), fs03vuln.offsec.lan (16), srvdefender01.offsec.lan (16)
low: MSEDGEWIN10 (33), FS03.offsec.lan (16), IEWIN7 (15), fs03vuln.offsec.lan (14), fs01.offsec.lan (10)
informational: IEWIN7 (18), MSEDGEWIN10 (18), fs01.offsec.lan (15), PC01.example.corp (14), FS03.offsec.lan (13)

...
Saved file: test.json (23.2 MB)
Elapsed time: 00:00:06.551

```
