### PR TITLE
enhance pivot terminal output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "hex",
  "hhmmss",
  "horrorshow",
+ "indexmap",
  "is_elevated",
  "itertools",
  "krapslog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ maxminddb = "0.*"
 cidr-utils = "0.*"
 aho-corasick = "*"
 memchr = "2.*"
+indexmap = "1.9.3"
 
 [profile.dev]
 debug = 0

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -577,29 +577,8 @@ hayabusa.exe pivot-keywords-list -d ../logs -m critical -o keywords
 #### `pivot-keywords-list`の設定ファイル
 
 検索キーワードは、`./rules/config/pivot_keywords.txt`を編集することでカスタマイズすることができます。
-デフォルト設定は以下の通りです:
+デフォルト設定は[こちらのページ](https://github.com/Yamato-Security/hayabusa-rules/blob/main/config/pivot_keywords.txt)です。
 
-```txt
-Source Computers.WorkstationName
-Subject Users.SubjectUserName
-Target Users.TargetUserName
-Users.User
-Subject Logon IDs.SubjectLogonId
-Target Logon IDs.TargetLogonId
-Logon IDs.LogonId
-IP Addresses.IpAddress
-Source IP Addresses.SourceIp
-Source IP Addresses.ClientAddress
-Source IP Addresses.SourceAddress
-Target IP Addresses.DestinationIp
-Target IP Addresses.DestAddress
-Processes.Image
-Processes.NewProcessName
-Process IDs.ProcessId
-Process IDs.NewProcessId
-Process GUIDs.ProcessGuid
-Command Lines.CommandLine
-```
 
 フォーマットは、`キーワード名.フィールド名`です。例えば、`Users`のリストを作成する場合、Hayabusaは、`SubjectUserName`、`TargetUserName`、`User`フィールドにあるすべての値をリストアップします。
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -576,18 +576,29 @@ hayabusa.exe pivot-keywords-list -d ../logs -m critical -o keywords
 
 #### `pivot-keywords-list`の設定ファイル
 
-検索キーワードは、`./config/pivot_keywords.txt`を編集することでカスタマイズすることができます。
+検索キーワードは、`./rules/config/pivot_keywords.txt`を編集することでカスタマイズすることができます。
 デフォルト設定は以下の通りです:
 
 ```txt
-Users.SubjectUserName
-Users.TargetUserName
+Source Computers.WorkstationName
+Subject Users.SubjectUserName
+Target Users.TargetUserName
 Users.User
-Logon IDs.SubjectLogonId
-Logon IDs.TargetLogonId
-Workstation Names.WorkstationName
-Ip Addresses.IpAddress
+Subject Logon IDs.SubjectLogonId
+Target Logon IDs.TargetLogonId
+Logon IDs.LogonId
+IP Addresses.IpAddress
+Source IP Addresses.SourceIp
+Source IP Addresses.ClientAddress
+Source IP Addresses.SourceAddress
+Target IP Addresses.DestinationIp
+Target IP Addresses.DestAddress
 Processes.Image
+Processes.NewProcessName
+Process IDs.ProcessId
+Process IDs.NewProcessId
+Process GUIDs.ProcessGuid
+Command Lines.CommandLine
 ```
 
 フォーマットは、`キーワード名.フィールド名`です。例えば、`Users`のリストを作成する場合、Hayabusaは、`SubjectUserName`、`TargetUserName`、`User`フィールドにあるすべての値をリストアップします。

--- a/README.md
+++ b/README.md
@@ -575,18 +575,29 @@ hayabusa.exe pivot-keywords-list -d ../logs -m critical -o keywords
 
 #### `pivot-keywords-list` config file
 
-You can customize what keywords you want to search for by editing `./config/pivot_keywords.txt`.
+You can customize what keywords you want to search for by editing `./rules/config/pivot_keywords.txt`.
 This is the default setting:
 
 ```txt
-Users.SubjectUserName
-Users.TargetUserName
+Source Computers.WorkstationName
+Subject Users.SubjectUserName
+Target Users.TargetUserName
 Users.User
-Logon IDs.SubjectLogonId
-Logon IDs.TargetLogonId
-Workstation Names.WorkstationName
-Ip Addresses.IpAddress
+Subject Logon IDs.SubjectLogonId
+Target Logon IDs.TargetLogonId
+Logon IDs.LogonId
+IP Addresses.IpAddress
+Source IP Addresses.SourceIp
+Source IP Addresses.ClientAddress
+Source IP Addresses.SourceAddress
+Target IP Addresses.DestinationIp
+Target IP Addresses.DestAddress
 Processes.Image
+Processes.NewProcessName
+Process IDs.ProcessId
+Process IDs.NewProcessId
+Process GUIDs.ProcessGuid
+Command Lines.CommandLine
 ```
 
 The format is `KeywordName.FieldName`. For example, when creating the list of `Users`, hayabusa will list up all the values in the `SubjectUserName`, `TargetUserName` and `User` fields.

--- a/README.md
+++ b/README.md
@@ -576,29 +576,8 @@ hayabusa.exe pivot-keywords-list -d ../logs -m critical -o keywords
 #### `pivot-keywords-list` config file
 
 You can customize what keywords you want to search for by editing `./rules/config/pivot_keywords.txt`.
-This is the default setting:
+[This page](https://github.com/Yamato-Security/hayabusa-rules/blob/main/config/pivot_keywords.txt) is the default setting.
 
-```txt
-Source Computers.WorkstationName
-Subject Users.SubjectUserName
-Target Users.TargetUserName
-Users.User
-Subject Logon IDs.SubjectLogonId
-Target Logon IDs.TargetLogonId
-Logon IDs.LogonId
-IP Addresses.IpAddress
-Source IP Addresses.SourceIp
-Source IP Addresses.ClientAddress
-Source IP Addresses.SourceAddress
-Target IP Addresses.DestinationIp
-Target IP Addresses.DestAddress
-Processes.Image
-Processes.NewProcessName
-Process IDs.ProcessId
-Process IDs.NewProcessId
-Process GUIDs.ProcessGuid
-Command Lines.CommandLine
-```
 
 The format is `KeywordName.FieldName`. For example, when creating the list of `Users`, hayabusa will list up all the values in the `SubjectUserName`, `TargetUserName` and `User` fields.
 

--- a/config/pivot_keywords.txt
+++ b/config/pivot_keywords.txt
@@ -1,8 +1,0 @@
-Users.SubjectUserName
-Users.TargetUserName
-Users.User
-Logon IDs.SubjectLogonId
-Logon IDs.TargetLogonId
-Workstation Names.WorkstationName
-Ip Addresses.IpAddress
-Processes.Image

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,7 +426,7 @@ impl App {
                         )
                         .ok();
 
-                        if pivot_keyword.keywords.len() == 0 {
+                        if pivot_keyword.keywords.is_empty() {
                             write_color_buffer(
                                 &BufferWriter::stdout(ColorChoice::Always),
                                 Some(Color::Red),

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ impl App {
                 load_pivot_keywords(
                     utils::check_setting_path(
                         &CURRENT_EXE_PATH.to_path_buf(),
-                        "config/pivot_keywords.txt",
+                        "rules/config/pivot_keywords.txt",
                         true,
                     )
                     .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,12 +367,10 @@ impl App {
                         for i in pivot_keyword.fields.iter() {
                             write!(output, "%{i}% ").ok();
                         }
-                        writeln!(output, "):").ok();
 
                         for i in pivot_keyword.keywords.iter() {
                             writeln!(output, "{i}").ok();
                         }
-                        writeln!(output).ok();
 
                         output
                     };
@@ -422,11 +420,21 @@ impl App {
                     pivot_key_unions.iter().for_each(|(key, pivot_keyword)| {
                         write_color_buffer(
                             &BufferWriter::stdout(ColorChoice::Always),
-                            None,
+                            Some(Color::Green),
                             &create_output(String::default(), key, pivot_keyword),
                             true,
                         )
                         .ok();
+
+                        if pivot_keyword.keywords.len() == 0 {
+                            write_color_buffer(
+                                &BufferWriter::stdout(ColorChoice::Always),
+                                Some(Color::Red),
+                                "No keywords found\n\n",
+                                true,
+                            )
+                            .ok();
+                        }
                     });
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,7 @@ impl App {
                             write_color_buffer(
                                 &BufferWriter::stdout(ColorChoice::Always),
                                 Some(Color::Red),
-                                "No keywords found\n\n",
+                                "No keywords found\n",
                                 true,
                             )
                             .ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,12 @@ impl App {
                             write!(output, "%{i}% ").ok();
                         }
 
+                        if pivot_keyword.keywords.is_empty() {
+                            write!(output, "):").ok();
+                        } else {
+                            writeln!(output, "):").ok();
+                        }
+
                         for i in pivot_keyword.keywords.iter() {
                             writeln!(output, "{i}").ok();
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,7 @@ impl App {
                     .ok();
                 } else {
                     //標準出力の場合
-                    let output = "The following pivot keywords were found:";
+                    let output = "\nThe following pivot keywords were found:\n";
                     write_color_buffer(
                         &BufferWriter::stdout(ColorChoice::Always),
                         None,

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -1,9 +1,11 @@
 use indexmap::{IndexMap, IndexSet};
 use lazy_static::lazy_static;
 use serde_json::Value;
+use std::fmt::Write as _;
 use std::sync::RwLock;
+use termcolor::{BufferWriter, Color, ColorChoice};
 
-use crate::detections::utils::get_serde_number_to_string;
+use crate::detections::utils::{get_serde_number_to_string, write_color_buffer};
 
 use crate::detections::configs::EventKeyAliasConfig;
 
@@ -83,6 +85,62 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
             }
         }
     });
+}
+
+//pivot_keywordsの標準出力などに関する関数たち
+pub fn create_output(
+    mut output: String,
+    key: &String,
+    pivot_keyword: &PivotKeyword,
+    place: &str,
+) -> String {
+    if place == "standard" {
+        //headers
+        let output = String::default();
+        write_color_buffer(
+            &BufferWriter::stdout(ColorChoice::Always),
+            Some(Color::Green),
+            &fmt_headers(output, key, pivot_keyword),
+            false,
+        )
+        .ok();
+
+        //keywords_results
+        let output = String::default();
+        write_color_buffer(
+            &BufferWriter::stdout(ColorChoice::Always),
+            None,
+            &fmt_keywords_results(output, pivot_keyword),
+            true,
+        )
+        .ok();
+        "".to_string()
+    } else {
+        output = fmt_headers(output, key, pivot_keyword);
+        fmt_keywords_results(output, pivot_keyword)
+    }
+}
+
+pub fn fmt_headers(mut output: String, key: &String, pivot_keyword: &PivotKeyword) -> String {
+    write!(output, "{key}: ( ").ok();
+    for i in pivot_keyword.fields.iter() {
+        write!(output, "%{i}% ").ok();
+    }
+
+    if pivot_keyword.keywords.is_empty() {
+        write!(output, "):").ok();
+    } else {
+        writeln!(output, "):").ok();
+    }
+
+    output
+}
+
+pub fn fmt_keywords_results(mut output: String, pivot_keyword: &PivotKeyword) -> String {
+    for i in pivot_keyword.keywords.iter() {
+        writeln!(output, "{i}").ok();
+    }
+    output
 }
 
 #[cfg(test)]

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -1,4 +1,4 @@
-use hashbrown::{HashMap, HashSet};
+use indexmap::{IndexMap, IndexSet};
 use lazy_static::lazy_static;
 use serde_json::Value;
 use std::sync::RwLock;
@@ -9,13 +9,13 @@ use crate::detections::configs::EventKeyAliasConfig;
 
 #[derive(Debug)]
 pub struct PivotKeyword {
-    pub keywords: HashSet<String>,
-    pub fields: HashSet<String>,
+    pub keywords: IndexSet<String>,
+    pub fields: IndexSet<String>,
 }
 
 lazy_static! {
-    pub static ref PIVOT_KEYWORD: RwLock<HashMap<String, PivotKeyword>> =
-        RwLock::new(HashMap::new());
+    pub static ref PIVOT_KEYWORD: RwLock<IndexMap<String, PivotKeyword>> =
+        RwLock::new(IndexMap::new());
 }
 
 impl Default for PivotKeyword {
@@ -27,8 +27,8 @@ impl Default for PivotKeyword {
 impl PivotKeyword {
     pub fn new() -> PivotKeyword {
         PivotKeyword {
-            keywords: HashSet::new(),
-            fields: HashSet::new(),
+            keywords: IndexSet::new(),
+            fields: IndexSet::new(),
         }
     }
 }


### PR DESCRIPTION
fix #1022 

## What Changed


   - [x] Put spaces
   - [x] Output the headings (Target IP Addresses: ( %DestAddress% %DestinationIp% ):, Subject Users: ( %SubjectUserName% ):, etc..) in the same Green color as the hayabusa logo. (No color if --no-color is specified)
   - [x] If there are no keywords, the results are just blank. Can you output the message "No keywords found." in red?
   - [x] Can you output in the same order as defined in the pivot_keywords.txt file? Now it seems random but would like to determine the order. Any other way to set the order is also fine.
   - [x] Can you move the pivot_keywords.txt file path to rules/config/pivot_keywords.txt? This is so I can update it in real time. I will create the config file there.
   - [x] change document(hayabusa-rulesレポジトリの方にconfigが移動になったので、こっちのリポジトリに追従しなくなりました。なので、デフォルト設定ファイルの中身をベタ書きするのではなく、そちらのページを参照できるように変更しました。)


## Evidence



Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.
