### PR TITLE
fixed result summary table breaks

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -779,7 +779,7 @@ fn emit_csv<W: std::io::Write>(
             &level_abbr,
             &mut html_output_stock,
             stored_static,
-            cmp::min((terminal_width / 2) - 10, 200),
+            cmp::min((terminal_width / 2) - 15, 200),
         );
         println!();
         if html_output_flag {


### PR DESCRIPTION
## What Changed

- fixed result summary table breaks

## Evidence

<img width="783" alt="image" src="https://github.com/Yamato-Security/hayabusa/assets/2350416/a26596d6-30a0-43ce-aafe-d22f79b396a8">

I would appreciate it if you could review when you have time.