### PR TITLE
Trim extra space in levels when outputting to files

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,7 +4,7 @@
 
 **改善:**
 
-- ファイル(CSV, JSON, JSONL)出力の際に余分なスペースを削除したRemoved extra space when outputting to files. (#979) (@hitenkoku)
+- ファイル(CSV, JSON, JSONL)出力の際に`Level`の余分なスペースを削除した。 (#979) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,6 +2,10 @@
 
 ## 2.3.3 [2023/03/XX] "XXX"
 
+**改善:**
+
+- ファイル(CSV, JSON, JSONL)出力の際に余分なスペースを削除したRemoved extra space when outputting to files. (#979) (@hitenkoku)
+
 **バグ修正:**
 
 - v2.3.0にて`level-tuning`コマンド実行時にクラッシュする問題を修正した。 (#977) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.3.3 [2023/03/XX] "XXX"
 
+**Enhancements:**
+
+- Removed extra space when outputting to files(CSV, JSON, JSONL). (#979) (@hitenkoku)
+
 **Bug Fixes:**
 
 - Fixed a crash when the `level-tuning` command was executed on version 2.3.0. (#977) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Enhancements:**
 
-- Removed extra space when outputting to files(CSV, JSON, JSONL). (#979) (@hitenkoku)
+- Removed an extra space when outputting `Level` to files(CSV, JSON, JSONL). (#979) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -396,7 +396,7 @@ fn emit_csv<W: std::io::Write>(
                 wtr.write_record(detect_info.ext_field.iter().map(|x| {
                     output_remover.replace_all(
                         &output_replacer.replace_all(
-                            &x.1.to_value(),
+                            x.1.to_value().trim(),
                             &output_replaced_maps.values().collect_vec(),
                         ),
                         &removed_replaced_maps.values().collect_vec(),

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1280,7 +1280,7 @@ fn output_json_str(
                 _convert_valid_json_str(&tmp_val, matches!(profile, Profile::AllFieldInfo(_)));
             target.push(_create_json_output_format(
                 key,
-                &output_val,
+                output_val.trim(),
                 key.starts_with('\"'),
                 output_val.starts_with('\"'),
                 4,
@@ -1474,7 +1474,7 @@ fn output_json_str(
                     };
                     target.push(_create_json_output_format(
                         &key,
-                        &fmted_val,
+                        fmted_val.trim(),
                         key.starts_with('\"'),
                         true,
                         4,


### PR DESCRIPTION
## What Changed

- Trim extra space in levels when outputting to files(csv, json, jsonl)

## Evidence

- csv-timeline

`./979.exe csv-timeline -d ../hayabusa-sample-evtx -o 969-hse.csv -p super-verbose --debug -q`

[979CSVcomp.zip](https://github.com/Yamato-Security/hayabusa/files/11062988/979CSVcomp.zip)

- json-timeline

`./979.exe json-timeline -d ../hayabusa-sample-evtx -o 969-hse.json -p super-verbose --debug -q`

```
> cat ./979.json | jq .Level | sort | unique
"crit"
"high"
"info"
"low"
"med"
```

- jsonl

`./979.exe json-timeline -d ../hayabusa-sample-evtx -o 969-hse.json -p super-verbose --debug -q -L`

[979JSONLcomp.zip](https://github.com/Yamato-Security/hayabusa/files/11062981/979JSONLcomp.zip)

