### PR TITLE
Feature/1067 word wrap in cell when event title is long

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,7 @@
 - `csv-timeline`、`json-timeline`、`metrics`、`logon-summary`、`search`コマンドに対して、出力ファイルを上書きするための`-C, --clobber`オプションを追加した。 (#1063) (@YamatoSecurity, @hitenkoku)
 - HTML内にCSSと画像を組み込んだ。 (#1078) (@hitenkoku, 提案者: @joswr1ght)
 - 出力時の速度向上。 (#1088) (@hitenkoku, @fukusuket)
+- `metrics`コマンドは、テーブルが正しくレンダリングされるように、ワードラップを行うようになった。 (#1067) (@garigariganzy)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added the `-C, --clobber` option to overwrite existing output files in `csv-timeline`, `json-timeline`, `metrics`, `logon-summary`, and `search` commands. (#1063) (@YamatoSecurity, @hitenkoku)
 - Made the HTML report portable by embedding the images and inlining CSS. (#1078) (@hitenkoku, thanks for the suggestion from @joswr1ght)
 - Speed improvements in the output. (#1088) (@hitenkoku, @fukusuket)
+- The `metrics` command now performs word wrapping to make sure the table gets rendered correctly. (#1067) (@garigariganzy)
 
 **Bug Fixes:**
 

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
@@ -185,7 +186,7 @@ impl Timeline {
             UpperBoundary(Fixed(9)),  // Maximum number of characters for "percent"
             UpperBoundary(Fixed(20)), // Maximum number of characters for "Channel"
             UpperBoundary(Fixed(12)), // Maximum number of characters for "ID"
-            UpperBoundary(Fixed(terminal_width - 55)), // Maximum number of characters for "Event"
+            UpperBoundary(Fixed(cmp::max(terminal_width - 55, 45))), // Maximum number of characters for "Event"
         ];
         for (column_index, column) in stats_tb.column_iter_mut().enumerate() {
             let constraint = constraints.get(column_index).unwrap();

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -147,6 +147,10 @@ impl Timeline {
         }
 
         let header = vec!["Total", "%", "Channel", "ID", "Event"];
+        let mut header_cells = vec![];
+        for header_str in &header {
+            header_cells.push(Cell::new(header_str).set_alignment(CellAlignment::Center));
+        }
         if let Some(ref mut w) = wtr {
             w.write_record(&header).ok();
         }
@@ -155,7 +159,8 @@ impl Timeline {
         stats_tb
             .load_preset(UTF8_FULL)
             .apply_modifier(UTF8_ROUND_CORNERS);
-        stats_tb.set_header(header);
+
+        stats_tb.set_header(header_cells);
 
         // 集計件数でソート
         let mut mapsorted: Vec<_> = self.stats.stats_list.iter().collect();

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -148,6 +148,8 @@ impl Timeline {
         let mut stats_tb = Table::new();
         stats_tb
             .load_preset(UTF8_FULL)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_width(100)
             .apply_modifier(UTF8_ROUND_CORNERS);
         stats_tb.set_header(header);
 
@@ -330,6 +332,8 @@ impl Timeline {
         let mut logins_stats_tb = Table::new();
         logins_stats_tb
             .load_preset(UTF8_FULL)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_width(100)
             .apply_modifier(UTF8_ROUND_CORNERS);
         logins_stats_tb.set_header(&header);
         // 集計するログオン結果を設定

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -332,8 +332,6 @@ impl Timeline {
         let mut logins_stats_tb = Table::new();
         logins_stats_tb
             .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_width(100)
             .apply_modifier(UTF8_ROUND_CORNERS);
         logins_stats_tb.set_header(&header);
         // 集計するログオン結果を設定

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -709,7 +709,7 @@ mod tests {
         );
         // Event column is defined in rules/config/channel_eid_info.txt
         let expect_records = vec![vec!["1", "100.0%", "Sec", "4625", "Logon failure"]];
-        let expect = "Count,Percent,Channel,ID,Event\n".to_owned()
+        let expect = "Total,%,Channel,ID,Event\n".to_owned()
             + &expect_records.join(&"\n").join(",").replace(",\n,", "\n")
             + "\n";
         match read_to_string("./test_tm_stats.csv") {

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -176,7 +176,7 @@ impl Timeline {
         }
         stats_tb.add_rows(stats_msges.iter());
         let terminal_width = match terminal_size() {
-            Some((Width(w), _)) => w as u16,
+            Some((Width(w), _)) => w,
             None => 100,
         };
 


### PR DESCRIPTION
## What Changed

- Changed 1
Fixed the metrics content only to dynamically wrap to maintain the specified table width (100 characters).

## Evidence
![1067_metrics_image](https://github.com/Yamato-Security/hayabusa/assets/25587634/f7d1d9d1-5579-410d-a231-4c38a0836b16)

Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.
