### PR TITLE
Fix: set-default-profile's README option was incorrect

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -996,8 +996,8 @@ Hayabusaの`config/profiles.yaml`設定ファイルでは、５つのプロフ�
 8. `timesketch-verbose`
 
 このファイルを編集することで、簡単に独自のプロファイルをカスタマイズしたり、追加したりすることができます。
-`set-default-profile --profile <profile>`オプションでデフォルトのプロファイルを変更することもできます。
-利用可能なプロファイルとそのフィールド情報を表示するには、`csv-timeline --list-profiles`オプションを使用してください。
+`set-default-profile --profile <profile>`コマンドでデフォルトのプロファイルを変更することもできます。
+利用可能なプロファイルとそのフィールド情報を表示するには、`csv-timeline --list-profiles`コマンドを使用してください。
 
 ### 1. `minimal`プロファイルの出力
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -996,7 +996,7 @@ Hayabusaの`config/profiles.yaml`設定ファイルでは、５つのプロフ�
 8. `timesketch-verbose`
 
 このファイルを編集することで、簡単に独自のプロファイルをカスタマイズしたり、追加したりすることができます。
-`set-default-profile -P <profile>`オプションでデフォルトのプロファイルを変更することもできます。
+`set-default-profile --profile <profile>`オプションでデフォルトのプロファイルを変更することもできます。
 利用可能なプロファイルとそのフィールド情報を表示するには、`csv-timeline --list-profiles`オプションを使用してください。
 
 ### 1. `minimal`プロファイルの出力

--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ Hayabusa has 5 pre-defined output profiles to use in `config/profiles.yaml`:
 8. `timesketch-verbose`
 
 You can easily customize or add your own profiles by editing this file.
-You can also easily change the default profile with `set-default-profile -P <profile>`.
+You can also easily change the default profile with `set-default-profile --profile <profile>`.
 Use the `list-profiles` command to show the available profiles and their field information.
 
 ### 1. `minimal` profile output

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1560,7 +1560,7 @@ fn extract_author_name(yaml_path: &str, stored_static: &StoredStatic) -> Nested<
     {
         if let Some(author) = yaml["author"].as_str() {
             let mut ret = Nested::<String>::new();
-            for author in author.to_string().split(',').into_iter().map(|s| {
+            for author in author.to_string().split(',').map(|s| {
                 // 各要素の括弧以降の記載は名前としないためtmpの一番最初の要素のみを参照する
                 // データの中にdouble quote と single quoteが入っているためここで除外する
                 s.split('(').next().unwrap_or_default().to_string()

--- a/src/detections/pivot.rs
+++ b/src/detections/pivot.rs
@@ -59,7 +59,7 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
         return;
     }
     let mut pivots = PIVOT_KEYWORD.write().unwrap();
-    pivots.iter_mut().into_iter().for_each(|(_, pivot)| {
+    pivots.iter_mut().for_each(|(_, pivot)| {
         for field in &pivot.fields {
             if let Some(array_str) = eventkey_alias.get_event_key(&String::from(field)) {
                 let mut is_exist_event_key = false;

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -113,7 +113,6 @@ pub fn read_jsonl_to_value(path: &str) -> Result<Box<dyn Iterator<Item = Value>>
     };
     if is_jsonl {
         let ret = peekable_lines
-            .into_iter()
             .filter_map(|s| s.ok())
             .filter(|s| !s.trim().is_empty())
             .map(|line| {


### PR DESCRIPTION
## What Changed

- Fix set-default-profile's option document was incorrect.
- `-P` -> `-p`
- Use long style option in README
  `-p` -> `--profile`
  - I changed the command samples in the README to use long options because short option was unclear what omitting the options meant.

## Evidence

Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.

- `set-default-profile` is command
  - https://github.com/Yamato-Security/hayabusa/blob/04f82194530d9d6b6bfceaff3a2311e776bb7402/README-Japanese.md?plain=1#L384-L392
- `set-deafult-profile` 's option is `-p`
  - https://github.com/Yamato-Security/hayabusa/blob/89c24f654945e375d2e3f725e7eb6fcb97bd8ba5/src/detections/configs.rs#L632-L640
  - https://github.com/Yamato-Security/hayabusa/blob/89c24f654945e375d2e3f725e7eb6fcb97bd8ba5/src/detections/configs.rs#L542-L543