### PR TITLE
shorten author name length

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1521,10 +1521,10 @@ fn output_detected_rule_authors(rule_author_counter: HashMap<CompactString, i128
         let mut tmp = Vec::new();
         for y in 0..div {
             if y * 4 + x < sorted_authors.len() {
-                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 40 {
+                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 { /// Limit length to 27 to prevent the table from wrapping 
                     sorted_authors[y * 4 + x].0.to_string()
                 } else {
-                    format!("{}...", &sorted_authors[y * 4 + x].0[0..37])
+                    format!("{}...", &sorted_authors[y * 4 + x].0[0..24])
                 };
                 tmp.push(format!(
                     "{} ({})",

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1521,7 +1521,7 @@ fn output_detected_rule_authors(rule_author_counter: HashMap<CompactString, i128
         let mut tmp = Vec::new();
         for y in 0..div {
             if y * 4 + x < sorted_authors.len() {
-                /// Limit length to 27 to prevent the table from wrapping
+                // Limit length to 27 to prevent the table from wrapping
                 let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 {
                     sorted_authors[y * 4 + x].0.to_string()
                 } else {

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1521,7 +1521,8 @@ fn output_detected_rule_authors(rule_author_counter: HashMap<CompactString, i128
         let mut tmp = Vec::new();
         for y in 0..div {
             if y * 4 + x < sorted_authors.len() {
-                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 { /// Limit length to 27 to prevent the table from wrapping 
+                /// Limit length to 27 to prevent the table from wrapping 
+                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 { 
                     sorted_authors[y * 4 + x].0.to_string()
                 } else {
                     format!("{}...", &sorted_authors[y * 4 + x].0[0..24])

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1521,8 +1521,8 @@ fn output_detected_rule_authors(rule_author_counter: HashMap<CompactString, i128
         let mut tmp = Vec::new();
         for y in 0..div {
             if y * 4 + x < sorted_authors.len() {
-                /// Limit length to 27 to prevent the table from wrapping 
-                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 { 
+                /// Limit length to 27 to prevent the table from wrapping
+                let filter_author = if sorted_authors[y * 4 + x].0.len() <= 27 {
                     sorted_authors[y * 4 + x].0.to_string()
                 } else {
                     format!("{}...", &sorted_authors[y * 4 + x].0[0..24])


### PR DESCRIPTION
ルール作者のテーブルの幅が最近思ったより広くなっちゃって、ターミナルを全画面にしないとテーブルが崩れてしまうケースが多いので、40文字を27文字に減らしました。
changelog更新や新しいリリースほどではないので、2.5.1に入れて、新しいバイナリを再アップロードしようと思ってますが、どうでしょうか？