### PR TITLE
output json format in json timeline for standard output

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -9,6 +9,7 @@
 **Enhancements:**
 
 - `update-rules`コマンドを実行したときに、検知ルールが変更された場合にルール名を出力するようにした。以前は`modified:`フィールドを更新したルールだけが表示されていた。(#1243) (@hitenkoku)
+- `json-timeline`コマンドの標準出力でJSONフォーマットを出力するように修正した。 (#1197) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 **Enhancements:**
 
 - Any time there is a change in a detection rule, it will be displayed when running the `update-rules` command. Previously, only rules that updated their `modified:` field would be displayed. (#1243) (@hitenkoku)
-- Modified to Output JSON format in `json-timeline` command for standard output. (#1197) (@hitenkoku)
+- The `json-timeline` command now outputs in JSON format when outputting to the terminal. (#1197) (@hitenkoku)
 - Added support for parsing JSON input when the data is inside an array. (#1248) (@hitenkoku)
 
 **Bug Fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Enhancements:**
 
 - Any time there is a change in a detection rule, it will be displayed when running the `update-rules` command. Previously, only rules that updated their `modified:` field would be displayed. (#1243) (@hitenkoku)
+- Modified to Output JSON format in `json-timeline` command for standard output. (#1197) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -380,7 +380,7 @@ fn emit_csv<W: std::io::Write>(
                     time, detect_info.eventid
                 )));
             }
-            if displayflag {
+            if displayflag && !(json_output_flag || jsonl_output_flag) {
                 // 標準出力の場合
                 if plus_header {
                     // ヘッダーのみを出力
@@ -431,10 +431,13 @@ fn emit_csv<W: std::io::Write>(
                 );
                 prev_message = result.1;
                 prev_details_convert_map = detect_info.details_convert_map.clone();
-                wtr.write_field(format!("{{ {} }}", &result.0))?;
+                if displayflag {
+                    write_color_buffer(&disp_wtr, None, &format!("{{ {} }}", &result.0), true).ok();
+                } else {
+                    wtr.write_field(format!("{{ {} }}", &result.0))?;
+                }
             } else if json_output_flag {
                 // JSON output
-                wtr.write_field("{")?;
                 let result = output_json_str(
                     &detect_info.ext_field,
                     prev_message,
@@ -446,8 +449,14 @@ fn emit_csv<W: std::io::Write>(
                 );
                 prev_message = result.1;
                 prev_details_convert_map = detect_info.details_convert_map.clone();
-                wtr.write_field(&result.0)?;
-                wtr.write_field("}")?;
+                if displayflag {
+                    write_color_buffer(&disp_wtr, None, &format!("{{\n{}\n}}", &result.0), true)
+                        .ok();
+                } else {
+                    wtr.write_field("{")?;
+                    wtr.write_field(&result.0)?;
+                    wtr.write_field("}")?;
+                }
             } else {
                 // csv output format
                 if plus_header {


### PR DESCRIPTION
## What Changed

- Modified to Output JSON format in `json-timeline` command for standard output.

I would appreciate it if you could review when you have time.
