### PR TITLE
Disabled MacOS CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,8 @@ jobs:
               target: "x86_64-unknown-linux-musl",
               cross: true,
             }
-          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
-          - { os: "macOS-latest", target: "aarch64-apple-darwin", cross: false }
+          # - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
+          # - { os: "macOS-latest", target: "aarch64-apple-darwin", cross: false }
           - {
               os: "windows-latest",
               target: "x86_64-pc-windows-msvc",


### PR DESCRIPTION
because error raised when openssl-sys is build

## What Changed

- Disabled MacOS CI

