### PR TITLE
add conflicting args

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -688,8 +688,9 @@ pub struct SearchOption {
         help_heading = Some("Filtering"),
         short = 'k',
         long,
-        value_name = "KEYWORDS",
-        display_order = 370
+        value_name = "keywords",
+        display_order = 370,
+        conflicts_with = "regex"
     )]
     pub keywords: Option<Vec<String>>,
 
@@ -698,18 +699,19 @@ pub struct SearchOption {
         help_heading = Some("Filtering"),
         short = 'r',
         long,
-        value_name = "REGEX",
-        display_order = 440
+        value_name = "regex",
+        display_order = 440,
+        conflicts_with = "keywords"
     )]
     pub regex: Option<String>,
 
-    /// case-insensitive Search(require kewords option)
+    /// Case-insensitive keyword search
     #[arg(
         help_heading = Some("Filtering"),
         short,
         long = "ignore-case",
         display_order = 350,
-        requires = "keywords"
+        conflicts_with = "regex"
     )]
     pub ignore_case: bool,
 
@@ -717,7 +719,7 @@ pub struct SearchOption {
     #[arg(
         help_heading = Some("Filtering"),
         short = 'F',
-        long,
+        long = "filter",
         display_order = 320
     )]
     pub filter: Vec<String>,


### PR DESCRIPTION
@itiB 
PRありがとうございます！引数の組み合わせ対応良いですね。
`-i`を`--keywords`をrequireするより、エラーを出した方が分かりやすそうなので、少し変えてみました。
ご確認ください。

```
./target/release/hayabusa search -d ../hayabusa-sample-evtx -r ".*" -i
error: the argument '--regex <REGEX>' cannot be used with '--ignore-case'
```

```
./target/release/hayabusa search -d ../hayabusa-sample-evtx -r ".*" -k "hi"
error: the argument '--regex <regex>' cannot be used with '--keywords <keywords>'
```

因みに、long option nameが大文字にした理由はありますか？
実際の小文字のオプション名に変えましたが、大文字の方が良いのであれば、戻しましょう。