### PR TITLE
sorted filtering options

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,6 +7,7 @@
 - `csv-timeline`の出力のフィールドでダブルクォートを追加した。 (#965) (@hitenkoku)
 - `logon-summary`の見出しを更新した。 (#964) (@yamatosecurity)
 - `--enable-deprecated-rules`の`-D`ショートオプションと`--enable-unsupported-rules`の`-u`ショートオプションを追加した。(@yamatosecurity)
+- Filteringセクションのオプションの表示順とヘルプの表示内容を修正した。 (#969) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added double quotes in CSV fields of `csv-timeline` output to support multiple lines in fields. (#965) (@hitenkoku)
 - Updated `logon-summary` headers. (#964) (@yamatosecurity)
 - Added short-hand option `-D` for `--enable-deprecated-rules` and `-u` for `--enable-unsupported-rules`. (@yamatosecurity)
+- Reordered option in Filtering and Changed option help contents. (#969) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -732,16 +732,16 @@ pub struct PivotKeywordOption {
     #[clap(flatten)]
     pub common_options: CommonOptions,
 
-    /// Enable rules marked as deprecated
+    /// Enable rules with status of deprecated
     #[arg(help_heading = Some("Filtering"), short = 'D', long = "enable-deprecated-rules", display_order = 310)]
     pub enable_deprecated_rules: bool,
 
-    /// Enable rules marked as unsupported
+    /// Enable rules with status of unsupported
     #[arg(help_heading = Some("Filtering"), short = 'u', long = "enable-unsupported-rules", display_order = 312)]
     pub enable_unsupported_rules: bool,
 
     /// Ignore rules according to status (ex: experimental) (ex: stable,test)
-    #[arg(help_heading = Some("Filtering"), long = "exclude-status", value_name = "STATUS", use_value_delimiter = true, value_delimiter = ',', display_order = 313)]
+    #[arg(help_heading = Some("Filtering"), long = "exclude-status", value_name = "STATUS", use_value_delimiter = true, value_delimiter = ',', display_order = 314)]
     pub exclude_status: Option<Vec<String>>,
 
     /// Minimum level for rules (default: informational)
@@ -766,7 +766,7 @@ pub struct PivotKeywordOption {
     )]
     pub exact_level: Option<String>,
 
-    /// Enable rules marked as noisy (./rules/config/noisy_rules.txt)
+    /// Enable rules set to noisy (./rules/config/noisy_rules.txt)
     #[arg(help_heading = Some("Filtering"), short = 'n', long = "enable-noisy-rules", display_order = 311)]
     pub enable_noisy_rules: bool,
 
@@ -844,16 +844,16 @@ pub struct OutputOption {
     #[clap(flatten)]
     pub common_options: CommonOptions,
 
-    /// Enable rules marked as deprecated
+    /// Enable rules with status of deprecated
     #[arg(help_heading = Some("Filtering"), short = 'D', long = "enable-deprecated-rules", display_order = 310)]
     pub enable_deprecated_rules: bool,
 
-    /// Enable rules marked as unsupported
+    /// Enable rules with status of unsupported
     #[arg(help_heading = Some("Filtering"), short = 'u', long = "enable-unsupported-rules", display_order = 312)]
     pub enable_unsupported_rules: bool,
 
     /// Ignore rules according to status (ex: experimental) (ex: stable,test)
-    #[arg(help_heading = Some("Filtering"), long = "exclude-status", value_name = "STATUS", use_value_delimiter = true, value_delimiter = ',', display_order = 312)]
+    #[arg(help_heading = Some("Filtering"), long = "exclude-status", value_name = "STATUS", use_value_delimiter = true, value_delimiter = ',', display_order = 314)]
     pub exclude_status: Option<Vec<String>>,
 
     /// Minimum level for rules (default: informational)
@@ -878,7 +878,7 @@ pub struct OutputOption {
     )]
     pub exact_level: Option<String>,
 
-    /// Enable rules marked as noisy (./rules/config/noisy_rules.txt)
+    /// Enable rules set to noisy (./rules/config/noisy_rules.txt)
     #[arg(help_heading = Some("Filtering"), short = 'n', long = "enable-noisy-rules", display_order = 311)]
     pub enable_noisy_rules: bool,
 


### PR DESCRIPTION
## What Changed

- Changed help string and option sorted

## Evidence

<details>
<summary>main</summary>

```
>./main.exe help csv-timeline
...

Filtering:
  -E, --EID-filter                Scan only common EIDs for faster speed (./rules/config/target_event_IDs.txt)
  -D, --enable-deprecated-rules   Enable rules marked as deprecated
  -n, --enable-noisy-rules        Enable rules marked as noisy (./rules/config/noisy_rules.txt)
      --exclude-status <STATUS>   Ignore rules according to status (ex: experimental) (ex: stable,test)
  -u, --enable-unsupported-rules  Enable rules marked as unsupported
  -e, --exact-level <LEVEL>       Scan for only specific levels (informational, low, medium, high, critical)
  -m, --min-level <LEVEL>         Minimum level for rules (default: informational)
      --timeline-end <DATE>       End time of the event logs to load (ex: "2022-02-22 23:59:59 +09:00")
      --timeline-start <DATE>     Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
```
</details>

<details>
<summary>this PR</details>

```
>./969.exe help csv-timeline
...
Filtering:
  -E, --EID-filter                Scan only common EIDs for faster speed (./rules/config/target_event_IDs.txt)
  -D, --enable-deprecated-rules   Enable rules with status of deprecated
  -n, --enable-noisy-rules        Enable rules set to noisy (./rules/config/noisy_rules.txt)
  -u, --enable-unsupported-rules  Enable rules with status of unsupported
  -e, --exact-level <LEVEL>       Scan for only specific levels (informational, low, medium, high, critical)
      --exclude-status <STATUS>   Ignore rules according to status (ex: experimental) (ex: stable,test)
  -m, --min-level <LEVEL>         Minimum level for rules (default: informational)
      --timeline-end <DATE>       End time of the event logs to load (ex: "2022-02-22 23:59:59 +09:00")
      --timeline-start <DATE>     Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")

>./969.exe help json-timeline 
...
Filtering:
  -E, --EID-filter                Scan only common EIDs for faster speed (./rules/config/target_event_IDs.txt)
  -D, --enable-deprecated-rules   Enable rules with status of deprecated
  -n, --enable-noisy-rules        Enable rules set to noisy (./rules/config/noisy_rules.txt)
  -u, --enable-unsupported-rules  Enable rules with status of unsupported
  -e, --exact-level <LEVEL>       Scan for only specific levels (informational, low, medium, high, critical)
      --exclude-status <STATUS>   Ignore rules according to status (ex: experimental) (ex: stable,test)
  -m, --min-level <LEVEL>         Minimum level for rules (default: informational)
      --timeline-end <DATE>       End time of the event logs to load (ex: "2022-02-22 23:59:59 +09:00")
      --timeline-start <DATE>     Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
>./969.exe help pivot-keywords-list
...
Filtering:
  -E, --EID-filter                Scan only common EIDs for faster speed (./rules/config/target_event_IDs.txt)
  -D, --enable-deprecated-rules   Enable rules with status of deprecated
  -n, --enable-noisy-rules        Enable rules set to noisy (./rules/config/noisy_rules.txt)
  -u, --enable-unsupported-rules  Enable rules with status of unsupported
  -e, --exact-level <LEVEL>       Scan for only specific levels (informational, low, medium, high, critical)
      --exclude-status <STATUS>   Ignore rules according to status (ex: experimental) (ex: stable,test)
  -m, --min-level <LEVEL>         Minimum level for rules (default: informational)
      --timeline-end <DATE>       End time of the event logs to load (ex: "2022-02-22 23:59:59 +09:00")
      --timeline-start <DATE>     Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
```
</details>