### PR TITLE
Fixed misaligned fields in json output

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -21,11 +21,11 @@
 - JSON/L形式のログを読み込む際のメモリ使用量を約50%削減した。 (#906) (@fukusuket)
 - Longオプションを基にしたオプションの並べ替えを行った。 (#904) (@hitenkoku)
 - `-J, --JSON-input`オプションを`logon-summary`, `metrics`, `pivot-keywords-list`コマンドに対応させた。 (#908) (@hitenkoku)
-- JSON出力内のCmdLineとPayloadフィールドの出力が実際の情報と一致していない問題を修正した。 (#895) (@hitenkoku)
 
 **バグ修正:**
 
-- ルールの条件にバックスラッシュが4つある場合、ルールがマッチしない不具合を修正しました。 (#897) (@fukuseket)
+- ルールの条件にバックスラッシュが4つある場合、ルールがマッチしない不具合を修正した。 (#897) (@fukuseket)
+- JSON出力では、PowerShell EID 4103をパースする際に`Payload`フィールドが複数のフィールドに分離されるバグを修正した。(#895) (@hitenkoku)
 
 **脆弱性修正:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -21,6 +21,7 @@
 - JSON/L形式のログを読み込む際のメモリ使用量を約50%削減した。 (#906) (@fukusuket)
 - Longオプションを基にしたオプションの並べ替えを行った。 (#904) (@hitenkoku)
 - `-J, --JSON-input`オプションを`logon-summary`, `metrics`, `pivot-keywords-list`コマンドに対応させた。 (#908) (@hitenkoku)
+- JSON出力内のCmdLineとPayloadフィールドの出力が実際の情報と一致していない問題を修正した。 (#895) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Reduced memory usage by approximately 50% when reading JSON/L formatted logs. (#906) (@fukusuket)
 - Alphabetically sorted options based on their long names. (#904) (@hitenkoku)
 - Added JSON input support (`-J, --JSON-input` option) for `logon-summary`, `metrics` and `pivot-keywords-list` commands. (#908) (@hitenkoku)
+- Fixed misalignment of CmdLine and Payload fields in json output. (#895) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@
 - Reduced memory usage by approximately 50% when reading JSON/L formatted logs. (#906) (@fukusuket)
 - Alphabetically sorted options based on their long names. (#904) (@hitenkoku)
 - Added JSON input support (`-J, --JSON-input` option) for `logon-summary`, `metrics` and `pivot-keywords-list` commands. (#908) (@hitenkoku)
-- Fixed misalignment of CmdLine and Payload fields in json output. (#895) (@hitenkoku)
 
 **Bug Fixes:**
 
 - Fixed a bug when rules with 4 consecutive backslashes in their conditions would not be detected. (#897) (@fukusuket)
+- When parsing PowerShell EID 4103, the `Payload` field would be separated into multiple fields when outputting to JSON. (#895) (@hitenkoku)
 
 **Vulnerability Fixes:**
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1198,7 +1198,17 @@ fn output_json_str(
                                 tmp_stock.push(sp.to_owned());
                             }
                         }
-                        stocked_value.push(tmp_stock);
+                        if !tmp_stock.is_empty() {
+                            stocked_value.push(tmp_stock);
+                        }
+                    }
+                    if stocked_value.iter().counts_by(|x| x.len()).get(&0).unwrap_or(&0) != &key_index_stock.len() {
+                        if let Some((target_idx, _)) = key_index_stock.iter().enumerate().rfind(|(_, y)| "CmdLine" == *y) {
+                            let cmd_line_vec_idx_len = stocked_value[2*(target_idx+1) -1].len();
+                            stocked_value[2*(target_idx+1)-1][cmd_line_vec_idx_len -1].push_str(&format!(" {}:", key_index_stock[target_idx + 1]));
+                            key_index_stock.remove(target_idx + 1);
+                        }
+
                     }
                     let mut key_idx = 0;
                     let mut output_value_stock = String::default();

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1213,9 +1213,10 @@ fn output_json_str(
                     let mut key_idx = 0;
                     let mut output_value_stock = String::default();
                     for (value_idx, value) in stocked_value.iter().enumerate() {
-                        let mut tmp = if key_idx >= key_index_stock.len() {
-                            ""
-                        } else if value_idx == 0 && !value.is_empty() {
+                        if key_idx >= key_index_stock.len() {
+                            break;
+                        }
+                        let mut tmp = if value_idx == 0 && !value.is_empty() {
                             key.as_str()
                         } else {
                             key_index_stock[key_idx].as_str()
@@ -1225,21 +1226,12 @@ fn output_json_str(
                         }
                         output_value_stock.push_str(&value.join(" "));
                         //``1つまえのキーの段階で以降にvalueの配列で区切りとなる空の配列が存在しているかを確認する
-                        let is_remain_split_stock = if key_idx == key_index_stock.len() - 2
+                        let is_remain_split_stock = key_idx == key_index_stock.len() - 2
                             && value_idx < stocked_value.len() - 1
                             && !output_value_stock.is_empty()
-                        {
-                            let mut ret = true;
-                            for remain_value in stocked_value[value_idx + 1..].iter() {
-                                if remain_value.is_empty() {
-                                    ret = false;
-                                    break;
-                                }
-                            }
-                            ret
-                        } else {
-                            false
-                        };
+                            && !stocked_value[value_idx + 1..]
+                                .iter()
+                                .any(|remain_value| remain_value.is_empty());
                         if (value_idx < stocked_value.len() - 1
                             && stocked_value[value_idx + 1].is_empty())
                             || is_remain_split_stock
@@ -1263,7 +1255,9 @@ fn output_json_str(
                             tmp = "";
                             key_idx += 1;
                         }
-                        if value_idx == stocked_value.len() - 1 {
+                        if value_idx == stocked_value.len() - 1
+                            && !(tmp.is_empty() && stocked_value.is_empty())
+                        {
                             let output_tmp = format!("{tmp}: {output_value_stock}");
                             let output: Vec<&str> = output_tmp.split(": ").collect();
                             let key = _convert_valid_json_str(&[output[0]], false);

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1175,16 +1175,25 @@ fn output_json_str(
                 Profile::AllFieldInfo(_) | Profile::Details(_) => {
                     let mut output_stock: Vec<String> = vec![];
                     output_stock.push(format!("    \"{key}\": {{"));
-                    let mut stocked_value = vec![];
+                    let mut stocked_value:Vec<Vec<String>> = vec![];
                     let mut key_index_stock = vec![];
                     for detail_contents in vec_data.iter() {
                         // 分解してキーとなりえる箇所を抽出する
                         let mut tmp_stock = vec![];
-                        for sp in detail_contents.split(' ') {
+                        let mut space_split_contents = detail_contents.split(' ');
+                        while let Some(sp) = space_split_contents.next() {
                             if sp.ends_with(':') && sp.len() > 2 {
-                                stocked_value.push(tmp_stock);
-                                tmp_stock = vec![];
                                 key_index_stock.push(sp.replace(':', ""));
+                                if sp == "Payload:" {
+                                    stocked_value.push(vec![]);
+                                    stocked_value.push(
+                                        space_split_contents.map(|s| s.to_string()).collect(),
+                                    );
+                                    break;
+                                } else {
+                                    stocked_value.push(tmp_stock);
+                                    tmp_stock = vec![];
+                                }
                             } else {
                                 tmp_stock.push(sp.to_owned());
                             }

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1175,7 +1175,7 @@ fn output_json_str(
                 Profile::AllFieldInfo(_) | Profile::Details(_) => {
                     let mut output_stock: Vec<String> = vec![];
                     output_stock.push(format!("    \"{key}\": {{"));
-                    let mut stocked_value:Vec<Vec<String>> = vec![];
+                    let mut stocked_value: Vec<Vec<String>> = vec![];
                     let mut key_index_stock = vec![];
                     for detail_contents in vec_data.iter() {
                         // 分解してキーとなりえる箇所を抽出する
@@ -1202,13 +1202,24 @@ fn output_json_str(
                             stocked_value.push(tmp_stock);
                         }
                     }
-                    if stocked_value.iter().counts_by(|x| x.len()).get(&0).unwrap_or(&0) != &key_index_stock.len() {
-                        if let Some((target_idx, _)) = key_index_stock.iter().enumerate().rfind(|(_, y)| "CmdLine" == *y) {
-                            let cmd_line_vec_idx_len = stocked_value[2*(target_idx+1) -1].len();
-                            stocked_value[2*(target_idx+1)-1][cmd_line_vec_idx_len -1].push_str(&format!(" {}:", key_index_stock[target_idx + 1]));
+                    if stocked_value
+                        .iter()
+                        .counts_by(|x| x.len())
+                        .get(&0)
+                        .unwrap_or(&0)
+                        != &key_index_stock.len()
+                    {
+                        if let Some((target_idx, _)) = key_index_stock
+                            .iter()
+                            .enumerate()
+                            .rfind(|(_, y)| "CmdLine" == *y)
+                        {
+                            let cmd_line_vec_idx_len =
+                                stocked_value[2 * (target_idx + 1) - 1].len();
+                            stocked_value[2 * (target_idx + 1) - 1][cmd_line_vec_idx_len - 1]
+                                .push_str(&format!(" {}:", key_index_stock[target_idx + 1]));
                             key_index_stock.remove(target_idx + 1);
                         }
-
                     }
                     let mut key_idx = 0;
                     let mut output_value_stock = String::default();


### PR DESCRIPTION
## What Changed

- Fixed misalignment of CmdLine and Payload fields in json output. 

## Evidence


### Environment
- OS: Windows 11
- Hard: Memory 16GB , Core 8, SSD

### Benchmark1

#### Executed Command

> ./hayabusa.exe json-timeline -t "../hayabusa-sample-evtx/EVTX-to-MITRE-Attack/TA0007-Discovery/T1087-Account discovery/ID4103-4104 - SPN discovery (moder nPowerShell).evtx" -o out.json

<details>
<summary>[before]((https://github.com/Yamato-Security/hayabusa/commit/6e2276ac1ddc91ce74ec7f607c6e0b62ee7ce10b) )</summary>

```
{
    "Timestamp": "2021-01-30 18:13:13.309 +09:00",
    "Computer": "fs02.offsec.lan",
    "Channel": "PwSh",
    "EventID": 4103,
    "Level": "info",
    "RecordID": 16015,
    "RuleTitle": "PwSh Pipeline Exec",
    "Details": {
        "Payload": "",
        "CommandInvocation(Out-Default)": "\"Out-Default\""
    }
}
...
```
</details>

<details>
<summary>[This PR](https://github.com/Yamato-Security/hayabusa/tree/895-bug-misaligned-fields-in-json-output) </summary>

```
{
    "Timestamp": "2021-01-30 18:13:13.309 +09:00",
    "Computer": "fs02.offsec.lan",
    "Channel": "PwSh",
    "EventID": 4103,
    "Level": "info",
    "RecordID": 16015,
    "RuleTitle": "PwSh Pipeline Exec",
    "Details": {
        "Payload": "CommandInvocation(Out-Default): \"Out-Default\""
    }
}
...
```
</details>

### Benchmark2

#### Executed Command

> ./hayabusa.exe json-timeline -f ..\\hayabusa-sample-evtx\\DeepBlueCLI\\many-events-security.evtx -o out.json -r .\rules\hayabusa\builtin\Security\DetailedTracking\ProcessCreation\Sec_4688_Info_ProcExec.yml

<details>
<summary>[before]((https://github.com/Yamato-Security/hayabusa/commit/6e2276ac1ddc91ce74ec7f607c6e0b62ee7ce10b) )</summary>

```
...
{
    "Timestamp": "2016-08-19 02:33:00.013 +09:00",
    "Computer": "IE10Win7",
    "Channel": "Sec",
    "EventID": 4688,
    "Level": "info",
    "RecordID": 6573,
    "RuleTitle": "Proc Exec",
    "Details": {
        "CmdLine": "taskeng.exe {1052D286-2BA1-43B1-8B92-EFF406F6EF4E} S-1-5-18:NT",
        "AUTHORITY\\SystemService": "",
        "Path": "C:\\Windows\\System32\\taskeng.exe",
        "PID": "0x6e0",
        "User": "IE10WIN7$",
        "LID": "0x3e7"
    }
}
...
```
</details>

<details>
<summary>[This PR](https://github.com/Yamato-Security/hayabusa/tree/895-bug-misaligned-fields-in-json-output) </summary>

```
...
{
    "Timestamp": "2016-08-19 02:33:00.013 +09:00",
    "Computer": "IE10Win7",
    "Channel": "Sec",
    "EventID": 4688,
    "Level": "info",
    "RecordID": 6573,
    "RuleTitle": "Proc Exec",
    "Details": {
        "CmdLine": "taskeng.exe {1052D286-2BA1-43B1-8B92-EFF406F6EF4E} S-1-5-18:NT AUTHORITY\\SystemService:",
        "Path": "C:\\Windows\\System32\\taskeng.exe",
        "PID": "0x6e0",
        "User": "IE10WIN7$",
        "LID": "0x3e7"
    }
}

...
```
</details>


### Benchmark3
I ran a benchmark using [this procedure(6.1GB evtx)](https://github.com/Yamato-Security/hayabusa/issues/778#issuecomment-1296504766) and the results were as follows.

#### Executed Command

> .\main.exe json-timeline -d ..\all-evtx\ -o main-test.json --debug -q 


|Version| Elapsed time | Memory(peak)  | Events with hits / Total events | Output file size(bytes)|
|-------| ------------ | --------|--------|--------| 
| [before](https://github.com/Yamato-Security/hayabusa/commit/6e2276ac1ddc91ce74ec7f607c6e0b62ee7ce10b) | 00:04:07.496| 4.2 GiB| 1,593,731 / 4,817,181 | 956689562 | 
| [This PR](https://github.com/Yamato-Security/hayabusa/tree/895-bug-misaligned-fields-in-json-output)  | 00:04:06.925| 4.1 GiB | 1,593,715 / 4,817,181 | 956689675 |

#### Console output
<details>
<summary>[before](https://github.com/Yamato-Security/hayabusa/commit/6e2276ac1ddc91ce74ec7f607c6e0b62ee7ce10b) </summary>

```
>.\main.exe json-timeline -d ..\all-evtx\ -o main-test.json --debug -q
Results Summary:

Events with hits / Total events: 1,593,731 / 4,817,181 (Data reduction: 3,223,450 events (66.92%))

Total | Unique detections: 1,627,147 | 151
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 12,044 (0.74%) | 20 (13.25%)
Total | Unique medium detections: 11,011 (0.68%) | 39 (25.83%)
Total | Unique low detections: 1,053,593 (64.75%) | 42 (27.81%)
Total | Unique informational detections: 550,499 (33.83%) | 50 (33.11%)
...
Saved file: main-test.json (956.7 MB)
Elapsed time: 00:04:07.496
Rule Parse Processing Time: 00:00:01.330
Analysis Processing Time: 00:03:42.141
Output Processing Time: 00:00:24.023

Memory usage stats:
heap stats:    peak      total      freed    current       unit      count
  reserved:    4.2 GiB    4.2 GiB   83.0 MiB    4.1 GiB
 committed:    3.4 GiB   69.2 GiB   65.9 GiB    3.3 GiB
```
</details>

<details>
<summary>[This PR](https://github.com/Yamato-Security/hayabusa/tree/895-bug-misaligned-fields-in-json-output) </summary>

```
>.\895.exe json-timeline -d ..\all-evtx\ -o 895-test.json --debug -q
Results Summary:

Events with hits / Total events: 1,593,731 / 4,817,181 (Data reduction: 3,223,450 events (66.92%))

Total | Unique detections: 1,627,147 | 151
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 12,044 (0.74%) | 20 (13.25%)
Total | Unique medium detections: 11,011 (0.68%) | 39 (25.83%)
Total | Unique low detections: 1,053,593 (64.75%) | 42 (27.81%)
Total | Unique informational detections: 550,499 (33.83%) | 50 (33.11%)

...

Saved file: 895-test.json (956.7 MB)
Elapsed time: 00:04:06.925
Rule Parse Processing Time: 00:00:01.404
Analysis Processing Time: 00:03:40.693
Output Processing Time: 00:00:24.826

Memory usage stats:
heap stats:    peak      total      freed    current       unit      count
  reserved:    4.1 GiB    4.1 GiB   83.0 MiB    4.0 GiB
 committed:    3.4 GiB   69.1 GiB   65.8 GiB    3.3 GiB
```
</details>



