### PR TITLE
added output Event.UserData to AllFieldInfo

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,7 @@
 **改善:**
 
 - コマンドの表示順を辞書順に並べ替えた。 (#991) (@hitenkoku)
+- `csv-timeline`, `json-timeline`, `search`コマンドの `AllFieldInfo`の出力に`Event.UserData`の属性情報を追加した。 (#1006) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Enhancements:**
 
 - Alphabetically sorted commands. (#991) (@hitenkoku)
+- Added attribute information of `Event.UserData` to the output of `AllFieldInfo` in `csv-timeline`, `json-timeline` and `search` commands. (#1006) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -412,8 +412,7 @@ fn _collect_recordinfo<'a>(
                 keys.push(parent_key);
             }
             for (key, value) in obj {
-                // 属性は出力しない
-                if key.ends_with("_attributes") {
+                if key.eq("xmlns") {
                     continue;
                 }
                 // Event.Systemは出力しない

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -206,12 +206,11 @@ impl EventSearch {
                     _ => CompactString::new("-"),
                 };
 
-                let allfieldinfo = match utils::get_serde_number_to_string(
-                    &record.record["Event"]["EventData"],
-                    true,
-                ) {
-                    Some(eventdata) => eventdata,
-                    _ => CompactString::new("-"),
+                let datainfo = utils::create_recordinfos(&record.record);
+                let allfieldinfo = if !datainfo.is_empty() {
+                    datainfo.into()
+                } else {
+                    CompactString::new("-")
                 };
 
                 self.search_result.insert((
@@ -366,11 +365,13 @@ fn extract_search_event_info(
         _ => CompactString::new("-"),
     };
 
-    let allfieldinfo =
-        match utils::get_serde_number_to_string(&record.record["Event"]["EventData"], true) {
-            Some(eventdata) => eventdata,
-            _ => CompactString::new("-"),
-        };
+    let datainfo = utils::create_recordinfos(&record.record);
+    let allfieldinfo = if !datainfo.is_empty() {
+        datainfo.into()
+    } else {
+        CompactString::new("-")
+    };
+
     (
         timestamp.into(),
         hostname,


### PR DESCRIPTION
## What Changed

- added output Event.UserData to AllFieldInfo in csv-timeline, json-timeline, search command

## Evidence

- main
```
>./main.exe csv-timeline -d ..\hayabusa-sample-evtx\ -r .\1006test.yml -o 1006main.csv -p super-verbose -q
...
> cat 1006main.csv
"Timestamp","Computer","Channel","Provider","EventID","Level","MitreTactics","MitreTags","OtherTags","RecordID","RuleTitle","RuleAuthor","RuleCreationDate","RuleModifiedDate","Status","Details","RuleFile","EvtxFile","AllFieldInfo"
"2019-08-28 12:36:49.826 +09:00","MSEDGEWIN10","RDP-CoreTS","MS-Win-RemoteDesktopServices-RdpCoreTS",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",979,"Test Event","Test","2020/01/15","2022/10/22","experimental","DisplayDriverName: rdpudd.dll","1006test.yml","..\hayabusa-sample-evtx\EVTX-ATTACK-SAMPLES\Other\rdpcorets_148_mst120_bluekeep_rpdscan_full.evtx","DisplayDriverName: rdpudd.dll"
"2019-08-29 03:59:59.972 +09:00","MSEDGEWIN10","RDP-CoreTS","MS-Win-RemoteDesktopServices-RdpCoreTS",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",988,"Test Event","Test","2020/01/15","2022/10/22","experimental","DisplayDriverName: rdpudd.dll","1006test.yml","..\hayabusa-sample-evtx\EVTX-ATTACK-SAMPLES\Other\rdpcorets_148_mst120_bluekeep_rpdscan_full.evtx","DisplayDriverName: rdpudd.dll"
"2020-07-11 22:21:11.693 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969076,"Test Event","Test","2020/01/15","2022/10/22","experimental","-","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","-"
"2020-07-11 22:21:17.514 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969094,"Test Event","Test","2020/01/15","2022/10/22","experimental","-","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","-"
"2020-07-11 22:21:18.640 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969096,"Test Event","Test","2020/01/15","2022/10/22","experimental","-","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","-"
```

```
>./main.exe search -f '..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx' -k mimikatz -i -q

...
Total event log files: 1
Total file size: 69.6 KB

1 / 1 [=====================================================================================================] 100.00 % Timestamp ‖ Hostname ‖ Channel ‖ Event ID ‖ Record ID ‖ EventTitle ‖ AllFieldInfo ‖ EvtxFile
2020-07-11T13:21:17.514076Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969094 ‖ - ‖ -:  ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx
2020-07-11T13:21:18.640983Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969096 ‖ - ‖ -:  ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx
2020-07-11T13:21:11.693103Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969076 ‖ - ‖ -:  ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx


Total findings: 3
```


- this PR

```
>./1006.exe csv-timeline -d ..\hayabusa-sample-evtx\ -r .\1006test.yml -o 1006.csv -p super-verbose -q
> cat 1006.csv
"Timestamp","Computer","Channel","Provider","EventID","Level","MitreTactics","MitreTags","OtherTags","RecordID","RuleTitle","RuleAuthor","RuleCreationDate","RuleModifiedDate","Status","Details","RuleFile","EvtxFile","AllFieldInfo"
"2019-08-28 12:36:49.826 +09:00","MSEDGEWIN10","RDP-CoreTS","MS-Win-RemoteDesktopServices-RdpCoreTS",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",979,"Test Event","Test","2020/01/15","2022/10/22","experimental","DisplayDriverName: rdpudd.dll","1006test.yml","..\hayabusa-sample-evtx\EVTX-ATTACK-SAMPLES\Other\rdpcorets_148_mst120_bluekeep_rpdscan_full.evtx","DisplayDriverName: rdpudd.dll"
"2019-08-29 03:59:59.972 +09:00","MSEDGEWIN10","RDP-CoreTS","MS-Win-RemoteDesktopServices-RdpCoreTS",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",988,"Test Event","Test","2020/01/15","2022/10/22","experimental","DisplayDriverName: rdpudd.dll","1006test.yml","..\hayabusa-sample-evtx\EVTX-ATTACK-SAMPLES\Other\rdpcorets_148_mst120_bluekeep_rpdscan_full.evtx","DisplayDriverName: rdpudd.dll"
"2020-07-11 22:21:11.693 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969076,"Test Event","Test","2020/01/15","2022/10/22","experimental","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {973F48B9-7001-410B-A904-B1DD8692B60A} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {973F48B9-7001-410B-A904-B1DD8692B60A} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000"
"2020-07-11 22:21:17.514 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969094,"Test Event","Test","2020/01/15","2022/10/22","experimental","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {4254EC74-97ED-4EF5-A12B-8CB3F120BDD1} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {4254EC74-97ED-4EF5-A12B-8CB3F120BDD1} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000"
"2020-07-11 22:21:18.640 +09:00","wec02","MS-Win-CAPI2/Op","MS-Win-CAPI2",70,"crit","Exec ¦ PrivEsc ¦ Evas ¦ CredAccess ¦ LatMov ¦ Impact","T1203 ¦ T1068 ¦ T1211 ¦ T1212 ¦ T1210 ¦ T1499.004","",13969096,"Test Event","Test","2020/01/15","2022/10/22","experimental","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {3BCB843F-0FC0-4408-982A-256E321B13D1} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000","1006test.yml","..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx","CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦ ProcessName: mimikatz.exe ¦ SeqNumber: 2 ¦ TaskId: {3BCB843F-0FC0-4408-982A-256E321B13D1} ¦ fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦ subjectName: wec02.offsec.lan ¦ value: 0 ¦ value: 10000"

```
```
>./1006.exe search -f '..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx' -k mimikatz -i -q

...
Total event log files: 1
Total file size: 69.6 KB

1 / 1 [=====================================================================================================] 100.00 % Timestamp ‖ Hostname ‖ Channel ‖ Event ID ‖ Record ID ‖ EventTitle ‖ AllFieldInfo ‖ EvtxFile
2020-07-11T13:21:18.640983Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969096 ‖ - ‖ CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦  ProcessName: mimikatz.exe ¦  SeqNumber: 2 ¦  TaskId: {3BCB843F-0FC0-4408-982A-256E321B13D1} ¦  fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦  subjectName: wec02.offsec.lan ¦  value: 0 ¦  value: 10000 ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx
2020-07-11T13:21:17.514076Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969094 ‖ - ‖ CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦  ProcessName: mimikatz.exe ¦  SeqNumber: 2 ¦  TaskId: {4254EC74-97ED-4EF5-A12B-8CB3F120BDD1} ¦  fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦  subjectName: wec02.offsec.lan ¦  value: 0 ¦  value: 10000 ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx
2020-07-11T13:21:11.693103Z ‖ wec02 ‖ MS-Win-CAPI2/Op ‖ 70 ‖ 13969076 ‖ - ‖ CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: true ¦  ProcessName: mimikatz.exe ¦  SeqNumber: 2 ¦  TaskId: {973F48B9-7001-410B-A904-B1DD8692B60A} ¦  fileRef: 3CD6B0EFAF68549EFE9ED2316426FCD7FF81A6A8.cer ¦  subjectName: wec02.offsec.lan ¦  value: 0 ¦  value: 10000 ‖ ..\hayabusa-sample-evtx\EVTX-to-MITRE-Attack\TA0006-Credential Access\T1552.004-Unsecured Credentials-Private Keys\ID70-CAPI-Private key accessed Mimikatz.evtx


Total findings: 3
```

I would appreciate it if you could review.