### PR TITLE
added require `-d`, `-l` or `-f` with commands

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 **バグ修正:**
 
 - JSON出力において、同じ名前の複数のフィールド名が配列として出力されないため、`jq`でパースすると1つの結果しか返されなかった。同じフィールド名を持つ複数のフィールドデータを配列内に出力することで修正した。 (#1202) (@hitenkoku)
+- `csv-timeline`、`json-timeline`、`eid-metrics`、`logon-summary`、`pivot-keywords-list`、`search`コマンドで調査対象ファイルの指定オプション(`-l`、 `-f`、 `-d`)が存在しないときに処理が実行されないように修正した。 (#1235) (@hitenkoku)
 
 ## 2.11.0 [2023/12/03] "Nasi Lemak Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **Bug Fixes:**
 
 - In JSON output, multiple field names with the same names were not outputted as an array so only one result would be returned when parsing with `jq`. We fixed this by outputting multiple field data with the same field name inside an array. (#1202) (@hitenkoku)
-- Fixed a bug in the `csv-timeline`, `json-timeline`, `eid-metrics`, `logon-summary`, `pivot-keywords-list` and `search` commands so that processing is not executed when the option (`-l`, `-f` or `-d`) specifying the file to be investigated does not exist. (#1235) (@hitenkoku)
+- Fixed a bug in the `csv-timeline`, `json-timeline`, `eid-metrics`, `logon-summary`, `pivot-keywords-list` and `search` commands so that Hayabusa will quit whenever no input option (`-l`, `-f` or `-d`) is specified. (#1235) (@hitenkoku)
 
 ## 2.11.0 [2023/12/03] "Nasi Lemak Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes:**
 
 - In JSON output, multiple field names with the same names were not outputted as an array so only one result would be returned when parsing with `jq`. We fixed this by outputting multiple field data with the same field name inside an array. (#1202) (@hitenkoku)
+- Fixed a bug in the `csv-timeline`, `json-timeline`, `eid-metrics`, `logon-summary`, `pivot-keywords-list` and `search` commands so that processing is not executed when the option (`-l`, `-f` or `-d`) specifying the file to be investigated does not exist. (#1235) (@hitenkoku)
 
 ## 2.11.0 [2023/12/03] "Nasi Lemak Release"
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1182,6 +1182,7 @@ pub struct EidMetricsOption {
 }
 
 #[derive(Args, Clone, Debug)]
+#[clap(group(ArgGroup::new("input_filtering").args(["directory", "filepath", "live_analysis"]).required(true)))]
 #[clap(group(ArgGroup::new("level_rule_filtering").args(["min_level", "exact_level"]).multiple(false)))]
 pub struct PivotKeywordOption {
     #[clap(flatten)]
@@ -1525,6 +1526,7 @@ pub struct CommonOptions {
 }
 
 #[derive(Args, Clone, Debug)]
+#[clap(group(ArgGroup::new("input_filtering").args(["directory", "filepath", "live_analysis"]).required(true)))]
 pub struct InputOption {
     /// Directory of multiple .evtx files
     #[arg(help_heading = Some("Input"), short = 'd', long, value_name = "DIR", conflicts_with_all = ["filepath", "live_analysis"], display_order = 300)]


### PR DESCRIPTION
## What Changed

- Fixed a bug in the `csv-timeline`, `json-timeline`, `eid-metrics`, `logon-summary`, `pivot-keywords-list` and `search` commands so that processing is not executed when the option (`-l`, `-f` or `-d`) specifying the file to be investigated does not exist.

I would appreciate it if you could review when you have time.