### PR TITLE
UI(main): add help output when variable is conflicted in search command

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -690,7 +690,6 @@ pub struct SearchOption {
         long,
         value_name = "KEYWORDS",
         display_order = 370,
-        conflicts_with = "regex",
     )]
     pub keywords: Option<Vec<String>>,
 
@@ -701,7 +700,6 @@ pub struct SearchOption {
         long,
         value_name = "REGEX",
         display_order = 440,
-        conflicts_with = "keywords",
     )]
     pub regex: Option<String>,
 
@@ -711,7 +709,6 @@ pub struct SearchOption {
         short,
         long = "ignore-case",
         display_order = 350,
-        conflicts_with = "regex",
     )]
     pub ignore_case: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ impl App {
             let variable_split_error = error_str.split('\'');
             write_color_buffer(
                 &BufferWriter::stdout(ColorChoice::Always),
-                Some(Color::Red),
+                Some(Color::Rgb(238, 102, 97)),
                 "error: ",
                 false,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1477,6 +1477,9 @@ impl App {
     }
 
     fn check_is_valid_args_num(&self, action: Option<&Action>) -> Result<(), &str> {
+        if action.is_none() {
+            return Ok(());
+        }
         match action.as_ref().unwrap() {
             Action::CsvTimeline(_)
             | Action::JsonTimeline(_)

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,10 +142,15 @@ impl App {
                 } else {
                     None
                 };
+                let output = if variable_color_flag {
+                    format!("'{}'", output_err_str)
+                } else {
+                    output_err_str.to_string()
+                };
                 write_color_buffer(
                     &BufferWriter::stdout(ColorChoice::Always),
                     output_color,
-                    output_err_str,
+                    &output,
                     false,
                 )
                 .ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1497,11 +1497,11 @@ impl App {
                     return Err("");
                 } else if !(opt.keywords.is_some() ^ opt.regex.is_some()) {
                     // key word and regex are conflict
-                    return Err("the argument '--regex <REGEX>' cannot be used with '--keywords <KEYWORDS>'");
+                    return Err("the arguments '--regex <REGEX>' and '--keywords <KEYWORDS>' cannot be used together.");
                 } else if opt.regex.is_some() && opt.ignore_case {
                     // ignore case is not supported for regex
                     return Err(
-                        "the argument '--regex <REGEX>' cannot be used with '--ignore-case'",
+                        "the arguments '--regex <REGEX>' and '--ignore-case' cannot be used together.",
                     );
                 }
                 Ok(())


### PR DESCRIPTION
## What Changed

- add help output when variable is conflicted in search command

## Evidence

```
 >./1011.exe search -d ..\hayabusa-sample-evtx\  -q
Hayabusa v2.4.0
Yamato Security (https://github.com/Yamato-Security/hayabusa) @SecurityYamato)

Usage:
  hayabusa.exe search <INPUT> <--keywords "<KEYWORDS>" OR --regex "<REGEX>"> [OPTIONS]

Display Settings:
      --no-color  Disable color output
  -q, --quiet     Quiet mode: do not display the launch banner
  -v, --verbose   Output verbose information

Input:
  -d, --directory <DIR>  Directory of multiple .evtx files
  -f, --file <FILE>      File path to one .evtx file
  -l, --live-analysis    Analyze the local C:\Windows\System32\winevt\Logs folder

Filtering:
  -F, --filter <FILTER>      Filter by specific field(s)
  -i, --ignore-case          Case-insensitive keyword search
  -k, --keywords <KEYWORDS>  Search by keyword(s)
  -r, --regex <REGEX>        Search by regular expression

Output:
  -o, --output <FILE>  Save the search results in CSV format (ex: search.csv)

General Options:
  -Q, --quiet-errors                     Quiet errors mode: do not save error logs
  -c, --rules-config <DIR>               Specify custom rule config directory (default: ./rules/config)
      --target-file-ext <EVTX_FILE_EXT>  Specify additional file extensions (ex: evtx_data) (ex: evtx1,evtx2)
  -t, --threads <NUMBER>                 Number of threads (default: optimal number for performance)
```

```
>./1011.exe search -d ..\hayabusa-sample-evtx\  --keywords "null" --regex ".*" -q
Hayabusa v2.4.0
Yamato Security (https://github.com/Yamato-Security/hayabusa) @SecurityYamato)

Usage:
  hayabusa.exe search <INPUT> <--keywords "<KEYWORDS>" OR --regex "<REGEX>"> [OPTIONS]

Display Settings:
      --no-color  Disable color output
  -q, --quiet     Quiet mode: do not display the launch banner
  -v, --verbose   Output verbose information

Input:
  -d, --directory <DIR>  Directory of multiple .evtx files
  -f, --file <FILE>      File path to one .evtx file
  -l, --live-analysis    Analyze the local C:\Windows\System32\winevt\Logs folder

Filtering:
  -F, --filter <FILTER>      Filter by specific field(s)
  -i, --ignore-case          Case-insensitive keyword search
  -k, --keywords <KEYWORDS>  Search by keyword(s)
  -r, --regex <REGEX>        Search by regular expression

Output:
  -o, --output <FILE>  Save the search results in CSV format (ex: search.csv)

General Options:
  -Q, --quiet-errors                     Quiet errors mode: do not save error logs
  -c, --rules-config <DIR>               Specify custom rule config directory (default: ./rules/config)
      --target-file-ext <EVTX_FILE_EXT>  Specify additional file extensions (ex: evtx_data) (ex: evtx1,evtx2)
  -t, --threads <NUMBER>                 Number of threads (default: optimal number for performance)

error: the argument '--regex <REGEX>' cannot be used with '--keywords <KEYWORDS>'
```

```
 >./1011.exe search -d ..\hayabusa-sample-evtx\  --regex ".*" -i -q
Hayabusa v2.4.0
Yamato Security (https://github.com/Yamato-Security/hayabusa) @SecurityYamato)

Usage:
  hayabusa.exe search <INPUT> <--keywords "<KEYWORDS>" OR --regex "<REGEX>"> [OPTIONS]

Display Settings:
      --no-color  Disable color output
  -q, --quiet     Quiet mode: do not display the launch banner
  -v, --verbose   Output verbose information

Input:
  -d, --directory <DIR>  Directory of multiple .evtx files
  -f, --file <FILE>      File path to one .evtx file
  -l, --live-analysis    Analyze the local C:\Windows\System32\winevt\Logs folder

Filtering:
  -F, --filter <FILTER>      Filter by specific field(s)
  -i, --ignore-case          Case-insensitive keyword search
  -k, --keywords <KEYWORDS>  Search by keyword(s)
  -r, --regex <REGEX>        Search by regular expression

Output:
  -o, --output <FILE>  Save the search results in CSV format (ex: search.csv)

General Options:
  -Q, --quiet-errors                     Quiet errors mode: do not save error logs
  -c, --rules-config <DIR>               Specify custom rule config directory (default: ./rules/config)
      --target-file-ext <EVTX_FILE_EXT>  Specify additional file extensions (ex: evtx_data) (ex: evtx1,evtx2)
  -t, --threads <NUMBER>                 Number of threads (default: optimal number for performance)

error: the argument '--regex <REGEX>' cannot be used with '--ignore-case'
```