### PR TITLE
Added message about reporting issues and FPs

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,6 +5,7 @@
 **改善:**
 
 - JSON出力において、MitreTactics、MitreTags, OtherTagsの出力を要素ごとに文字列で出力させるように修正した。 (#1230) (@hitenkoku)
+- `csv-timeline` or `json-timeline` コマンドが利用されたときにissueやpull-requestの連絡先についてのメッセージを追加した。 (#1236) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Enhancements:**
 
 - `%MitreTactics%`, `%MitreTags%`, `%OtherTags%` fields are now outputted as an array of strings in JSON output. (#1230) (@hitenkoku)
+- Printed message about reporting issues and false positives when `csv-timeline` or `json-timeline` command was used. (#1236) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Enhancements:**
 
 - `%MitreTactics%`, `%MitreTags%`, `%OtherTags%` fields are now outputted as an array of strings in JSON output. (#1230) (@hitenkoku)
-- Printed message about reporting issues and false positives when `csv-timeline` or `json-timeline` command was used. (#1236) (@hitenkoku)
+- Output messages about reporting issues and false positives when using `csv-timeline` or `json-timeline` commands. (#1236) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -731,7 +731,7 @@ impl App {
                 println!();
                 println!("Please report any issues with Hayabusa rules to: https://github.com/Yamato-Security/hayabusa-rules/issues");
                 println!("Please report any false positives with Sigma rules to: https://github.com/SigmaHQ/sigma/issues");
-                println!("Please submit new detection rules with pull requests to: https://github.com/SigmaHQ/sigma/pulls");
+                println!("Please submit new Sigma rules with pull requests to: https://github.com/SigmaHQ/sigma/pulls");
             }
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -726,6 +726,15 @@ impl App {
             "General Overview {#general_overview}",
             &stored_static.html_report_flag,
         );
+        match stored_static.config.action {
+            Some(Action::CsvTimeline(_)) | Some(Action::JsonTimeline(_)) => {
+                println!();
+                println!("Please report any issues with Hayabusa rules to: https://github.com/Yamato-Security/hayabusa-rules/issues");
+                println!("Please report any false positives with Sigma rules to: https://github.com/SigmaHQ/sigma/issues");
+                println!("Please submit new detection rules with pull requests to: https://github.com/SigmaHQ/sigma/pulls");
+            }
+            _ => {}
+        }
 
         // Qオプションを付けた場合もしくはパースのエラーがない場合はerrorのstackが0となるのでエラーログファイル自体が生成されない。
         if ERROR_LOG_STACK.lock().unwrap().len() > 0 {


### PR DESCRIPTION
## What Changed

- Added message about reporting issues and FPs when `csv-timeline` or `json-timeline` command was used.

I would appreciate it if you could review when you have time.