### PR TITLE
Add multiline option in csv timeline command

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## 2.3.2 [202X/XX/XX] "XXX"
+
+**改善:**
+
+- `csv-timeline`コマンドに`--multiline`オプションを追加した。 (#965) (@hitenkoku)
+
 ## 2.3.1 [2023/03/18] "TMCIT Release-2"
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.2 [202X/XX/XX] "XXX"
+
+**Enhancements:**
+
+- Added `--multiline` option in `csv-timeline` command. (#972) (@hitenkoku)
+
 ## 2.3.1 [2023/03/18] "TMCIT Release-2"
 
 **Enhancements:**

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -215,13 +215,13 @@ fn emit_csv<W: std::io::Write>(
     stored_static: &StoredStatic,
     tl_start_end_time: (&Option<DateTime<Utc>>, &Option<DateTime<Utc>>),
 ) -> io::Result<()> {
-    let mut output_replaced_maps: HashMap<&str, &str> =
+    let output_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("🛂r", "\r"), ("🛂n", "\n"), ("🛂t", "\t")]);
-    if stored_static.multiline_flag {
-        output_replaced_maps.insert(" ¦ ", "\r\n");
-    }
-    let removed_replaced_maps: HashMap<&str, &str> =
+    let mut removed_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("\n", " "), ("\r", " "), ("\t", " ")]);
+    if stored_static.multiline_flag {
+        removed_replaced_maps.insert(" ¦ ", "\r\n");
+    }
     let output_replacer = AhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(output_replaced_maps.keys());
@@ -402,8 +402,6 @@ fn emit_csv<W: std::io::Write>(
                             ),
                             &removed_replaced_maps.values().collect_vec(),
                         )
-                        .split_whitespace()
-                        .join(" ")
                 }))?;
             }
             // 各種集計作業

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -394,14 +394,13 @@ fn emit_csv<W: std::io::Write>(
                     plus_header = false;
                 }
                 wtr.write_record(detect_info.ext_field.iter().map(|x| {
-                    output_remover
-                        .replace_all(
-                            &output_replacer.replace_all(
-                                &x.1.to_value(),
-                                &output_replaced_maps.values().collect_vec(),
-                            ),
-                            &removed_replaced_maps.values().collect_vec(),
-                        )
+                    output_remover.replace_all(
+                        &output_replacer.replace_all(
+                            &x.1.to_value(),
+                            &output_replaced_maps.values().collect_vec(),
+                        ),
+                        &removed_replaced_maps.values().collect_vec(),
+                    )
                 }))?;
             }
             // 各種集計作業
@@ -1932,6 +1931,313 @@ mod tests {
             }
         };
         assert!(remove_file("./test_emit_csv.csv").is_ok());
+    }
+
+    #[test]
+    fn test_emit_csv_output_with_multiline_opt() {
+        let mock_ch_filter = message::create_output_filter_config(
+            "test_files/config/channel_abbreviations.txt",
+            true,
+        );
+        let test_filepath: &str = "test.evtx";
+        let test_rulepath: &str = "test-rule.yml";
+        let test_title = "test_title";
+        let test_level = "high";
+        let test_computername = "testcomputer";
+        let test_computername2 = "testcomputer2";
+        let test_eventid = "1111";
+        let test_channel = "Sec";
+        let output = "pokepoke";
+        let test_attack = "execution/txxxx.yyy";
+        let test_recinfo = "CommandRLine: hoge ¦ Test1: hogetest1 ¦ Test2: hogetest2";
+        let test_record_id = "11111";
+        let expect_time = Utc
+            .datetime_from_str("1996-02-27T01:05:01Z", "%Y-%m-%dT%H:%M:%SZ")
+            .unwrap();
+        let expect_tz = expect_time.with_timezone(&Utc);
+        let dummy_action = Action::CsvTimeline(CsvOutputOption {
+            output_options: OutputOption {
+                input_args: InputOption {
+                    directory: None,
+                    filepath: None,
+                    live_analysis: false,
+                },
+                profile: Some("verbose-2".to_string()),
+                enable_deprecated_rules: false,
+                exclude_status: None,
+                min_level: "informational".to_string(),
+                exact_level: None,
+                enable_noisy_rules: false,
+                end_timeline: None,
+                start_timeline: None,
+                eid_filter: false,
+                european_time: false,
+                iso_8601: false,
+                rfc_2822: false,
+                rfc_3339: false,
+                us_military_time: false,
+                us_time: false,
+                utc: false,
+                visualize_timeline: false,
+                rules: Path::new("./rules").to_path_buf(),
+                html_report: None,
+                no_summary: true,
+                common_options: CommonOptions {
+                    no_color: false,
+                    quiet: false,
+                },
+                detect_common_options: DetectCommonOption {
+                    evtx_file_ext: None,
+                    thread_number: None,
+                    quiet_errors: false,
+                    config: Path::new("./rules/config").to_path_buf(),
+                    verbose: false,
+                    json_input: false,
+                },
+                enable_unsupported_rules: false,
+            },
+            geo_ip: None,
+            output: Some(Path::new("./test_emit_csv_multiline.csv").to_path_buf()),
+            multiline: true,
+        });
+        let dummy_config = Some(Config {
+            action: Some(dummy_action),
+            debug: false,
+        });
+        let stored_static = StoredStatic::create_static_data(dummy_config);
+        let output_profile: Vec<(CompactString, Profile)> = load_profile(
+            "test_files/config/default_profile.yaml",
+            "test_files/config/profiles.yaml",
+            Some(&stored_static),
+        )
+        .unwrap_or_default();
+        {
+            let messages = &message::MESSAGES;
+            messages.clear();
+            let val = r##"
+                {
+                    "Event": {
+                        "EventData": {
+                            "CommandRLine": "hoge",
+                            "Test1": "hogetest1",
+                            "Test2": "hogetest2"
+                        },
+                        "System": {
+                            "TimeCreated_attributes": {
+                                "SystemTime": "1996-02-27T01:05:01Z"
+                            }
+                        }
+                    }
+                }
+            "##;
+            let event: Value = serde_json::from_str(val).unwrap();
+            let output_option = OutputOption {
+                input_args: InputOption {
+                    directory: None,
+                    filepath: None,
+                    live_analysis: false,
+                },
+                profile: Some("verbose-2".to_string()),
+                enable_deprecated_rules: false,
+                exclude_status: None,
+                min_level: "informational".to_string(),
+                exact_level: None,
+                enable_noisy_rules: false,
+                end_timeline: None,
+                start_timeline: None,
+                eid_filter: false,
+                european_time: false,
+                iso_8601: false,
+                rfc_2822: false,
+                rfc_3339: false,
+                us_military_time: false,
+                us_time: false,
+                utc: false,
+                visualize_timeline: false,
+                rules: Path::new("./rules").to_path_buf(),
+                html_report: None,
+                no_summary: false,
+                common_options: CommonOptions {
+                    no_color: false,
+                    quiet: false,
+                },
+                detect_common_options: DetectCommonOption {
+                    evtx_file_ext: None,
+                    thread_number: None,
+                    quiet_errors: false,
+                    config: Path::new("./rules/config").to_path_buf(),
+                    verbose: false,
+                    json_input: false,
+                },
+                enable_unsupported_rules: false,
+            };
+            let mut profile_converter: HashMap<&str, Profile> = HashMap::from([
+                (
+                    "Timestamp",
+                    Profile::Timestamp(format_time(&expect_time, false, &output_option)),
+                ),
+                (
+                    "Computer",
+                    Profile::Computer(CompactString::from(test_computername2)),
+                ),
+                (
+                    "Channel",
+                    Profile::Channel(
+                        mock_ch_filter
+                            .get(&CompactString::from("security"))
+                            .unwrap_or(&CompactString::default())
+                            .to_owned(),
+                    ),
+                ),
+                ("Level", Profile::Level(CompactString::from(test_level))),
+                (
+                    "EventID",
+                    Profile::EventID(CompactString::from(test_eventid)),
+                ),
+                (
+                    "MitreAttack",
+                    Profile::MitreTactics(CompactString::from(test_attack)),
+                ),
+                (
+                    "RecordID",
+                    Profile::RecordID(CompactString::from(test_record_id)),
+                ),
+                (
+                    "RuleTitle",
+                    Profile::RuleTitle(CompactString::from(test_title)),
+                ),
+                (
+                    "AllFieldInfo",
+                    Profile::AllFieldInfo(CompactString::from(test_recinfo)),
+                ),
+                (
+                    "RuleFile",
+                    Profile::RuleFile(CompactString::from(test_rulepath)),
+                ),
+                (
+                    "EvtxFile",
+                    Profile::EvtxFile(CompactString::from(test_filepath)),
+                ),
+                ("Tags", Profile::MitreTags(CompactString::from(test_attack))),
+            ]);
+            let eventkey_alias = load_eventkey_alias(
+                utils::check_setting_path(
+                    &CURRENT_EXE_PATH.to_path_buf(),
+                    "rules/config/eventkey_alias.txt",
+                    true,
+                )
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            );
+            message::insert(
+                &event,
+                CompactString::new(output),
+                DetectInfo {
+                    rulepath: CompactString::from(test_rulepath),
+                    ruletitle: CompactString::from(test_title),
+                    level: CompactString::from(test_level),
+                    computername: CompactString::from(test_computername2),
+                    eventid: CompactString::from(test_eventid),
+                    detail: CompactString::default(),
+                    ext_field: output_profile.to_owned(),
+                    is_condition: false,
+                },
+                expect_time,
+                &mut profile_converter,
+                false,
+                &eventkey_alias,
+            );
+            *profile_converter.get_mut("Computer").unwrap() =
+                Profile::Computer(CompactString::from(test_computername));
+
+            message::insert(
+                &event,
+                CompactString::new(output),
+                DetectInfo {
+                    rulepath: CompactString::from(test_rulepath),
+                    ruletitle: CompactString::from(test_title),
+                    level: CompactString::from(test_level),
+                    computername: CompactString::from(test_computername),
+                    eventid: CompactString::from(test_eventid),
+                    detail: CompactString::default(),
+                    ext_field: output_profile.to_owned(),
+                    is_condition: false,
+                },
+                expect_time,
+                &mut profile_converter,
+                false,
+                &eventkey_alias,
+            );
+            let multi = message::MESSAGES.get(&expect_time).unwrap();
+            let (_, detect_infos) = multi.pair();
+
+            println!("message: {detect_infos:?}");
+        }
+        let expect =
+            "\"Timestamp\",\"Computer\",\"Channel\",\"EventID\",\"Level\",\"Tags\",\"RecordID\",\"RuleTitle\",\"Details\",\"AllFieldInfo\"\n\""
+                .to_string()
+                + &expect_tz.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S%.3f %:z").to_string()
+                + "\",\""
+                + test_computername
+                + "\",\""
+                + test_channel
+                + "\","
+                + test_eventid
+                + ",\""
+                + test_level
+                + "\",\""
+                + test_attack
+                + "\","
+                + test_record_id
+                + ",\""
+                + test_title
+                + "\",\""
+                + output
+                + "\",\""
+                + &test_recinfo.replace(" ¦ ", "\r\n")
+                + "\"\n\""
+                + &expect_tz.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S%.3f %:z")
+                .to_string()
+                + "\",\""
+                + test_computername2
+                + "\",\""
+                + test_channel
+                + "\","
+                + test_eventid
+                + ",\""
+                + test_level
+                + "\",\""
+                + test_attack
+                + "\","
+                + test_record_id
+                + ",\""
+                + test_title
+                + "\",\""
+                + output
+                + "\",\""
+                + &test_recinfo.replace(" ¦ ", "\r\n")
+                + "\"\n";
+        let mut file: Box<dyn io::Write> =
+            Box::new(File::create("./test_emit_csv_multiline.csv").unwrap());
+
+        assert!(emit_csv(
+            &mut file,
+            false,
+            HashMap::new(),
+            1,
+            &output_profile,
+            &stored_static,
+            (&Some(expect_tz), &Some(expect_tz))
+        )
+        .is_ok());
+        match read_to_string("./test_emit_csv_multiline.csv") {
+            Err(_) => panic!("Failed to open file."),
+            Ok(s) => {
+                assert_eq!(s, expect);
+            }
+        };
+        assert!(remove_file("./test_emit_csv_multiline.csv").is_ok());
     }
 
     #[test]

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1685,6 +1685,7 @@ mod tests {
             },
             geo_ip: None,
             output: Some(Path::new("./test_emit_csv.csv").to_path_buf()),
+            multiline: false,
         });
         let dummy_config = Some(Config {
             action: Some(dummy_action),

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -215,8 +215,11 @@ fn emit_csv<W: std::io::Write>(
     stored_static: &StoredStatic,
     tl_start_end_time: (&Option<DateTime<Utc>>, &Option<DateTime<Utc>>),
 ) -> io::Result<()> {
-    let output_replaced_maps: HashMap<&str, &str> =
+    let mut output_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("🛂r", "\r"), ("🛂n", "\n"), ("🛂t", "\t")]);
+    if stored_static.multiline_flag {
+        output_replaced_maps.insert(" ¦ ", "\r\n");
+    }
     let removed_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("\n", " "), ("\r", " "), ("\t", " ")]);
     let output_replacer = AhoCorasickBuilder::new()

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -70,6 +70,7 @@ pub struct StoredStatic {
     pub json_input_flag: bool,
     pub output_path: Option<PathBuf>,
     pub common_options: CommonOptions,
+    pub multiline_flag: bool,
 }
 impl StoredStatic {
     /// main.rsでパースした情報からデータを格納する関数
@@ -277,6 +278,10 @@ impl StoredStatic {
                 .unwrap(),
             false,
         );
+        let multiline_flag = match &input_config.as_ref().unwrap().action {
+            Some(Action::CsvTimeline(opt)) => opt.multiline,
+            _ => false,
+        };
         let mut ret = StoredStatic {
             config: input_config.as_ref().unwrap().to_owned(),
             config_path: config_path.to_path_buf(),
@@ -376,6 +381,7 @@ impl StoredStatic {
             json_input_flag,
             output_path: output_path.cloned(),
             common_options,
+            multiline_flag,
         };
         ret.profiles = load_profile(
             check_setting_path(
@@ -980,6 +986,10 @@ pub struct InputOption {
 pub struct CsvOutputOption {
     #[clap(flatten)]
     pub output_options: OutputOption,
+
+    /// Output event field information in multiple rows
+    #[arg(help_heading = Some("Output"), long="multiline", display_order = 390)]
+    pub multiline: bool,
 
     // display_order value is defined acronym of long option (A=10,B=20,...,Z=260,a=270, b=280...,z=520)
     /// Add GeoIP (ASN, city, country) info to IP addresses

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -1135,6 +1135,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))
@@ -1379,6 +1380,7 @@ mod tests {
             },
             geo_ip: Some(Path::new("test_files/mmdb").to_path_buf()),
             output: Some(Path::new("./test_emit_csv.csv").to_path_buf()),
+            multiline: false,
         });
         let dummy_config = Some(Config {
             action: Some(dummy_action),
@@ -1496,6 +1498,7 @@ mod tests {
             },
             geo_ip: Some(Path::new("test_files/mmdb").to_path_buf()),
             output: Some(Path::new("./test_emit_csv.csv").to_path_buf()),
+            multiline: false,
         });
         let dummy_config = Some(Config {
             action: Some(dummy_action),

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -596,6 +596,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -620,6 +620,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -831,6 +831,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }));

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -428,6 +428,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -487,6 +487,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1498,6 +1498,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -249,6 +249,7 @@ mod tests {
             },
             geo_ip: None,
             output: None,
+            multiline: false,
         });
         let csv_html_flag_enable = create_dummy_stored_static(Some(enable_csv_action));
         assert!(htmlreport::check_html_flag(&csv_html_flag_enable.config));
@@ -296,6 +297,7 @@ mod tests {
             },
             geo_ip: None,
             output: None,
+            multiline: false,
         });
         let csv_html_flag_disable = create_dummy_stored_static(Some(disable_csv_action));
         assert!(!htmlreport::check_html_flag(&csv_html_flag_disable.config));

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -443,6 +443,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             }));
         assert_eq!(
             Nested::<Vec<String>>::new(),
@@ -551,6 +552,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             }));
         *GEOIP_DB_PARSER.write().unwrap() = None;
         assert_eq!(
@@ -609,6 +611,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             }));
 
         let expect: Vec<(CompactString, Profile)> = vec![
@@ -697,6 +700,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             }));
         //両方のファイルが存在しない場合
         assert_eq!(

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -401,6 +401,7 @@ mod tests {
                 },
                 geo_ip: None,
                 output: None,
+                multiline: false,
             })),
             debug: false,
         }))


### PR DESCRIPTION
## What Changed

- Add multiline option in csv timeline command

## Evidence
<details>
<summary>・ help output</summary>


```
>./972.exe help csv-timeline
Hayabusa v2.3.1
Yamato Security (https://github.com/Yamato-Security/hayabusa) @SecurityYamato)

Usage:
  hayabusa.exe csv-timeline <INPUT> [OPTIONS]

Input:
  -d, --directory <DIR>  Directory of multiple .evtx files
  -f, --file <FILE>      File path to one .evtx file
  -l, --live-analysis    Analyze the local C:\Windows\System32\winevt\Logs folder
  -J, --JSON-input       Scan JSON formatted logs instead of .evtx (.json or .jsonl)

Output:
  -G, --GeoIP <MAXMIND-DB-DIR>  Add GeoIP (ASN, city, country) info to IP addresses
  -H, --HTML-report <FILE>      Save Results Summary details to an HTML report (ex: results.html)
      --multiline               Output event field information in multiple rows
  -o, --output <FILE>           Save the timeline in CSV format (ex: results.csv)
  -p, --profile <PROFILE>       Specify output profile

Display Settings:
      --no-color            Disable color output
      --no-summary          Do not display Results Summary (slightly faster speed)
  -q, --quiet               Quiet mode: do not display the launch banner
  -v, --verbose             Output verbose information
  -T, --visualize-timeline  Output event frequency timeline (terminal needs to support unicode)

Filtering:
  -E, --EID-filter                Scan only common EIDs for faster speed (./rules/config/target_event_IDs.txt)
  -D, --enable-deprecated-rules   Enable rules with status of deprecated
  -n, --enable-noisy-rules        Enable rules set to noisy (./rules/config/noisy_rules.txt)
  -u, --enable-unsupported-rules  Enable rules with status of unsupported
  -e, --exact-level <LEVEL>       Scan for only specific levels (informational, low, medium, high, critical)
      --exclude-status <STATUS>   Ignore rules according to status (ex: experimental) (ex: stable,test)
  -m, --min-level <LEVEL>         Minimum level for rules (default: informational)
      --timeline-end <DATE>       End time of the event logs to load (ex: "2022-02-22 23:59:59 +09:00")
      --timeline-start <DATE>     Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")

General Options:
  -Q, --quiet-errors                     Quiet errors mode: do not save error logs
  -r, --rules <DIR/FILE>                 Specify a custom rule directory or file (default: ./rules)
  -c, --rules-config <DIR>               Specify custom rule config directory (default: ./rules/config)
      --target-file-ext <EVTX_FILE_EXT>  Specify additional file extensions (ex: evtx_data) (ex: evtx1,evtx2)
  -t, --threads <NUMBER>                 Number of threads (default: optimal number for performance)

Time Format:
      --European-time     Output timestamp in European time format (ex: 22-02-2022 22:00:00.123 +02:00)
      --ISO-8601          Output timestamp in ISO-8601 format (ex: 2022-02-22T10:10:10.1234567Z) (Always UTC)
      --RFC-2822          Output timestamp in RFC 2822 format (ex: Fri, 22 Feb 2022 22:00:00 -0600)
      --RFC-3339          Output timestamp in RFC 3339 format (ex: 2022-02-22 22:00:00.123456-06:00)
      --US-military-time  Output timestamp in US military time format (ex: 02-22-2022 22:00:00.123 -06:00)
      --US-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
  -U, --UTC               Output time in UTC format (default: local time)
```
</details>

<details>
<summary>This PR </summary>

```
> ./972.exe csv-timeline --multiline -d ..\all-evtx\ -o 972.csv -p super-verbose -q --debug
...
Total event log files: 1858
Total file size: 6.1 GB

Loading detections rules. Please wait.

Excluded rules: 20
Noisy rules: 7 (Disabled)

Deprecated rules: 150 (4.34%) (Disabled)
Experimental rules: 1760 (50.93%)
Stable rules: 223 (6.45%)
Test rules: 1473 (42.62%)
Unsupported rules: 43 (1.24%) (Disabled)

Hayabusa rules: 149
Sigma rules: 3307
...
Results Summary:

First Timestamp: 2009-07-14 13:56:45.074 +09:00
Last Timestamp: 2022-09-18 23:37:13.088 +09:00

Events with hits / Total events: 1,594,356 / 4,817,181 (Data reduction: 3,222,825 events (66.90%))

Total | Unique detections: 1,627,665 | 152
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 12,043 (0.74%) | 20 (13.16%)
Total | Unique medium detections: 11,015 (0.68%) | 42 (27.63%)
Total | Unique low detections: 1,054,520 (64.79%) | 40 (26.32%)
Total | Unique informational detections: 550,087 (33.80%) | 50 (32.89%)

...
Saved file: 972.csv (2.1 GB)
Elapsed time: 00:04:37.194
Rule Parse Processing Time: 00:00:00.851
Analysis Processing Time: 00:04:09.165
Output Processing Time: 00:00:27.175

Memory usage stats:
heap stats:    peak      total      freed    current       unit      count
  reserved:    8.2 GiB    8.2 GiB   83.0 MiB    8.1 GiB
 committed:    7.5 GiB   66.1 GiB   58.7 GiB    7.3 GiB
     reset:      0          0          0          0                            ok
   touched:   64.2 KiB   16.5 MiB   55.6 GiB  -55.6 GiB                        ok
  segments:     14        264        255          9                            not all freed!
-abandoned:      0          0          0          0                            ok
   -cached:      0          0          0          0                            ok
     pages:      0          0      732.1 Ki  -732.1 Ki                         ok
-abandoned:      0          0          0          0                            ok
 -extended:      0
 -noretire:      0
     mmaps:      0
   commits:   54.3 Ki
   threads:     32         32          0         32                            not all freed!
  searches:     0.0 avg
numa nodes:       1
   elapsed:     277.207 s
```
</details>