### PR TITLE
fix: Update GitHub Actions for Integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'windows-2019']
+        os: ['ubuntu-22.04', 'windows-2019']
 
     steps:
       - name: Checkout main
@@ -28,17 +28,27 @@ jobs:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
 
+      - name: Set up Rust toolchain
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
       - name: help
         run: cd main && cargo run --release -- help
 
       - name: update-rules
         run: cd main && cargo run --release -- update-rules -q
 
+      - name: computer-metrics
+        run: cd main && cargo run --release -- computer-metrics -d ../hayabusa-sample-evtx -q
+
       - name: csv-timeline
         run: cd main && cargo run --release -- csv-timeline -d ../hayabusa-sample-evtx -o out.csv -q
 
       - name: csv-timeline(-p super-verbose)
         run: cd main && cargo run --release -- csv-timeline -d ../hayabusa-sample-evtx -o out-s.csv -p super-verbose -q
+
+      - name: eid-metrics
+        run: cd main && cargo run --release -- eid-metrics -d ../hayabusa-sample-evtx -q
 
       - name: json-timeline
         run: cd main && cargo run --release -- json-timeline -d ../hayabusa-sample-evtx -o out.json -q
@@ -49,20 +59,23 @@ jobs:
       - name: json-timeline(-L)
         run: cd main && cargo run --release -- json-timeline -d ../hayabusa-sample-evtx -o out.jsonl -q -L
 
+      - name: level-tuning
+        run: cd main && cargo run --release -- level-tuning -f ./rules/config/level_tuning.txt -q
+
+      - name: list-contributors
+        run: cd main && cargo run --release -- list-contributors -q
+
+      - name: list-profiles
+        run: cd main && cargo run --release -- list-profiles -q
+
       - name: logon-summary
         run: cd main && cargo run --release -- logon-summary -d ../hayabusa-sample-evtx -q
-
-      - name: metrics
-        run: cd main && cargo run --release -- metrics -d ../hayabusa-sample-evtx -q
 
       - name: pivot-keywords-list
         run: cd main && cargo run --release -- pivot-keywords-list -d ../hayabusa-sample-evtx -o p.csv -q
 
-      - name: level-tuning
-        run: cd main && cargo run --release -- level-tuning -f ./rules/config/level_tuning.txt -q
+      - name: search
+        run: cd main && cargo run --release -- search -d ../hayabusa-sample-evtx -k mimikatz -o p.csv -q
 
       - name: set-default-profile
         run: cd main && cargo run --release -- set-default-profile -p verbose -q
-
-      - name: list-contributors
-        run: cd main && cargo run --release -- list-contributors -q


### PR DESCRIPTION
## What Changed
Update GitHub Actions for integration test.
- added test case
  - added `search` command test
  - rename `metrics` to `eid-metrics/computer-metrics` command

## Evidence
I made a copy with fukusuket count and confirmed the job success as follows.
https://github.com/fukusuket/hayabusa-ci/actions/runs/5775070895/job/15652670782

I would appreciate it if you could review when you have time🙏
