### PR TITLE
change self modifier to reduce clone()

### DIFF
--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -58,7 +58,7 @@ impl IntoIterator for ConditionToken {
 }
 
 impl ConditionToken {
-    fn replace_subtoken(&self, sub_tokens: Vec<ConditionToken>) -> ConditionToken {
+    fn replace_subtoken(self, sub_tokens: Vec<ConditionToken>) -> ConditionToken {
         match self {
             ConditionToken::ParenthesisContainer(_) => {
                 ConditionToken::ParenthesisContainer(sub_tokens.into_iter())
@@ -69,15 +69,13 @@ impl ConditionToken {
             ConditionToken::OperandContainer(_) => {
                 ConditionToken::OperandContainer(sub_tokens.into_iter())
             }
-            ConditionToken::LeftParenthesis => ConditionToken::LeftParenthesis,
-            ConditionToken::RightParenthesis => ConditionToken::RightParenthesis,
-            ConditionToken::Space => ConditionToken::Space,
-            ConditionToken::Not => ConditionToken::Not,
-            ConditionToken::And => ConditionToken::And,
-            ConditionToken::Or => ConditionToken::Or,
-            ConditionToken::SelectionReference(name) => {
-                ConditionToken::SelectionReference(name.clone())
-            }
+            ConditionToken::LeftParenthesis => self,
+            ConditionToken::RightParenthesis => self,
+            ConditionToken::Space => self,
+            ConditionToken::Not => self,
+            ConditionToken::And => self,
+            ConditionToken::Or => self,
+            ConditionToken::SelectionReference(_) => self,
         }
     }
 


### PR DESCRIPTION
## What Changed
- I've changed the modifier of the argument in the function 'replace_subtoken()' from &self to self. This helps us to reduce clone() uses.

## Evidence

Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.


## Memo
This is just a first step to reduce clone uses so we cannot close the issue 787.

Some testcases have failed on this branch but testcases also failed on main branch as I mentioned in slack(https://yamatosecurity2.slack.com/archives/C01BBBC4DU7/p1706798362376809).
Please check this.
