### PR TITLE
feat: Support `1 of selection*` and `all of selection*`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,7 +4,8 @@
 
 **新機能:**
 
-- 新たなパイプキーワード(`contains|all`)`に対応した。 (#945) (@hitenkoku)
+- 新たなキーワードの`1 of selection*`と`all of selection*`に対応した。 (#957) (@fukusuket)
+- 新たなパイプキーワードの`|contains|all`に対応した。 (#945) (@hitenkoku)
 - ステータスが`unsupported`となっているルールの件数を表示した。ステータス`unsupported`のルールも検知対象とするオプションとして`--enable-supported-rules`オプションを追加した。 (#949) (@hitenkoku)
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **New Features:**
 
+- Added support for `1 of selection*` and `all of selection*`. (#957) (@fukusuket)
 - Added support for the `|contains|all` pipe keyword. (#945) (@hitenkoku)
 - Added the `--enable-unsupported-rules` option to enable rules marked as `unsupported`. (#949) (@hitenkoku) (#949) (@hitenkoku)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -158,7 +158,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
 ]
@@ -189,9 +189,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -444,9 +444,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -471,15 +471,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -1101,9 +1101,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
@@ -1558,9 +1558,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -1784,9 +1784,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5e082f6ea090deaf0e6dd04b68360fd5cddb152af6ce8927c9d25db299f98c"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -1809,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -1824,18 +1824,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -2098,18 +2098,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2251,15 +2251,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -2484,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2499,45 +2499,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winstructs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,3 @@ openssl = { version = "*", features = ["vendored"] }  #vendored is needed to com
 [profile.release]
 lto = true
 strip = "symbols"
-codegen-units = 1

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -158,7 +158,7 @@ impl ConditionCompiler {
         match r.captures(condition_str) {
             Some(c) => {
                 let s = keys.iter().filter(|x| x.contains(&c[1])).join(sep);
-                condition_str.replace(&c[0], format!(" ({}) ", s).as_str())
+                condition_str.replace(&c[0], format!("({})", s).as_str())
             }
             None => condition_str.to_string(),
         }
@@ -1484,18 +1484,39 @@ mod tests {
     #[test]
     fn test_convert_condition_all_of_selection() {
         let condition = "all of selection*";
+
         let keys = vec!["selection1".to_string(), "selection2".to_string()];
         let result = ConditionCompiler::convert_condition(condition, &keys);
-        let expected = " (selection1 and selection2) ".to_string();
+        let expected = "(selection1 and selection2)".to_string();
+        assert_eq!(result, expected);
+
+        let keys = vec!["selection1".to_string(), "selection2".to_string(),"selection3".to_string()];
+        let result = ConditionCompiler::convert_condition(condition, &keys);
+        let expected = "(selection1 and selection2 and selection3)".to_string();
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_convert_condition_one_of_selection() {
         let condition = "1 of selection*";
+
         let keys = vec!["selection1".to_string(), "selection2".to_string()];
         let result = ConditionCompiler::convert_condition(condition, &keys);
-        let expected = " (selection1 or selection2) ".to_string();
+        let expected = "(selection1 or selection2)".to_string();
+        assert_eq!(result, expected);
+
+        let keys = vec!["selection1".to_string(), "selection2".to_string(), "selection3".to_string()];
+        let result = ConditionCompiler::convert_condition(condition, &keys);
+        let expected = "(selection1 or selection2 or selection3)".to_string();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_convert_condition_convert_complex_condition() {
+        let condition = "all of selection* and test1 or test2 or 1 of filter*";
+        let keys = vec!["selection1".to_string(), "selection2".to_string(), "test".to_string(), "filter1".to_string(), "filter2".to_string()];
+        let result = ConditionCompiler::convert_condition(condition, &keys);
+        let expected = "(selection1 and selection2) and test1 or test2 or (filter1 or filter2)".to_string();
         assert_eq!(result, expected);
     }
 

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -158,7 +158,8 @@ impl ConditionCompiler {
                 .iter()
                 .filter(|x| x.starts_with(target_node_key_prefix.as_str()))
                 .join(sep);
-            converted_str = converted_str.replace(match_str, format!("({})", replaced_condition).as_str())
+            converted_str =
+                converted_str.replace(match_str, format!("({})", replaced_condition).as_str())
         }
         converted_str
     }
@@ -1569,5 +1570,81 @@ mod tests {
         let keys = vec!["selection1".to_string(), "selection2".to_string()];
         let result = ConditionCompiler::convert_condition(condition, &keys);
         assert_eq!(result, condition);
+    }
+
+    #[test]
+    fn test_condition_1_of_select_detect() {
+        // conditionにorを使ったパターンのテスト
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection1:
+                Channel: 'System'
+            selection2:
+                EventID: 7040
+            selection3:
+                param1: 'Windows Event Log'
+            condition: 1 of selection*
+        details: 'Service name : %param1%¥nMessage : Event Log Service Stopped¥nResults: Selective event log manipulation may follow this event.'
+        "#;
+
+        check_select(rule_str, SIMPLE_RECORD_STR, true);
+    }
+
+    #[test]
+    fn test_condition_1_of_select_not_detect() {
+        // conditionにorを使ったパターンのテスト
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection1:
+                Channel: 'NODETECT'
+            selection2:
+                EventID: 9999
+            selection3:
+                param1: 'NODETECT'
+            condition: 1 of selection*
+        details: 'Service name : %param1%¥nMessage : Event Log Service Stopped¥nResults: Selective event log manipulation may follow this event.'
+        "#;
+
+        check_select(rule_str, SIMPLE_RECORD_STR, false);
+    }
+
+    #[test]
+    fn test_condition_all_of_select_detect() {
+        // conditionにorを使ったパターンのテスト
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection1:
+                Channel: 'System'
+            selection2:
+                EventID: 7040
+            selection3:
+                param1: 'Windows Event Log'
+            condition: all of selection*
+        details: 'Service name : %param1%¥nMessage : Event Log Service Stopped¥nResults: Selective event log manipulation may follow this event.'
+        "#;
+
+        check_select(rule_str, SIMPLE_RECORD_STR, true);
+    }
+
+    #[test]
+    fn test_condition_all_of_select_not_detect() {
+        // conditionにorを使ったパターンのテスト
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection1:
+                Channel: 'NOTDETECT'
+            selection2:
+                EventID: 7040
+            selection3:
+                param1: 'Windows Event Log'
+            condition: all of selection*
+        details: 'Service name : %param1%¥nMessage : Event Log Service Stopped¥nResults: Selective event log manipulation may follow this event.'
+        "#;
+
+        check_select(rule_str, SIMPLE_RECORD_STR, false);
     }
 }

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -1490,7 +1490,11 @@ mod tests {
         let expected = "(selection1 and selection2)".to_string();
         assert_eq!(result, expected);
 
-        let keys = vec!["selection1".to_string(), "selection2".to_string(),"selection3".to_string()];
+        let keys = vec![
+            "selection1".to_string(),
+            "selection2".to_string(),
+            "selection3".to_string(),
+        ];
         let result = ConditionCompiler::convert_condition(condition, &keys);
         let expected = "(selection1 and selection2 and selection3)".to_string();
         assert_eq!(result, expected);
@@ -1505,7 +1509,11 @@ mod tests {
         let expected = "(selection1 or selection2)".to_string();
         assert_eq!(result, expected);
 
-        let keys = vec!["selection1".to_string(), "selection2".to_string(), "selection3".to_string()];
+        let keys = vec![
+            "selection1".to_string(),
+            "selection2".to_string(),
+            "selection3".to_string(),
+        ];
         let result = ConditionCompiler::convert_condition(condition, &keys);
         let expected = "(selection1 or selection2 or selection3)".to_string();
         assert_eq!(result, expected);
@@ -1514,9 +1522,16 @@ mod tests {
     #[test]
     fn test_convert_condition_convert_complex_condition() {
         let condition = "all of selection* and test1 or test2 or 1 of filter*";
-        let keys = vec!["selection1".to_string(), "selection2".to_string(), "test".to_string(), "filter1".to_string(), "filter2".to_string()];
+        let keys = vec![
+            "selection1".to_string(),
+            "selection2".to_string(),
+            "test".to_string(),
+            "filter1".to_string(),
+            "filter2".to_string(),
+        ];
         let result = ConditionCompiler::convert_condition(condition, &keys);
-        let expected = "(selection1 and selection2) and test1 or test2 or (filter1 or filter2)".to_string();
+        let expected =
+            "(selection1 and selection2) and test1 or test2 or (filter1 or filter2)".to_string();
         assert_eq!(result, expected);
     }
 


### PR DESCRIPTION
## What Changed

- Fixed #956
- Added rule `conditions:` block conversion process internally with the following specifications before rule compilation/tokenize
  -  `1 of selection*` -> `(select1 or select2 or select3)`
  -  `all of selection*` -> `(select1 and select2 and select3)`

## Evidence
### Environment 
- OS: macOS montery version 13.1
- Hard: Macbook Air(M1, 2020) , Memory 8GB, Core 8

### Test1
Detection count
 of rule which has `1 of selection_*` is the same before/after.
- main: `./hayabusa-2.2.2 -d ... -r` [hayabusa-rules/win_security_pass_the_hash_2.yml](https://github.com/Yamato-Security/hayabusa-rules/blob/main/sigma/builtin/security/win_security_pass_the_hash_2.yml)
- [This PR](https://github.com/Yamato-Security/hayabusa/compare/support-condition-allof-1of): `./hayabusa-new -d ... -r` [Sigma/win_security_pass_the_hash_2.yml](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/security/win_security_pass_the_hash_2.yml)

The result of the above two commands is as follows
```
Total | Unique medium detections: 48 (100.00%) | 1 (100.00%)
...
│ Top medium alerts:              Top low alerts:  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Pass the Hash Activity 2 (48)
```

### Test2
Detection count
 of rule which has `1 of filter_*` and `all of suspicious2*` is the same before/after.
- main: `./hayabusa-2.2.2 -d ... -r` [hayabusa-rules/win_system_susp_service_installation.yml](https://github.com/Yamato-Security/hayabusa-rules/blob/main/sigma/builtin/system/win_system_susp_service_installation.yml)
- [This PR](https://github.com/Yamato-Security/hayabusa/compare/support-condition-allof-1of): `./hayabusa-new -d ... -r` [Sigma/win_system_susp_service_installation.yml](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/system/win_system_susp_service_installation.yml)

The result of the above two commands is as follows
```
Total | Unique high detections: 12 (100.00%) | 1 (100.00%)
...
│ Top critical alerts:        Top high alerts:                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                         Suspicious Service Installation (12)
```

### Benchmark1
Data: [evtx-baseline v0.7](https://github.com/NextronSystems/evtx-baseline/releases/)
Command: `./hayabusa csv-timeline -d  ./all-evtx -o out.csv --debug`
|Version| Elapsed time | Memory(peak) | Events with hits / Total events | Output file size(bytes)|
|-------| ------------ | --------|--------|--------| 
| main | 00:06:38.867 | 3.8 GiB | 1,594,761 / 4,817,181 | 575641441 |
| [This PR](https://github.com/Yamato-Security/hayabusa/compare/support-condition-allof-1of)  | 00:06:40.312 | 3.8 GiB | 1,594,761 / 4,817,181 |  575641441 | 


### Benchmark2
Data: [hayabusa-sample-evtx](https://github.com/Yamato-Security/hayabusa-sample-evtx)
Command: `./hayabusa csv-timeline -d  ./all-evtx -o out.csv --debug`
|Version| Elapsed time | Memory(peak) | Events with hits / Total events | Output file size(bytes)|
|-------| ------------ | --------|--------|--------| 
| main | 00:00:06.862 | 1.0 GiB | 19,616 / 47,465 | 16181402 |
| [This PR](https://github.com/Yamato-Security/hayabusa/compare/support-condition-allof-1of)   | 00:00:06.878 | 1.0 GiB | 19,616 / 47,465 |  16181402 | 


I would appreciate it if you could review🙏