### PR TITLE
Added channel names shorter in the metrics/csv-timeline/json-timeline command

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,7 +10,7 @@
 
 - オプションのグループ分けを再修正した。(#918)(@hitenkoku)
 - JSONL形式のログを読み込む際のメモリ使用量を約75%削減した。 (#921) (@fukusuket)
-- チャンネル名の一般的な単語名を省略する機能をmetrics、json-timeline、csv-timelineに追加した。 (#923) (@hitenkoku)
+- `rules/config/channel_abbreviations_generic.txt`によってチャンネル名の一般的な単語名を省略する機能をmetrics、json-timeline、csv-timelineに追加した。 (#923) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,7 @@
 
 - オプションのグループ分けを再修正した。(#918)(@hitenkoku)
 - JSONL形式のログを読み込む際のメモリ使用量を約75%削減した。 (#921) (@fukusuket)
+- チャンネル名の一般的な単語名を省略する機能をmetrics、json-timeline、csv-timelineに追加した。 (#923) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Reorganized the grouping of command line options. (#918) (@hitenkoku)
 - Reduced memory usage by approximately 75% when reading JSONL formatted logs. (#921) (@fukusuket)
-- Added channel names general shorter in metrics, json-timeline, csv-timeline (#923) (@hitenkoku)
+- Channel names are now further abbreviated in the metrics, json-timeline, csv-timeline commands according to `rules/config/channel_abbreviations_generic.txt`. (#923) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Reorganized the grouping of command line options. (#918) (@hitenkoku)
 - Reduced memory usage by approximately 75% when reading JSONL formatted logs. (#921) (@fukusuket)
+- Added channel names general shorter in metrics, json-timeline, csv-timeline (#923) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
 name = "hayabusa"
 version = "2.2.2-dev"
 dependencies = [
+ "aho-corasick",
  "base64 0.21.0",
  "bytesize",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ureq = "*"
 mockall = "*"
 maxminddb = "0.*"
 cidr-utils = "0.*"
+aho-corasick = "*"
 
 [profile.dev]
 debug = 0

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1518,8 +1518,10 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output() {
-        let mock_ch_filter =
-            message::create_output_filter_config("test_files/config/channel_abbreviations.txt");
+        let mock_ch_filter = message::create_output_filter_config(
+            "test_files/config/channel_abbreviations.txt",
+            true,
+        );
         let test_filepath: &str = "test.evtx";
         let test_rulepath: &str = "test-rule.yml";
         let test_title = "test_title";

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -283,12 +283,13 @@ impl Detection {
                     profile_converter.insert(
                         key.as_str(),
                         Channel(
-                            stored_static
+                            stored_static.ch_disp_abbr_generic.replace_all(
+                                stored_static
                                 .ch_config
                                 .get(&CompactString::from(ch_str.to_ascii_lowercase()))
-                                .unwrap_or(ch_str)
-                                .to_owned(),
-                        ),
+                                .unwrap_or(ch_str).as_str()
+                                , &stored_static.ch_disp_abbr_gen_rep_values).into()
+                            ),
                     );
                 }
                 Level(_) => {

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -283,13 +283,18 @@ impl Detection {
                     profile_converter.insert(
                         key.as_str(),
                         Channel(
-                            stored_static.ch_disp_abbr_generic.replace_all(
-                                stored_static
-                                .ch_config
-                                .get(&CompactString::from(ch_str.to_ascii_lowercase()))
-                                .unwrap_or(ch_str).as_str()
-                                , &stored_static.ch_disp_abbr_gen_rep_values).into()
-                            ),
+                            stored_static
+                                .ch_disp_abbr_generic
+                                .replace_all(
+                                    stored_static
+                                        .ch_config
+                                        .get(&CompactString::from(ch_str.to_ascii_lowercase()))
+                                        .unwrap_or(ch_str)
+                                        .as_str(),
+                                    &stored_static.ch_disp_abbr_gen_rep_values,
+                                )
+                                .into(),
+                        ),
                     );
                 }
                 Level(_) => {

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -616,7 +616,7 @@ mod tests {
     #[test]
     /// test of loading output filter config by mitre_tactics.txt
     fn test_load_mitre_tactics_log() {
-        let actual = create_output_filter_config("test_files/config/mitre_tactics.txt");
+        let actual = create_output_filter_config("test_files/config/mitre_tactics.txt", true);
         let expected: HashMap<CompactString, CompactString> = HashMap::from([
             ("attack.impact".into(), "Impact".into()),
             ("xxx".into(), "yyy".into()),
@@ -627,8 +627,10 @@ mod tests {
     #[test]
     /// loading test to channel_abbrevations.txt
     fn test_load_abbrevations() {
-        let actual = create_output_filter_config("test_files/config/channel_abbreviations.txt");
-        let actual2 = create_output_filter_config("test_files/config/channel_abbreviations.txt");
+        let actual =
+            create_output_filter_config("test_files/config/channel_abbreviations.txt", true);
+        let actual2 =
+            create_output_filter_config("test_files/config/channel_abbreviations.txt", true);
         let expected: HashMap<CompactString, CompactString> = HashMap::from([
             ("security".into(), "Sec".into()),
             ("xxx".into(), "yyy".into()),

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -48,6 +48,7 @@ lazy_static! {
         utils::check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), "config/mitre_tactics.txt", true)
             .unwrap().to_str()
             .unwrap(),
+        true
     );
     pub static ref LEVEL_ABBR_MAP:HashMap<&'static str, &'static str> = HashMap::from_iter(vec![
         ("critical", "crit"),
@@ -68,7 +69,10 @@ lazy_static! {
 
 /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。
 /// ex. attack.impact,Impact
-pub fn create_output_filter_config(path: &str) -> HashMap<CompactString, CompactString> {
+pub fn create_output_filter_config(
+    path: &str,
+    is_lower_case: bool,
+) -> HashMap<CompactString, CompactString> {
     let mut ret: HashMap<CompactString, CompactString> = HashMap::new();
     let read_result = utils::read_csv(path);
     if read_result.is_err() {
@@ -80,8 +84,13 @@ pub fn create_output_filter_config(path: &str) -> HashMap<CompactString, Compact
             return;
         }
 
+        let key = if is_lower_case {
+            line[0].trim().to_ascii_lowercase()
+        } else {
+            line[0].trim().to_string()
+        };
         ret.insert(
-            CompactString::from(line[0].trim().to_ascii_lowercase()),
+            CompactString::from(key),
             CompactString::from(line[1].trim()),
         );
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1105,12 +1105,7 @@ impl App {
             ));
 
             // timeline機能の実行
-            tl.start(
-                &records_per_detect,
-                stored_static.metrics_flag,
-                stored_static.logon_summary_flag,
-                &stored_static.eventkey_alias,
-            );
+            tl.start(&records_per_detect, stored_static);
 
             if !(stored_static.metrics_flag || stored_static.logon_summary_flag) {
                 // ruleファイルの検知
@@ -1251,12 +1246,7 @@ impl App {
             ));
 
             // timeline機能の実行
-            tl.start(
-                &records_per_detect,
-                stored_static.metrics_flag,
-                stored_static.logon_summary_flag,
-                &stored_static.eventkey_alias,
-            );
+            tl.start(&records_per_detect, stored_static);
 
             if !(stored_static.metrics_flag || stored_static.logon_summary_flag) {
                 // ruleファイルの検知


### PR DESCRIPTION
## What Changed

- Added channel names shorter in the metrics/csv-timeline/json-timeline command.

## Evidence

<details>
<summary>main branch result</summary>

```
Analyzing event files: 584
Total file size: 137.1 MB

584 / 584 [==========================================================================] 100.00 %

Total Event Records: 47471

╭───────┬─────────┬────────────────────────────────────────────────────────────┬───────┬────────────────────────────────────────────────────────────────────────────────────────╮
│ Count ┆ Percent ┆ Channel                                                    ┆ ID    ┆ Event                                                                                  │
╞═══════╪═════════╪════════════════════════════════════════════════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════════════╡
...
│ 7     ┆ 0.0%    ┆ Microsoft-Windows-Application-Experience/Program-Telemetry ┆ 500   ┆ Unknown                                                                                │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
...
Elapsed time: 00:00:02.682
```
</details>


<details>

<summary></summary>

```
>./923.exe metrics -d ..\hayabusa-sample-evtx\
...
Analyzing event files: 584
Total file size: 137.1 MB

584 / 584 [==========================================================================] 100.00 %

Total Event Records: 47471

╭───────┬─────────┬─────────────────────────────────────────┬───────┬─────────╮
│ Count ┆ Percent ┆ Channel                                 ┆ ID    ┆ Event   │
╞═══════╪═════════╪═════════════════════════════════════════╪═══════╪═════════╡
...
│ 7     ┆ 0.0%    ┆ MS-Win-App-Experience/Program-Telemetry ┆ 500   ┆ Unknown │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌...
Elapsed time: 00:00:02.763
```
</details>