### PR TITLE
fixed unescaped control character c causing jq parsing errors

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -20,6 +20,7 @@
 
 - `json-timeline`コマンドを利用した出力で、`MitreTactics`、`MitreTags`、`OtherTags`フィールドが出力されていない問題を修正した。 (#1062) (@hitenkoku)
 - `no-summary`オプションを使用した時にイベント頻度のタイムラインが出力されない問題を修正した。 (#1072) (@hitenkoku)
+- `json-timline`コマンドの出力に制御文字が含まれる問題を修正した。 (#1068) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 **Bug Fixes:**
 
-- `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputed in the `json-timeline` command. (#1062) (@hitenkoku)
+- `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputted in the `json-timeline` command. (#1062) (@hitenkoku)
 - The detection frequency timeline (`-T`) would not output when the `no-summary` option was also enabled. (#1072) (@hitenkoku)
 - Escaped control character output in the `json-timeline` command. (#1068) (@hitenkoku)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputed in the `json-timeline` command. (#1062) (@hitenkoku)
 - The detection frequency timeline (`-T`) would not output when the `no-summary` option was also enabled. (#1072) (@hitenkoku)
+- Escaped control character output in the `json-timeline` command. (#1068) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputted in the `json-timeline` command. (#1062) (@hitenkoku)
 - The detection frequency timeline (`-T`) would not output when the `no-summary` option was also enabled. (#1072) (@hitenkoku)
-- Escaped control character output in the `json-timeline` command. (#1068) (@hitenkoku)
+- Control characters would not be escaped in the `json-timeline` command causing a JSON parsing error. (#1068) (@hitenkoku)
 
 ## 2.5.1 [2023/05/14] "Mothers Day Release"
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1234,12 +1234,12 @@ fn _create_json_output_format(
 ) -> String {
     let head = if key_quote_exclude_flag {
         key.chars()
-            .filter(|x| !x.is_ascii_control())
+            .filter(|x| !x.is_ascii_control() || x == &'\n')
             .collect::<CompactString>()
     } else {
         format!("\"{key}\"")
             .chars()
-            .filter(|x| !x.is_ascii_control())
+            .filter(|x| !x.is_ascii_control() || x == &'\n')
             .collect::<CompactString>()
     };
     // 4 space is json indent.
@@ -1254,7 +1254,7 @@ fn _create_json_output_format(
             head,
             value
                 .chars()
-                .filter(|x| !x.is_ascii_control())
+                .filter(|x| !x.is_ascii_control() || x == &'\n')
                 .collect::<CompactString>()
         )
     } else {
@@ -1264,7 +1264,7 @@ fn _create_json_output_format(
             head,
             value
                 .chars()
-                .filter(|x| !x.is_ascii_control())
+                .filter(|x| !x.is_ascii_control() || x == &'\n')
                 .collect::<CompactString>()
         )
     }

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1266,7 +1266,13 @@ fn _create_json_output_format(
             head,
             value
                 .chars()
-                .filter(|x| !x.is_ascii_control() || x == &'\n')
+                .map(|x| {
+                    if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                        c.to_string()
+                    } else {
+                        String::from(x)
+                    }
+                })
                 .collect::<CompactString>()
         )
     } else {
@@ -1276,7 +1282,13 @@ fn _create_json_output_format(
             head,
             value
                 .chars()
-                .filter(|x| !x.is_ascii_control() || x == &'\n')
+                .map(|x| {
+                    if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                        c.to_string()
+                    } else {
+                        String::from(x)
+                    }
+                })
                 .collect::<CompactString>()
         )
     }

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1,5 +1,5 @@
 use crate::detections::configs::{
-    Action, OutputOption, StoredStatic, CURRENT_EXE_PATH, GEOIP_DB_PARSER,
+    Action, OutputOption, StoredStatic, CONTROL_CHAT_REPLACE_MAP, CURRENT_EXE_PATH, GEOIP_DB_PARSER,
 };
 use crate::detections::message::{self, AlertMessage, LEVEL_FULL, MESSAGEKEYS};
 use crate::detections::utils::{
@@ -1234,12 +1234,24 @@ fn _create_json_output_format(
 ) -> String {
     let head = if key_quote_exclude_flag {
         key.chars()
-            .filter(|x| !x.is_ascii_control() || x == &'\n')
+            .map(|x| {
+                if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                    c.to_string()
+                } else {
+                    String::from(x)
+                }
+            })
             .collect::<CompactString>()
     } else {
         format!("\"{key}\"")
             .chars()
-            .filter(|x| !x.is_ascii_control() || x == &'\n')
+            .map(|x| {
+                if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                    c.to_string()
+                } else {
+                    String::from(x)
+                }
+            })
             .collect::<CompactString>()
     };
     // 4 space is json indent.

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1233,9 +1233,14 @@ fn _create_json_output_format(
     space_cnt: usize,
 ) -> String {
     let head = if key_quote_exclude_flag {
-        key.to_string()
+        key.chars()
+            .filter(|x| !x.is_ascii_control())
+            .collect::<CompactString>()
     } else {
         format!("\"{key}\"")
+            .chars()
+            .filter(|x| !x.is_ascii_control())
+            .collect::<CompactString>()
     };
     // 4 space is json indent.
     if let Ok(i) = i64::from_str(value) {
@@ -1243,9 +1248,25 @@ fn _create_json_output_format(
     } else if let Ok(b) = bool::from_str(value) {
         format!("{}{}: {}", " ".repeat(space_cnt), head, b)
     } else if concat_flag {
-        format!("{}{}: {}", " ".repeat(space_cnt), head, value)
+        format!(
+            "{}{}: {}",
+            " ".repeat(space_cnt),
+            head,
+            value
+                .chars()
+                .filter(|x| !x.is_ascii_control())
+                .collect::<CompactString>()
+        )
     } else {
-        format!("{}{}: \"{}\"", " ".repeat(space_cnt), head, value)
+        format!(
+            "{}{}: \"{}\"",
+            " ".repeat(space_cnt),
+            head,
+            value
+                .chars()
+                .filter(|x| !x.is_ascii_control())
+                .collect::<CompactString>()
+        )
     }
 }
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1761,7 +1761,8 @@ fn load_eventcode_info(path: &str) -> EventInfoConfig {
 
 fn create_control_chat_replace_map() -> HashMap<char, CompactString> {
     let mut ret = HashMap::new();
-    for c in '\0'..='\x1F' {
+    let replace_char = '\0'..='\x1F';
+    for c in replace_char.into_iter().filter(|x| x != &'\x0A') {
         ret.insert(
             c,
             CompactString::from(format!(
@@ -1849,15 +1850,17 @@ mod tests {
 
     #[test]
     fn test_create_control_char_replace_map() {
-        let expect: HashMap<char, CompactString> = HashMap::from_iter(('\0'..='\x1F').map(|c| {
-            (
-                c as u8 as char,
-                CompactString::from(format!(
-                    "\\u00{}",
-                    format!("{:02x}", c as u8).to_uppercase()
-                )),
-            )
-        }));
+        let mut expect: HashMap<char, CompactString> =
+            HashMap::from_iter(('\0'..='\x1F').map(|c| {
+                (
+                    c as u8 as char,
+                    CompactString::from(format!(
+                        "\\u00{}",
+                        format!("{:02x}", c as u8).to_uppercase()
+                    )),
+                )
+            }));
+        expect.remove(&'\x0A');
         let actual = create_control_chat_replace_map();
         assert_eq!(expect, actual);
     }

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -33,6 +33,8 @@ lazy_static! {
         current_exe().unwrap().parent().unwrap().to_path_buf();
     pub static ref IDS_REGEX: Regex =
         Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
+    pub static ref CONTROL_CHAT_REPLACE_MAP: HashMap<char, CompactString> =
+        create_control_chat_replace_map();
 }
 
 pub struct ConfigReader {
@@ -1755,6 +1757,20 @@ fn load_eventcode_info(path: &str) -> EventInfoConfig {
         );
     });
     config
+}
+
+fn create_control_chat_replace_map() -> HashMap<char, CompactString> {
+    let mut ret = HashMap::new();
+    for c in '\0'..='\x1F' {
+        ret.insert(
+            c,
+            CompactString::from(format!(
+                "\\u00{}",
+                format!("{:02x}", c as u8).to_uppercase()
+            )),
+        );
+    }
+    ret
 }
 
 #[cfg(test)]

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1777,7 +1777,10 @@ fn create_control_chat_replace_map() -> HashMap<char, CompactString> {
 mod tests {
     use crate::detections::configs;
     use chrono::{DateTime, Utc};
-    use hashbrown::HashSet;
+    use compact_str::CompactString;
+    use hashbrown::{HashMap, HashSet};
+
+    use super::create_control_chat_replace_map;
 
     //     #[test]
     //     #[ignore]
@@ -1842,5 +1845,20 @@ mod tests {
         for contents in expect.iter() {
             assert!(ret.contains(&contents.to_string()));
         }
+    }
+
+    #[test]
+    fn test_create_control_char_replace_map() {
+        let expect: HashMap<char, CompactString> = HashMap::from_iter(('\0'..='\x1F').map(|c| {
+            (
+                c as u8 as char,
+                CompactString::from(format!(
+                    "\\u00{}",
+                    format!("{:02x}", c as u8).to_uppercase()
+                )),
+            )
+        }));
+        let actual = create_control_chat_replace_map();
+        assert_eq!(expect, actual);
     }
 }


### PR DESCRIPTION
## What Changed

- fixed unescaped control character c causing jq parsing errors

I would appreciate it if you could review when you have time.
