### PR TITLE
fixed `metrics` and `logon-summary` records and `csv-timline` show different total event records

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,10 +7,11 @@
 **改善:**
 
 - 新しいログ形式の`.evtx`を使用するWindows Vistaがリリースされた2007年1月31日以前のタイムスタンプを持つ破損されたイベントレコードを無視するようにした。(#1102) (@fukusuket)
+- `metrics`コマンドで`--output`オプションを指定した時に標準出力に結果を表示しないように変更した。 (#1099) (@hitenkoku)
 
 **バグ修正:**
 
-- `metrics`と`logon-summary`コマンドのレコード数の表示が`csv-timeline`のコマンドでのレコード数の表示と異なっている状態を修正した (#1105) (@hitenkoku)
+- `metrics`と`logon-summary`コマンドのレコード数の表示が`csv-timeline`のコマンドでのレコード数の表示と異なっている状態を修正した。 (#1105) (@hitenkoku)
 
 ## 2.6.0 [2023/06/16] "Ajisai Release"
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,8 @@
 
 **バグ修正:**
 
+- `metrics`と`logon-summary`コマンドのレコード数の表示が`csv-timeline`のコマンドでのレコード数の表示と異なっている状態を修正した (#1105) (@hitenkoku)
+
 ## 2.6.0 [2023/06/16] "Ajisai Release"
 
 **新機能:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 **Bug Fixes:**
 
-- Fixed `metrics` and `logon-summary` commands differed from the number of records in the `csv-timeline` command. (#1105) (@hitenkoku)
+- The total number of records being displayed in the `metrics` and `logon-summary` commands differed from the `csv-timeline` command. (#1105) (@hitenkoku)
 
 ## 2.6.0 [2023/06/16] "Ajisai Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Bug Fixes:**
 
+- Fixed `metrics` and `logon-summary` commands differed from the number of records in the `csv-timeline` command. (#1105) (@hitenkoku)
+
 ## 2.6.0 [2023/06/16] "Ajisai Release"
 
 **New Features:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Enhancements:**
 
 - Ignore corrupted event records with timestamps before 2007/1/31 when Windows Vista was released with the new `.evtx` log format. (#1102) (@fukusuket)
+- Modified don't output to terminal when `--output` is set in `metrics` command. (#1099) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1184,7 +1184,7 @@ impl App {
                 detection = detection.start(&self.rt, records_per_detect);
             }
         }
-        tl.stats.total += record_cnt;
+        tl.total_record_cnt += record_cnt;
         (detection, record_cnt, tl)
     }
 
@@ -1329,7 +1329,7 @@ impl App {
                 detection = detection.start(&self.rt, records_per_detect);
             }
         }
-        tl.stats.total += record_cnt;
+        tl.total_record_cnt += record_cnt;
         (detection, record_cnt, tl)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1176,7 +1176,6 @@ impl App {
 
             // timeline機能の実行
             tl.start(&records_per_detect, stored_static);
-
             if !(stored_static.metrics_flag
                 || stored_static.logon_summary_flag
                 || stored_static.search_flag)
@@ -1185,7 +1184,7 @@ impl App {
                 detection = detection.start(&self.rt, records_per_detect);
             }
         }
-
+        tl.stats.total += record_cnt;
         (detection, record_cnt, tl)
     }
 
@@ -1330,7 +1329,7 @@ impl App {
                 detection = detection.start(&self.rt, records_per_detect);
             }
         }
-
+        tl.stats.total += record_cnt;
         (detection, record_cnt, tl)
     }
 

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -145,6 +145,7 @@ impl EventMetrics {
                 check_start_end_time(&evttime);
             };
         }
+        self.total += records.len();
     }
 
     /// EventIDで集計

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -145,7 +145,6 @@ impl EventMetrics {
                 check_start_end_time(&evttime);
             };
         }
-        self.total += records.len();
     }
 
     /// EventIDで集計

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -29,6 +29,7 @@ use hashbrown::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
 pub struct Timeline {
+    pub total_record_cnt: usize,
     pub stats: EventMetrics,
     pub event_search: EventSearch,
 }
@@ -57,6 +58,7 @@ impl Timeline {
         );
         let search = EventSearch::new(filepath, search_result);
         Timeline {
+            total_record_cnt: 0,
             stats: statistic,
             event_search: search,
         }
@@ -99,7 +101,7 @@ impl Timeline {
         let mut sammsges: Nested<String> = Nested::new();
         let total_event_record = format!(
             "\n\nTotal Event Records: {}\n",
-            self.stats.total.to_formatted_string(&Locale::en)
+            self.total_record_cnt.to_formatted_string(&Locale::en)
         );
         let mut wtr;
         let target;
@@ -213,7 +215,7 @@ impl Timeline {
         let mut sammsges: Vec<String> = Vec::new();
         let total_event_record = format!(
             "\n\nTotal Event Records: {}\n",
-            self.stats.total.to_formatted_string(&Locale::en)
+            self.total_record_cnt.to_formatted_string(&Locale::en)
         );
         if let Action::LogonSummary(logon_summary_option) =
             &stored_static.config.action.as_ref().unwrap()

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -202,7 +202,9 @@ impl Timeline {
             let constraint = constraints.get(column_index).unwrap();
             column.set_constraint(*constraint);
         }
-        println!("{stats_tb}");
+        if wtr.is_none() {
+            println!("{stats_tb}");
+        }
     }
 
     /// ログオン統計情報のメッセージ出力関数

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -18,6 +18,7 @@ use compact_str::CompactString;
 use csv::WriterBuilder;
 use downcast_rs::__std::process;
 use nested::Nested;
+use num_format::{Locale, ToFormattedString};
 use termcolor::{BufferWriter, Color, ColorChoice};
 use terminal_size::terminal_size;
 use terminal_size::Width;
@@ -95,7 +96,10 @@ impl Timeline {
     ) {
         // 出力メッセージ作成
         let mut sammsges: Nested<String> = Nested::new();
-        let total_event_record = format!("\n\nTotal Event Records: {}\n", self.stats.total);
+        let total_event_record = format!(
+            "\n\nTotal Event Records: {}\n",
+            self.stats.total.to_formatted_string(&Locale::en)
+        );
         let mut wtr;
         let target;
 
@@ -204,7 +208,10 @@ impl Timeline {
     pub fn tm_logon_stats_dsp_msg(&mut self, stored_static: &StoredStatic) {
         // 出力メッセージ作成
         let mut sammsges: Vec<String> = Vec::new();
-        let total_event_record = format!("\n\nTotal Event Records: {}\n", self.stats.total);
+        let total_event_record = format!(
+            "\n\nTotal Event Records: {}\n",
+            self.stats.total.to_formatted_string(&Locale::en)
+        );
         if let Action::LogonSummary(logon_summary_option) =
             &stored_static.config.action.as_ref().unwrap()
         {

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -63,14 +63,15 @@ impl Timeline {
     }
 
     pub fn start(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
-        self.stats.evt_stats_start(records, stored_static);
-        self.stats.logon_stats_start(
-            records,
-            stored_static.logon_summary_flag,
-            &stored_static.eventkey_alias,
-        );
-
-        if stored_static.search_flag {
+        if stored_static.metrics_flag {
+            self.stats.evt_stats_start(records, stored_static);
+        } else if stored_static.logon_summary_flag {
+            self.stats.logon_stats_start(
+                records,
+                stored_static.logon_summary_flag,
+                &stored_static.eventkey_alias,
+            );
+        } else if stored_static.search_flag {
             self.event_search.search_start(
                 records,
                 stored_static


### PR DESCRIPTION
## What Changed

- fixed `metrics` and `logon-summary` records and `csv-timline` show different total event records.
- modified not to output standard output when the output option is set in metrics.  (1c9d00a1a5099ee578efefb22e668ee502b741d6)

I would appreciate it if you could review when you have time.