### PR TITLE
Fixed `--timeline-start` and `--timeline-end` do not work correctly with `json-timeline` command.

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -30,6 +30,7 @@
 
 - `metrics`と`logon-summary`コマンドのレコード数の表示が`csv-timeline`のコマンドでのレコード数の表示と異なっている状態を修正した。 (#1105) (@hitenkoku)
 - パスの代わりにルールIDでルール数を数えるように変更した。 (#1113) (@hitenkoku)
+- `json-timeline`コマンドで`--timeline-start`と`--timeline-end`オプションが動作しなかったのを修正した。 (#1148) (@hitenkoku)
 
 **その他:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - The total number of records being displayed in the `metrics` and `logon-summary` commands differed from the `csv-timeline` command. (#1105) (@hitenkoku)
 - Changed rule count by rule ID instead of path. (#1113) (@hitenkoku)
+- Fixed `--timeline-start` and `--timeline-end` do not work correctly with `json-timeline` command. (#1148) (@hitenkoku)
 
 **Other:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - The total number of records being displayed in the `metrics` and `logon-summary` commands differed from the `csv-timeline` command. (#1105) (@hitenkoku)
 - Changed rule count by rule ID instead of path. (#1113) (@hitenkoku)
-- Fixed `--timeline-start` and `--timeline-end` do not work correctly with `json-timeline` command. (#1148) (@hitenkoku)
+- `--timeline-start` and `--timeline-end` were not working correctly with the `json-timeline` command. (#1148) (@hitenkoku)
 
 **Other:**
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1683,7 +1683,7 @@ impl TargetEventTime {
                     "start-timeline field: the timestamp format is not correct.",
                 );
                 let end_time = get_time(
-                    option.output_options.start_timeline.as_ref(),
+                    option.output_options.end_timeline.as_ref(),
                     "end-timeline field: the timestamp format is not correct.",
                 );
                 Self::set(parse_success_flag, start_time, end_time)


### PR DESCRIPTION
## What Changed

- Fixed `--timeline-start` and `--timeline-end` do not work correctly with `json-timeline` command. 

I would appreciate it if you could review when you have time.