### PR TITLE
fixed `search` command line options associate

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ Filtering:
 Output:
   -J, --JSON-output    Save the search results in JSON format (ex: -J -o results.json)
   -L, --JSONL-output   Save the search results in JSONL format (ex: -L -o results.jsonl)
-  -M, --multiline      Output event field information in multiple rows
+  -M, --multiline      Output event field information in multiple rows for CSV output
   -o, --output <FILE>  Save the search results in CSV format (ex: search.csv)
 
 General Options:

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1052,7 +1052,7 @@ pub struct SearchOption {
     #[arg(help_heading = Some("Display Settings"), short = 'v', long, display_order = 480)]
     pub verbose: bool,
 
-    /// Output event field information in multiple rows
+    /// Output event field information in multiple rows for CSV output
     #[arg(help_heading = Some("Output"), short = 'M', long="multiline", display_order = 390)]
     pub multiline: bool,
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1061,11 +1061,11 @@ pub struct SearchOption {
     pub clobber: bool,
 
     /// Save the search results in JSON format (ex: -J -o results.json)
-    #[arg(help_heading = Some("Output"), short = 'J', long = "JSON-output", conflicts_with = "jsonl_output", requires = "output", display_order = 100)]
+    #[arg(help_heading = Some("Output"), short = 'J', long = "JSON-output", conflicts_with_all = ["jsonl_output", "multiline"], requires = "output", display_order = 100)]
     pub json_output: bool,
 
     /// Save the search results in JSONL format (ex: -L -o results.jsonl)
-    #[arg(help_heading = Some("Output"), short = 'L', long = "JSONL-output", conflicts_with = "jsonl_output", requires = "output", display_order = 100)]
+    #[arg(help_heading = Some("Output"), short = 'L', long = "JSONL-output", conflicts_with_all = ["jsonl_output", "multiline"], requires = "output", display_order = 100)]
     pub jsonl_output: bool,
 
     /// Output timestamp in European time format (ex: 22-02-2022 22:00:00.123 +02:00)

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -947,6 +947,7 @@ pub struct DefaultProfileOption {
 }
 
 #[derive(Args, Clone, Debug)]
+#[clap(group(ArgGroup::new("search_input_filtering").args(["keywords", "regex"]).required(true)))]
 pub struct SearchOption {
     #[clap(flatten)]
     pub common_options: CommonOptions,


### PR DESCRIPTION
## What Changed

- added required option filter in search command
- added conflict command filter in multiple row and json/jsonl output 

## Evidence

- Please check previous version result in #1257  description.

- this PR

  -  checked in search command without keywords/regex option.

```pwsh
❯ ./1257.exe search -d ../hayabusa-sample-evtx
error: the following required arguments were not provided:
  <--keyword <KEYWORD...>|--regex <REGEX>>

Usage: 1257.exe search <--directory <DIR>|--file <FILE>|--live-analysis> <--keyword <KEYWORD...>|--regex <REGEX>>
```

  - checked conflict multiline option to JSON-output and JSONL-output.

```pwsh
> ./1257.exe search -d ../hayabusa-sample-evtx -M -o test.jsonl -J
error: the argument '--multiline' cannot be used with '--JSON-output'

Usage: 1257.exe search --multiline --output <FILE> <--directory <DIR>|--file <FILE>|--live-analysis> <--keyword <KEYWORD...>|--regex <REGEX>>
```
```
> ./1257.exe search -d ../hayabusa-sample-evtx -M -o test.jsonl -L
error: the argument '--multiline' cannot be used with '--JSONL-output'

Usage: 1257.exe search --multiline --output <FILE> <--directory <DIR>|--file <FILE>|--live-analysis> <--keyword <KEYWORD...>|--regex <REGEX>>
```

I would appreciate it if you could review when you have time.