### PR TITLE
fix: added initial value when there is no `Data` field

### DIFF
--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -321,7 +321,7 @@ pub fn parse_message(
         if suffix >= 1 {
             tmp_event_record = tmp_event_record
                 .get("Data")
-                .unwrap()
+                .unwrap_or(tmp_event_record)
                 .get((suffix - 1) as usize)
                 .unwrap_or(tmp_event_record);
         }


### PR DESCRIPTION
## What Changed

- Fixed #1215 

## Evidence
### Enviroment
- OS: macOS Sonoma version 14.0

### Test
I confirmed that the problem does not occur using the steps to reproduce #1215 
```
% ./hayabusa csv-timeline -f ../apt29_evals_day1_manual_2020-05-01225525.json -J -r test.yml -w -q -o out.csv -C
Start time: 2023/11/12 22:20

Total event log files: 1
Total file size: 385.3 MB


Loading detection rules. Please wait.


Test rules: 1 (100.00%)

Hayabusa rules: 1
Total enabled detection rules: 1

Output profile: standard

Scanning in progress. Please wait.

[00:00:03] 1 / 1   [========================================] 100%

Scanning finished. Please wait while the results are being saved.

Rule Authors:

╭──────────╮
│ TEST (1) │
╰──────────╯

Results Summary:

Events with hits / Total events: 2,842 / 196,081 (Data reduction: 193,239 events (98.55%))

Total | Unique detections: 5,285 | 1
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 0 (0.00%) | 0 (0.00%)
Total | Unique medium detections: 0 (0.00%) | 0 (0.00%)
Total | Unique low detections: 0 (0.00%) | 0 (0.00%)
Total | Unique informational detections: 5,285 (100.00%) | 1 (100.00%)

Dates with most total detections:
critical: n/a, high: n/a, medium: n/a, low: n/a, informational: 2020-05-02 (5,285)

Top 5 computers with most unique detections:
critical: n/a
high: n/a
medium: n/a
low: n/a
informational: SCRANTON.dmevals.local (1), NEWYORK.dmevals.local (1), NASHUA.dmevals.local (1)

╭──────────────────────────────────────────────╮
│ Top critical alerts:        Top high alerts: │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top medium alerts:          Top low alerts:  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top informational alerts:                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ PwShClassic (5,285)         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
╰───────────────────────────╌──────────────────╯

Saved file: out.csv (8.6 MB)

Elapsed time: 00:00:03.487
```

output.csv
```
"Timestamp","Computer","Channel","EventID","Level","RecordID","RuleTitle","Details","ExtraFieldInfo"
"2020-05-02 11:56:15.887 +09:00","SCRANTON.dmevals.local","PwShClassic",600,"info",7475,"PwShClassic","Data: n/a","@timestamp: 2020-05-02T02:56:15.887Z ¦ @version: 1 ¦ Category: Provider Lifecycle ¦ Channel: Windows PowerShell ¦ EventID: 600 ¦ EventReceivedTime: 2020-05-01 22:56:15 ¦ EventTime: 2020-05-01 22:56:15 ¦ EventType: INFO ¦ ExecutionProcessID: 0 ¦ Hostname: SCRANTON.dmevals.local ¦ Keywords: 36028797018963968 ¦ Message: Provider ""Registry"" is Started. Details: ProviderName=Registry NewProviderState=Started SequenceNumber=1 HostName=ConsoleHost HostVersion=5.1.18362.628 HostId=e1855a36-02ca-4037-b00e-26dd3bfcd438 HostApplication=powershell EngineVersion= RunspaceId= PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine= ¦ Opcode: Info ¦ RecordNumber: 7475 ¦ Severity: INFO ¦ SeverityValue: 2 ¦ SourceModuleName: eventlog ¦ SourceModuleType: im_msvistalog ¦ SourceName: PowerShell ¦ Task: 6 ¦ ThreadID: 0 ¦ host: wec.internal.cloudapp.net ¦ port: 60737 ¦ tags: mordorDataset"
"2020-05-02 11:56:15.887 +09:00","SCRANTON.dmevals.local","PwShClassic",600,"info",7476,"PwShClassic","Data: n/a","@timestamp: 2020-05-02T02:56:15.887Z ¦ @version: 1 ¦ Category: Provider Lifecycle ¦ Channel: Windows PowerShell ¦ EventID: 600 ¦ EventReceivedTime: 2020-05-01 22:56:15 ¦ EventTime: 2020-05-01 22:56:15 ¦ EventType: INFO ¦ ExecutionProcessID: 0 ¦ Hostname: SCRANTON.dmevals.local ¦ Keywords: 36028797018963968 ¦ Message: Provider ""Alias"" is Started. Details: ProviderName=Alias NewProviderState=Started SequenceNumber=3 HostName=ConsoleHost HostVersion=5.1.18362.628 HostId=e1855a36-02ca-4037-b00e-26dd3bfcd438 HostApplication=powershell EngineVersion= RunspaceId= PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine= ¦ Opcode: Info ¦ RecordNumber: 7476 ¦ Severity: INFO ¦ SeverityValue: 2 ¦ SourceModuleName: eventlog ¦ SourceModuleType: im_msvistalog ¦ SourceName: PowerShell ¦ Task: 6 ¦ ThreadID: 0 ¦ host: wec.internal.cloudapp.net ¦ port: 60737 ¦ tags: mordorDataset"
"2020-05-02 11:56:15.887 +09:00","SCRANTON.dmevals.local","PwShClassic",600,"info",7477,"PwShClassic","Data: n/a","@timestamp: 2020-05-02T02:56:15.887Z ¦ @version: 1 ¦ Category: Provider Lifecycle ¦ Channel: Windows PowerShell ¦ EventID: 600 ¦ EventReceivedTime: 2020-05-01 22:56:15 ¦ EventTime: 2020-05-01 22:56:15 ¦ EventType: INFO ¦ ExecutionProcessID: 0 ¦ Hostname: SCRANTON.dmevals.local ¦ Keywords: 36028797018963968 ¦ Message: Provider ""Environment"" is Started. Details: ProviderName=Environment NewProviderState=Started SequenceNumber=5 HostName=ConsoleHost HostVersion=5.1.18362.628 HostId=e1855a36-02ca-4037-b00e-26dd3bfcd438 HostApplication=powershell EngineVersion= RunspaceId= PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine= ¦ Opcode: Info ¦ RecordNumber: 7477 ¦ Severity: INFO ¦ SeverityValue: 2 ¦ SourceModuleName: eventlog ¦ SourceModuleType: im_msvistalog ¦ SourceName: PowerShell ¦ Task: 6 ¦ ThreadID: 0 ¦ host: wec.internal.cloudapp.net ¦ port: 60737 ¦ tags: mordorDataset"
...
```

I would appreciate it if you could review when you have time🙏
