### PR TITLE
fix: set include_status * when `update-rules` command.

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -12,7 +12,7 @@
 
 **バグ修正:**
 
-- 新しいルールがダウンロードされても、`update-rules`コマンドは`You currently have the latest rules`というメッセージを出力していたので、修正した。 (#1209) (@fukusuket)
+- バージョン`2.10.0`の`update-rules`コマンドでは、新しいルールがダウンロードされても、`You currently have the latest rules`というメッセージを出力していた。 (#1209) (@fukusuket)
 
 **その他:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## x.x.x [xxxx/xx/xx]
+
+**バグ修正:**
+
+- 新しいルールがダウンロードされても、`update-rules`コマンドは`You currently have the latest rules`というメッセージを出力していたので、修正した。 (#1209) (@fukusuket)
+
 ## 2.10.0 [2023/10/31] "Halloween Release"
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## x.x.x [xxxx/xx/xx]
+
+**Bug Fixes:**
+
+- `update-rules` command would output `You currently have the latest rules` even if new rules were downloaded. (#1209) (@fukusuket)
+
 ## 2.10.0 [2023/10/31] "Halloween Release"
 
 **Enhancements:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Bug Fixes:**
 
-- `update-rules` command would output `You currently have the latest rules` even if new rules were downloaded. (#1209) (@fukusuket)
+- `update-rules` command would output `You currently have the latest rules` even if new rules were downloaded in version `2.10.0`. (#1209) (@fukusuket)
 
 **Other:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,7 +535,7 @@ impl App {
                     None
                 };
                 let now_version = &format!("v{}", env!("CARGO_PKG_VERSION"));
-
+                stored_static.include_status.insert("*".into());
                 match Update::update_rules(update_target.unwrap().to_str().unwrap(), stored_static)
                 {
                     Ok(output) => {


### PR DESCRIPTION
## What Changed

- Fixed #1209 
  - Explicitly set * to `stored_static.include_status`
  - If `include_status` is not set, when creating a list of yml rules with the read_dir function, it will be determined that there are no target rules
  
## Evidence
### Enviroment
- OS: macOS Sonoma version 14.0

The updated rule name will be displayed as shown below.
```
fukusuke@fukusukenoAir hayabusa-2.10.0-all-platforms % ./hayabusa update-rules

╔╗ ╔╦═══╦╗  ╔╦═══╦══╗╔╗ ╔╦═══╦═══╗
║║ ║║╔═╗║╚╗╔╝║╔═╗║╔╗║║║ ║║╔═╗║╔═╗║
║╚═╝║║ ║╠╗╚╝╔╣║ ║║╚╝╚╣║ ║║╚══╣║ ║║
║╔═╗║╚═╝║╚╗╔╝║╚═╝║╔═╗║║ ║╠══╗║╚═╝║
║║ ║║╔═╗║ ║║ ║╔═╗║╚═╝║╚═╝║╚═╝║╔═╗║
╚╝ ╚╩╝ ╚╝ ╚╝ ╚╝ ╚╩═══╩═══╩═══╩╝ ╚╝
   by Yamato Security

Start time: 2023/11/04 23:15

 - Uncommon PowerShell Hosts (Modified: 2023/11/03 | Path: rules/sigma/builtin/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml)
 - Suspicious Non-Browser Network Communication With Google API (Modified: 2023/11/03 | Path: rules/sigma/sysmon/network_connection/net_connection_win_google_api_non_browser_access.yml)

Updated Sigma rules: 2
Rules updated successfully.
```

I would appreciate it if you could review when you have time🙏