### PR TITLE
add short options

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -6,6 +6,7 @@
 
 - `csv-timeline`の出力のフィールドでダブルクォートを追加した。 (#965) (@hitenkoku)
 - `logon-summary`の見出しを更新した。 (#964) (@yamatosecurity)
+- `--enable-deprecated-rules`の`-D`ショートオプションと`--enable-unsupported-rules`の`-u`ショートオプションを追加した。(@yamatosecurity)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added double quotes in CSV fields of `csv-timeline` output to support multiple lines in fields. (#965) (@hitenkoku)
 - Updated `logon-summary` headers. (#964) (@yamatosecurity)
+- Added short-hand option `-D` for `--enable-deprecated-rules` and `-u` for `--enable-unsupported-rules`. (@yamatosecurity)
 
 **Bug Fixes:**
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -733,11 +733,11 @@ pub struct PivotKeywordOption {
     pub common_options: CommonOptions,
 
     /// Enable rules marked as deprecated
-    #[arg(help_heading = Some("Filtering"), long = "enable-deprecated-rules", display_order = 310)]
+    #[arg(help_heading = Some("Filtering"), short = 'D', long = "enable-deprecated-rules", display_order = 310)]
     pub enable_deprecated_rules: bool,
 
     /// Enable rules marked as unsupported
-    #[arg(help_heading = Some("Filtering"), long = "enable-unsupported-rules", display_order = 312)]
+    #[arg(help_heading = Some("Filtering"), short = 'u', long = "enable-unsupported-rules", display_order = 312)]
     pub enable_unsupported_rules: bool,
 
     /// Ignore rules according to status (ex: experimental) (ex: stable,test)
@@ -845,11 +845,11 @@ pub struct OutputOption {
     pub common_options: CommonOptions,
 
     /// Enable rules marked as deprecated
-    #[arg(help_heading = Some("Filtering"), long = "enable-deprecated-rules", display_order = 310)]
+    #[arg(help_heading = Some("Filtering"), short = 'D', long = "enable-deprecated-rules", display_order = 310)]
     pub enable_deprecated_rules: bool,
 
     /// Enable rules marked as unsupported
-    #[arg(help_heading = Some("Filtering"), long = "enable-unsupported-rules", display_order = 312)]
+    #[arg(help_heading = Some("Filtering"), short = 'u', long = "enable-unsupported-rules", display_order = 312)]
     pub enable_unsupported_rules: bool,
 
     /// Ignore rules according to status (ex: experimental) (ex: stable,test)


### PR DESCRIPTION
The `--enable-deprecated-rules` and `--enable-unsupport-rules` are useful options that I want to use frequently but are long to type so I added short options. Please check if this is ok.