### PR TITLE
Fixed no detection frequency timeline output when no-summary option is used.

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -15,6 +15,7 @@
 **バグ修正:**
 
 - `json-timeline`コマンドを利用した出力で、`MitreTactics`、`MitreTags`、`OtherTags`フィールドが出力されていない問題を修正した。 (#1062) (@hitenkoku)
+- `no-summary`オプションを使用した時にイベント頻度のタイムラインが出力されない問題を修正した。 (#1072) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 **Bug Fixes:**
 
 - `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputed in the `json-timeline` command. (#1062) (@hitenkoku)
-- Fixed no detection frequency timeline output when `no-summary` option is used. (#1072) (@hitenkoku)
+- The detection frequency timeline (`-T`) would not output when the `no-summary` option was also enabled. (#1072) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Bug Fixes:**
 
 - `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputed in the `json-timeline` command. (#1062) (@hitenkoku)
+- Fixed no detection frequency timeline output when `no-summary` option is used. (#1072) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -470,44 +470,56 @@ fn emit_csv<W: std::io::Write>(
     }
 
     disp_wtr_buf.clear();
-    if !output_option.no_summary {
-        let level_abbr: Nested<Vec<CompactString>> = Nested::from_iter(
-            vec![
-                [CompactString::from("critical"), CompactString::from("crit")].to_vec(),
-                [CompactString::from("high"), CompactString::from("high")].to_vec(),
-                [CompactString::from("medium"), CompactString::from("med ")].to_vec(),
-                [CompactString::from("low"), CompactString::from("low ")].to_vec(),
-                [
-                    CompactString::from("informational"),
-                    CompactString::from("info"),
-                ]
-                .to_vec(),
+    let level_abbr: Nested<Vec<CompactString>> = Nested::from_iter(
+        vec![
+            [CompactString::from("critical"), CompactString::from("crit")].to_vec(),
+            [CompactString::from("high"), CompactString::from("high")].to_vec(),
+            [CompactString::from("medium"), CompactString::from("med ")].to_vec(),
+            [CompactString::from("low"), CompactString::from("low ")].to_vec(),
+            [
+                CompactString::from("informational"),
+                CompactString::from("info"),
             ]
-            .iter(),
-        );
-        if !rule_author_counter.is_empty() {
-            write_color_buffer(
-                &disp_wtr,
-                get_writable_color(
-                    Some(Color::Rgb(0, 255, 0)),
-                    stored_static.common_options.no_color,
-                ),
-                "Rule Authors:",
-                false,
-            )
-            .ok();
-            write_color_buffer(
-                &disp_wtr,
-                get_writable_color(None, stored_static.common_options.no_color),
-                " ",
-                true,
-            )
-            .ok();
+            .to_vec(),
+        ]
+        .iter(),
+    );
 
-            println!();
-            output_detected_rule_authors(rule_author_counter);
-            println!();
-        }
+    if !output_option.no_summary && !rule_author_counter.is_empty() {
+        write_color_buffer(
+            &disp_wtr,
+            get_writable_color(
+                Some(Color::Rgb(0, 255, 0)),
+                stored_static.common_options.no_color,
+            ),
+            "Rule Authors:",
+            false,
+        )
+        .ok();
+        write_color_buffer(
+            &disp_wtr,
+            get_writable_color(None, stored_static.common_options.no_color),
+            " ",
+            true,
+        )
+        .ok();
+
+        println!();
+        output_detected_rule_authors(rule_author_counter);
+        println!();
+    }
+
+    let terminal_width = match terminal_size() {
+        Some((Width(w), _)) => w as usize,
+        None => 100,
+    };
+    println!();
+    if output_option.visualize_timeline {
+        _print_timeline_hist(timestamps, terminal_width, 3);
+        println!();
+    }
+
+    if !output_option.no_summary {
         disp_wtr_buf.clear();
         write_color_buffer(
             &disp_wtr,
@@ -519,17 +531,6 @@ fn emit_csv<W: std::io::Write>(
             true,
         )
         .ok();
-
-        let terminal_width = match terminal_size() {
-            Some((Width(w), _)) => w as usize,
-            None => 100,
-        };
-
-        println!();
-        if output_option.visualize_timeline {
-            _print_timeline_hist(timestamps, terminal_width, 3);
-            println!();
-        }
 
         if tl_start_end_time.0.is_some() {
             output_and_data_stack_for_html(

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1084,7 +1084,7 @@ pub struct OutputOption {
     pub html_report: Option<PathBuf>,
 
     /// Do not display Results Summary (slightly faster speed)
-    #[arg(help_heading = Some("Display Settings"), long = "no-summary", display_order = 400)]
+    #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 400)]
     pub no_summary: bool,
 }
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1084,7 +1084,7 @@ pub struct OutputOption {
     pub html_report: Option<PathBuf>,
 
     /// Do not display Results Summary (slightly faster speed)
-    #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 400)]
+    #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 401)]
     pub no_summary: bool,
 }
 


### PR DESCRIPTION
## What Changed

- Fixed no detection frequency timeline output when `no-summary` option is used.

I would appreciate it if you could review when you have time.