### PR TITLE
perf: Improve output speed by caching author_list

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -321,7 +321,7 @@ fn emit_csv<W: std::io::Write>(
             )
             .unwrap_or(&0) as usize
     };
-
+    let mut author_list_cache: HashMap<CompactString, Nested<String>> = HashMap::new();
     for (message_idx, time) in MESSAGEKEYS
         .iter()
         .map(|x| x.key().to_owned())
@@ -423,8 +423,14 @@ fn emit_csv<W: std::io::Write>(
             // 各種集計作業
             if !output_option.no_summary {
                 let level_suffix = get_level_suffix(detect_info.level.as_str());
-
-                let author_list = extract_author_name(&detect_info.rulepath, stored_static);
+                let author_list = match author_list_cache.get(&detect_info.rulepath) {
+                    None => {
+                        let x = extract_author_name(&detect_info.rulepath, stored_static);
+                        author_list_cache.insert(detect_info.rulepath.clone(), x.clone());
+                        x
+                    }
+                    Some(x) => x.clone(),
+                };
                 let author_str = author_list.iter().join(", ");
                 if !detected_rule_files.contains(&detect_info.rulepath) {
                     detected_rule_files.insert(detect_info.rulepath.to_owned());

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -423,14 +423,10 @@ fn emit_csv<W: std::io::Write>(
             // 各種集計作業
             if !output_option.no_summary {
                 let level_suffix = get_level_suffix(detect_info.level.as_str());
-                let author_list = match author_list_cache.get(&detect_info.rulepath) {
-                    None => {
-                        let x = extract_author_name(&detect_info.rulepath, stored_static);
-                        author_list_cache.insert(detect_info.rulepath.clone(), x.clone());
-                        x
-                    }
-                    Some(x) => x.clone(),
-                };
+                let author_list = author_list_cache
+                    .entry(detect_info.rulepath.clone())
+                    .or_insert_with(|| extract_author_name(&detect_info.rulepath, stored_static))
+                    .clone();
                 let author_str = author_list.iter().join(", ");
                 if !detected_rule_files.contains(&detect_info.rulepath) {
                     detected_rule_files.insert(detect_info.rulepath.to_owned());


### PR DESCRIPTION
## What Changed

- Related #1088
- Improve output speed by caching author_list when output
  - Once the author name is read from the file, it will be read from the cache from the second time onwards.
  - The result is less file IO and more speed.

This fix may not improve memory usage. In that case, it will be handled as a separate issue.
I would appreciate it if you could review🙏

## Evidence
### Environment 
- OS: macOS montery version 13.1
- Hard: Macbook Air(M1, 2020) , Memory 8GB, Core 8

### Test(all-evtx.tgz(6.1GB))
I confirmed that there is no difference result file and output speed improved.

main
```
fukusuke@fukusukenoMacBook-Air hayabusa-2.5.1-all-platforms % ./hayabusa csv-timeline -d ../all-evtx -o bug.csv --debug

╔╗ ╔╦═══╦╗  ╔╦═══╦══╗╔╗ ╔╦═══╦═══╗
║║ ║║╔═╗║╚╗╔╝║╔═╗║╔╗║║║ ║║╔═╗║╔═╗║
║╚═╝║║ ║╠╗╚╝╔╣║ ║║╚╝╚╣║ ║║╚══╣║ ║║
║╔═╗║╚═╝║╚╗╔╝║╚═╝║╔═╗║║ ║╠══╗║╚═╝║
║║ ║║╔═╗║ ║║ ║╔═╗║╚═╝║╚═╝║╚═╝║╔═╗║
╚╝ ╚╩╝ ╚╝ ╚╝ ╚╝ ╚╩═══╩═══╩═══╩╝ ╚╝
   by Yamato Security

Start time: 2023/06/08 00:05

Total event log files: 1858
Total file size: 6.1 GB

Loading detections rules. Please wait.

Excluded rules: 30
Noisy rules: 7 (Disabled)

Deprecated rules: 166 (4.51%) (Disabled)
Experimental rules: 1965 (53.37%)
Stable rules: 225 (6.11%)
Test rules: 1488 (40.41%)
Undefined rules: 4 (0.11%)
Unsupported rules: 43 (1.17%) (Disabled)

Hayabusa rules: 152
Sigma rules: 3530
Total enabled detection rules: 3682

Output profile: standard

Scanning in progress. Please wait.

1858 / 1858 [=======================================================================================================================] 100.00 %

Scanning finished. Please wait while the results are being saved.

Rule Authors:

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Zach Mathis (71)                  frack113 (29)              Florian Roth (17)                 Nasreddine Bencherchali (15)    │
│ oscd.community (12)               Roberto Rodriguez (6)      Roberto Rodriguez @Cyb3r... (6)   OTR (5)                         │
│ Tim Shelton (3)                   Thomas Patzke (3)          Timur Zinniatullin (2)            SOC Prime (2)                   │
│ Daniil Yugoslavskiy (2)           Teymur Kheirkhabarov (2)   Alexandr Yampolskyi (2)           @gott_cyber (1)                 │
│ Connor Martin (1)                 Jonhnathan Ribeiro (1)     James Dickenson (1)               Ecco (1)                        │
│ James Pemberton @4A616D6573 (1)   Sherif Eldeeb (1)          Cybex (1)                         Endgame (1)                     │
│ Open Threat Research (1)          Yusuke Matsui (1)          SCYTHE @scythe_io (1)             D3F7A5105 (1)                   │
│ Timur Zinniatullin oscd.... (1)   @0xrawsec (1)              Dimitrios Slamaris (1)            Gleb Sukhodolskiy (1)           │
│ Jakob Weinzettl (1)               Ilyas Ochkov (1)           Aleksey Potapov (1)               Michael Haag (1)                │
│ JHasenbusch (1)                   Andreas Hunkeler (1)       Sander Wiebing (1)                FPT.EagleEye (1)                │
│ Dmitry Uchakin (1)                Mark Russinovich (1)       Tim Rauch (1)                     Christopher Peacock @sec... (1) │
│ Oddvar Moe (1)                    Mark Woan (1)              James Pemberton@4A616D65... (1)   Matthew Green @mgreen27 (1)     │
│ Bhabesh Raj (1)                   @neu5ron (1)                                                                                 │
╰─────────────────────────────────╌──────────────────────────╌─────────────────────────────────╌─────────────────────────────────╯

Results Summary:
First Timestamp: 2009-07-14 00:56:45.074 -04:00
Last Timestamp: 2022-09-18 10:37:13.088 -04:00

Events with hits / Total events: 1,594,166 / 4,817,181 (Data reduction: 3,223,015 events (66.91%))

Total | Unique detections: 1,627,328 | 156
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 11,634 (0.71%) | 17 (10.90%)
Total | Unique medium detections: 11,016 (0.68%) | 43 (27.56%)
Total | Unique low detections: 1,054,591 (64.81%) | 46 (29.49%)
Total | Unique informational detections: 550,087 (33.80%) | 50 (32.05%)

Dates with most total detections:
critical: n/a, high: 2022-09-18 (3,425), medium: 2022-02-08 (4,670), low: 2022-09-18 (911,357), informational: 2022-03-01 (205,934)

Top 5 computers with most unique detections:
critical: n/a
high: evtx-PC (3), evtx-PC (3), DESKTOP-A8CALR3 (2), DESKTOP-A8CALR3 (2), DESKTOP-6D0DBMB (2)
medium: Agamemnon (7), WIN-TKC15D7KHUR (7), DESKTOP-A8CALR3 (6), DESKTOP-6D0DBMB (6), Agamemnon (6)
low: DESKTOP-A8CALR3 (9), DESKTOP-6D0DBMB (9), DESKTOP-6D0DBMB (8), Agamemnon (7), evtx-PC (6)
informational: DESKTOP-6D0DBMB (31), DESKTOP-A8CALR3 (30), WIN-TKC15D7KHUR (30), WIN-FPV0DSIC9O6.sigma.fr (26), Agamemnon (25)

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Top critical alerts:                        Top high alerts:                                                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                                         File Creation Date Changed to Another Year (10,490)                 │
│ n/a                                         Windows Shell/Scripting Application File Write to Suspicio... (991) │
│ n/a                                         Proc Exec (Non-Exe Filetype) (45)                                   │
│ n/a                                         SysmonEnte Usage (33)                                               │
│ n/a                                         Disabling Windows Event Auditing (29)                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top medium alerts:                          Top low alerts:                                                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Raw Access Read (8,544)                     Proc Access (1,020,252)                                             │
│ EVTX Created In Uncommon Location (986)     Possible Timestomping (31,784)                                      │
│ Proc Injection (673)                        System Drawing DLL Load (1,030)                                     │
│ Process Ran With High Privilege (191)       Creation of an Executable by an Executable (382)                    │
│ Use Short Name Path in Command Line (133)   Firewall Rule Modified In The Windows Firewall Exception L... (254) │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top informational alerts:                                                                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ File Created (422,037)                      Pipe Created (9,044)                                                │
│ File Deleted (53,696)                       Net Conn (8,755)                                                    │
│ Proc Exec (18,780)                          DNS Query (5,108)                                                   │
│ Pipe Conn (17,062)                          WMI Provider Started (681)                                          │
│ Proc Terminated (12,388)                    WMI Modules Loaded (342)                                            │
╰───────────────────────────────────────────╌─────────────────────────────────────────────────────────────────────╯

Saved file: bug.csv (601.2 MB)

Elapsed time: 00:07:51.136
Rule Parse Processing Time: 00:00:01.155
Analysis Processing Time: 00:06:37.199
Output Processing Time: 00:01:12.780

Memory usage stats:
heap stats:     peak       total       freed     current        unit       count
  reserved:     4.0 GiB     4.0 GiB     0           4.0 GiB
 committed:     1.0 GiB     4.0 GiB   201.8 GiB  -197.8 GiB                          ok
     reset:     0
    purged:    22.7 GiB
   touched:    64.2 KiB     8.6 MiB    53.0 GiB   -53.0 GiB                          ok
  segments:    16         138         130           8                                not all freed!
-abandoned:     0           0           0           0                                ok
   -cached:     0           0           0           0                                ok
     pages:     0           0         729.1 Ki   -729.1 Ki                           ok
-abandoned:     0           0           0           0                                ok
 -extended:     0
 -noretire:     0
     mmaps:     0
   commits:     0
    resets:     0
    purges:    13.1 Ki
   threads:    16          16           0          16                                not all freed!
  searches:     0.0 avg
numa nodes:     1
   elapsed:   471.148 s
   process: user: 2213.333 s, system: 40.050 s, faults: 25, rss: 3.3 GiB, commit: 1.0 GiB
```

This PR
```
fukusuke@fukusukenoMacBook-Air hayabusa-2.5.1-all-platforms % ./hayabusa csv-timeline -d ../all-evtx -o new.csv --debug

╔╗ ╔╦═══╦╗  ╔╦═══╦══╗╔╗ ╔╦═══╦═══╗
║║ ║║╔═╗║╚╗╔╝║╔═╗║╔╗║║║ ║║╔═╗║╔═╗║
║╚═╝║║ ║╠╗╚╝╔╣║ ║║╚╝╚╣║ ║║╚══╣║ ║║
║╔═╗║╚═╝║╚╗╔╝║╚═╝║╔═╗║║ ║╠══╗║╚═╝║
║║ ║║╔═╗║ ║║ ║╔═╗║╚═╝║╚═╝║╚═╝║╔═╗║
╚╝ ╚╩╝ ╚╝ ╚╝ ╚╝ ╚╩═══╩═══╩═══╩╝ ╚╝
   by Yamato Security

Start time: 2023/06/07 23:44

Total event log files: 1858
Total file size: 6.1 GB

Loading detections rules. Please wait.

Excluded rules: 30
Noisy rules: 7 (Disabled)

Deprecated rules: 166 (4.51%) (Disabled)
Experimental rules: 1965 (53.37%)
Stable rules: 225 (6.11%)
Test rules: 1488 (40.41%)
Undefined rules: 4 (0.11%)
Unsupported rules: 43 (1.17%) (Disabled)

Hayabusa rules: 152
Sigma rules: 3530
Total enabled detection rules: 3682

Output profile: standard

Scanning in progress. Please wait.

1858 / 1858 [=======================================================================================================================] 100.00 %

Scanning finished. Please wait while the results are being saved.

Rule Authors:

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Zach Mathis (71)                  frack113 (29)              Florian Roth (17)                 Nasreddine Bencherchali (15)    │
│ oscd.community (12)               Roberto Rodriguez (6)      Roberto Rodriguez @Cyb3r... (6)   OTR (5)                         │
│ Tim Shelton (3)                   Thomas Patzke (3)          Timur Zinniatullin (2)            SOC Prime (2)                   │
│ Daniil Yugoslavskiy (2)           Teymur Kheirkhabarov (2)   Alexandr Yampolskyi (2)           @gott_cyber (1)                 │
│ Connor Martin (1)                 Jonhnathan Ribeiro (1)     James Dickenson (1)               Ecco (1)                        │
│ James Pemberton @4A616D6573 (1)   Sherif Eldeeb (1)          Cybex (1)                         Endgame (1)                     │
│ Open Threat Research (1)          Yusuke Matsui (1)          SCYTHE @scythe_io (1)             D3F7A5105 (1)                   │
│ Timur Zinniatullin oscd.... (1)   @0xrawsec (1)              Dimitrios Slamaris (1)            Gleb Sukhodolskiy (1)           │
│ Jakob Weinzettl (1)               Ilyas Ochkov (1)           Aleksey Potapov (1)               Michael Haag (1)                │
│ JHasenbusch (1)                   Andreas Hunkeler (1)       Sander Wiebing (1)                FPT.EagleEye (1)                │
│ Dmitry Uchakin (1)                Mark Russinovich (1)       Tim Rauch (1)                     Christopher Peacock @sec... (1) │
│ Oddvar Moe (1)                    Mark Woan (1)              James Pemberton@4A616D65... (1)   Matthew Green @mgreen27 (1)     │
│ Bhabesh Raj (1)                   @neu5ron (1)                                                                                 │
╰─────────────────────────────────╌──────────────────────────╌─────────────────────────────────╌─────────────────────────────────╯

Results Summary:
First Timestamp: 2009-07-14 00:56:45.074 -04:00
Last Timestamp: 2022-09-18 10:37:13.088 -04:00

Events with hits / Total events: 1,594,166 / 4,817,181 (Data reduction: 3,223,015 events (66.91%))

Total | Unique detections: 1,627,328 | 156
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 11,634 (0.71%) | 17 (10.90%)
Total | Unique medium detections: 11,016 (0.68%) | 43 (27.56%)
Total | Unique low detections: 1,054,591 (64.81%) | 46 (29.49%)
Total | Unique informational detections: 550,087 (33.80%) | 50 (32.05%)

Dates with most total detections:
critical: n/a, high: 2022-09-18 (3,425), medium: 2022-02-08 (4,670), low: 2022-09-18 (911,357), informational: 2022-03-01 (205,934)

Top 5 computers with most unique detections:
critical: n/a
high: evtx-PC (3), evtx-PC (3), DESKTOP-A8CALR3 (2), DESKTOP-A8CALR3 (2), DESKTOP-6D0DBMB (2)
medium: Agamemnon (7), WIN-TKC15D7KHUR (7), DESKTOP-A8CALR3 (6), DESKTOP-6D0DBMB (6), Agamemnon (6)
low: DESKTOP-A8CALR3 (9), DESKTOP-6D0DBMB (9), DESKTOP-6D0DBMB (8), Agamemnon (7), evtx-PC (6)
informational: DESKTOP-6D0DBMB (31), DESKTOP-A8CALR3 (30), WIN-TKC15D7KHUR (30), WIN-FPV0DSIC9O6.sigma.fr (26), Agamemnon (25)

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Top critical alerts:                        Top high alerts:                                                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                                         File Creation Date Changed to Another Year (10,490)                 │
│ n/a                                         Windows Shell/Scripting Application File Write to Suspicio... (991) │
│ n/a                                         Proc Exec (Non-Exe Filetype) (45)                                   │
│ n/a                                         SysmonEnte Usage (33)                                               │
│ n/a                                         Disabling Windows Event Auditing (29)                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top medium alerts:                          Top low alerts:                                                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Raw Access Read (8,544)                     Proc Access (1,020,252)                                             │
│ EVTX Created In Uncommon Location (986)     Possible Timestomping (31,784)                                      │
│ Proc Injection (673)                        System Drawing DLL Load (1,030)                                     │
│ Process Ran With High Privilege (191)       Creation of an Executable by an Executable (382)                    │
│ Use Short Name Path in Command Line (133)   Firewall Rule Modified In The Windows Firewall Exception L... (254) │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top informational alerts:                                                                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ File Created (422,037)                      Pipe Created (9,044)                                                │
│ File Deleted (53,696)                       Net Conn (8,755)                                                    │
│ Proc Exec (18,780)                          DNS Query (5,108)                                                   │
│ Pipe Conn (17,062)                          WMI Provider Started (681)                                          │
│ Proc Terminated (12,388)                    WMI Modules Loaded (342)                                            │
╰───────────────────────────────────────────╌─────────────────────────────────────────────────────────────────────╯

Saved file: new.csv (601.2 MB)

Elapsed time: 00:06:32.975
Rule Parse Processing Time: 00:00:01.150
Analysis Processing Time: 00:06:23.481
Output Processing Time: 00:00:08.343

Memory usage stats:
heap stats:     peak       total       freed     current        unit       count
  reserved:     4.0 GiB     4.0 GiB     0           4.0 GiB
 committed:     1.0 GiB     4.0 GiB   207.5 GiB  -203.5 GiB                          ok
     reset:     0
    purged:    22.5 GiB
   touched:    64.2 KiB     8.7 MiB    53.0 GiB   -53.0 GiB                          ok
  segments:    16         140         132           8                                not all freed!
-abandoned:     0           0           0           0                                ok
   -cached:     0           0           0           0                                ok
     pages:     0           0         728.6 Ki   -728.6 Ki                           ok
-abandoned:     0           0           0           0                                ok
 -extended:     0
 -noretire:     0
     mmaps:     0
   commits:     0
    resets:     0
    purges:    12.8 Ki
   threads:    16          16           0          16                                not all freed!
  searches:     0.0 avg
numa nodes:     1
   elapsed:   392.980 s
   process: user: 2108.242 s, system: 26.089 s, faults: 17, rss: 2.8 GiB, commit: 1.0 GiB
```