### PR TITLE
enable --no-color with pivot of headers

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,19 @@
 # 変更点
 
+## 2.6.0 [2023/XX/XX] "XXX"
+
+**新機能:**
+
+- XXX
+
+**改善:**
+
+- XXX
+
+**バグ修正:**
+
+- `pivot-keywords-list`コマンドで`--no-color`を使用した場合でも、結果がカラーで出力された。 (#1044) (@kazuminn)
+
 ## 2.5.0 [2023/05/07] "Golden Week Release"
 
 **改善:**
@@ -10,6 +24,7 @@
 - `csv-timeline`コマンドの出力で不要な空白文字の削除を行った。 (#1019) (@hitenkoku)
 - `update-rules`コマンド使用時にハヤブサのバージョン番号の詳細を確認するようにした (#1028) (@hitenkoku)
 - `search`コマンドの結果を時刻順にソートした。 (#1033) (@hitenkoku)
+- `pivot-keywords-list`のターミナル出力の改善。 (#1022) (@kazuminn)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.6.0 [2023/XX/XX] "XXX"
+
+**New Features:**
+
+- XXX
+
+**Enhancements:**
+
+- XXX
+
+**Bug Fixes:**
+
+- Output would be in color even if `--no-color` was used in the `pivot-keywords-list` command. (#1044) (@kazuminn)
+
 ## 2.5.0 [2023/05/07] "Golden Week Release"
 
 **Enhancements:**
@@ -10,6 +24,7 @@
 - Deleted return characters in output of the `csv-timeline` command. (#1019) (@hitenkoku)
 - Don't show new version information with the `update-rules` command when building a newer dev build. (#1028) (@hitenkoku)
 - Sorted `search` timeline order. (#1033) (@hitenkoku)
+- Enhanced `pivot-keywords-list` terminal output. (#1022) (@kazuminn)
 
 **Bug Fixes:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,7 +370,14 @@ impl App {
                             .unwrap(),
                         );
                         f.write_all(
-                            create_output(String::default(), key, pivot_keyword, "file", &stored_static).as_bytes(),
+                            create_output(
+                                String::default(),
+                                key,
+                                pivot_keyword,
+                                "file",
+                                &stored_static,
+                            )
+                            .as_bytes(),
                         )
                         .unwrap();
                     });
@@ -404,7 +411,13 @@ impl App {
                     .ok();
 
                     pivot_key_unions.iter().for_each(|(key, pivot_keyword)| {
-                        create_output(String::default(), key, pivot_keyword, "standard", &stored_static);
+                        create_output(
+                            String::default(),
+                            key,
+                            pivot_keyword,
+                            "standard",
+                            &stored_static,
+                        );
 
                         if pivot_keyword.keywords.is_empty() {
                             write_color_buffer(

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,7 +370,7 @@ impl App {
                             .unwrap(),
                         );
                         f.write_all(
-                            create_output(String::default(), key, pivot_keyword, "file").as_bytes(),
+                            create_output(String::default(), key, pivot_keyword, "file", &stored_static).as_bytes(),
                         )
                         .unwrap();
                     });
@@ -404,7 +404,7 @@ impl App {
                     .ok();
 
                     pivot_key_unions.iter().for_each(|(key, pivot_keyword)| {
-                        create_output(String::default(), key, pivot_keyword, "standard");
+                        create_output(String::default(), key, pivot_keyword, "standard", &stored_static);
 
                         if pivot_keyword.keywords.is_empty() {
                             write_color_buffer(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use hayabusa::detections::configs::{
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
 use hayabusa::detections::message::{AlertMessage, ERROR_LOG_STACK};
 use hayabusa::detections::rule::{get_detection_keys, RuleNode};
-use hayabusa::detections::utils::{check_setting_path, output_and_data_stack_for_html};
+use hayabusa::detections::utils::{
+    check_setting_path, get_writable_color, output_and_data_stack_for_html,
+};
 use hayabusa::options;
 use hayabusa::options::htmlreport::{self, HTML_REPORTER};
 use hayabusa::options::pivot::create_output;
@@ -422,7 +424,10 @@ impl App {
                         if pivot_keyword.keywords.is_empty() {
                             write_color_buffer(
                                 &BufferWriter::stdout(ColorChoice::Always),
-                                Some(Color::Red),
+                                get_writable_color(
+                                    Some(Color::Red),
+                                    stored_static.common_options.no_color,
+                                ),
                                 "No keywords found\n",
                                 true,
                             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,7 +375,7 @@ impl App {
                                 key,
                                 pivot_keyword,
                                 "file",
-                                &stored_static,
+                                stored_static,
                             )
                             .as_bytes(),
                         )
@@ -416,7 +416,7 @@ impl App {
                             key,
                             pivot_keyword,
                             "standard",
-                            &stored_static,
+                            stored_static,
                         );
 
                         if pivot_keyword.keywords.is_empty() {

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -5,9 +5,11 @@ use std::fmt::Write as _;
 use std::sync::RwLock;
 use termcolor::{BufferWriter, Color, ColorChoice};
 
-use crate::detections::utils::{get_serde_number_to_string, write_color_buffer};
+use crate::detections::utils::{
+    get_serde_number_to_string, get_writable_color, write_color_buffer,
+};
 
-use crate::detections::configs::EventKeyAliasConfig;
+use crate::detections::configs::{EventKeyAliasConfig, StoredStatic};
 
 #[derive(Debug)]
 pub struct PivotKeyword {
@@ -93,13 +95,14 @@ pub fn create_output(
     key: &String,
     pivot_keyword: &PivotKeyword,
     place: &str,
+    stored_static: &StoredStatic,
 ) -> String {
     if place == "standard" {
         //headers
         let output = String::default();
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),
-            Some(Color::Green),
+            get_writable_color(Some(Color::Green), stored_static.common_options.no_color),
             &fmt_headers(output, key, pivot_keyword),
             false,
         )


### PR DESCRIPTION
## What Changed

- Changed 1
Enabling --no-color on pivot, headers is normal color.

I want to confirm under.
A message that's "No keywords found" is always RED.
Is it OK?

## Evidence
![image](https://user-images.githubusercontent.com/7457009/236684146-dc5c5ca6-c0a1-4672-b281-8f11761eb6d9.png)


Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.
