### PR TITLE
refactoring for low memory option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +797,7 @@ dependencies = [
  "nested",
  "num",
  "num-format",
+ "openssl",
  "pulldown-cmark",
  "rand",
  "regex",
@@ -1289,10 +1305,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "openssl-sys"
@@ -1302,6 +1353,7 @@ checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ wildmatch = "2.*"
 yaml-rust = "0.4.*"
 
 [profile.dev]
-debug = 0
+debug-assertions = false
 
 [dev-dependencies]
 rand = "0.8.*"

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -2274,6 +2274,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -2297,6 +2298,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -2610,6 +2612,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -2633,6 +2636,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -2936,6 +2940,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -2959,6 +2964,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -3272,6 +3278,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -3295,6 +3302,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -3680,6 +3688,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -4031,6 +4040,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),
@@ -4306,6 +4316,7 @@ mod tests {
                 &event,
                 CompactString::new(output),
                 DetectInfo {
+                    detected_time: expect_time,
                     rulepath: CompactString::from(test_rulepath),
                     ruleid: test_rule_id.into(),
                     ruletitle: CompactString::from(test_title),

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -81,60 +81,6 @@ struct InitLevelMapResult(
 );
 
 impl AfterfactInfo {
-    pub fn new() -> AfterfactInfo {
-        let InitLevelMapResult(
-            detect_counts_by_date_and_level,
-            detect_counts_by_computer_and_level,
-            detect_counts_by_rule_and_level,
-        ) = {
-            let levels = ["crit", "high", "med ", "low ", "info", "undefined"];
-            let mut detect_counts_by_date_and_level: HashMap<
-                CompactString,
-                HashMap<CompactString, i128>,
-            > = HashMap::new();
-            let mut detect_counts_by_computer_and_level: HashMap<
-                CompactString,
-                HashMap<CompactString, i128>,
-            > = HashMap::new();
-            let mut detect_counts_by_rule_and_level: HashMap<
-                CompactString,
-                HashMap<CompactString, i128>,
-            > = HashMap::new();
-            // レベル別、日ごとの集計用変数の初期化
-            for level_init in levels {
-                detect_counts_by_date_and_level
-                    .insert(CompactString::from(level_init), HashMap::new());
-                detect_counts_by_computer_and_level
-                    .insert(CompactString::from(level_init), HashMap::new());
-                detect_counts_by_rule_and_level
-                    .insert(CompactString::from(level_init), HashMap::new());
-            }
-
-            InitLevelMapResult(
-                detect_counts_by_date_and_level,
-                detect_counts_by_computer_and_level,
-                detect_counts_by_rule_and_level,
-            )
-        };
-        AfterfactInfo {
-            detect_infos: vec![],
-            tl_starttime: Option::None,
-            tl_endtime: Option::None,
-            record_cnt: 0,
-            recover_record_cnt: 0,
-            detected_record_idset: HashSet::new(),
-            total_detect_counts_by_level: vec![0; 6],
-            unique_detect_counts_by_level: vec![0; 6],
-            detect_counts_by_date_and_level,
-            detect_counts_by_computer_and_level,
-            detect_counts_by_rule_and_level,
-            detect_rule_authors: HashMap::new(),
-            rule_title_path_map: HashMap::new(),
-            rule_author_counter: HashMap::new(),
-            timestamps: vec![],
-        }
-    }
-
     pub fn sort_detect_info(&mut self) {
         self.detect_infos.sort_unstable_by(|a, b| {
             let cmp_time = a.detected_time.cmp(&b.detected_time);
@@ -216,6 +162,62 @@ impl AfterfactInfo {
             .collect();
 
         std::mem::swap(&mut self.detect_infos, &mut tmp_detect_infos);
+    }
+}
+
+impl Default for AfterfactInfo {
+    fn default() -> Self {
+        let InitLevelMapResult(
+            detect_counts_by_date_and_level,
+            detect_counts_by_computer_and_level,
+            detect_counts_by_rule_and_level,
+        ) = {
+            let levels = ["crit", "high", "med ", "low ", "info", "undefined"];
+            let mut detect_counts_by_date_and_level: HashMap<
+                CompactString,
+                HashMap<CompactString, i128>,
+            > = HashMap::new();
+            let mut detect_counts_by_computer_and_level: HashMap<
+                CompactString,
+                HashMap<CompactString, i128>,
+            > = HashMap::new();
+            let mut detect_counts_by_rule_and_level: HashMap<
+                CompactString,
+                HashMap<CompactString, i128>,
+            > = HashMap::new();
+            // レベル別、日ごとの集計用変数の初期化
+            for level_init in levels {
+                detect_counts_by_date_and_level
+                    .insert(CompactString::from(level_init), HashMap::new());
+                detect_counts_by_computer_and_level
+                    .insert(CompactString::from(level_init), HashMap::new());
+                detect_counts_by_rule_and_level
+                    .insert(CompactString::from(level_init), HashMap::new());
+            }
+
+            InitLevelMapResult(
+                detect_counts_by_date_and_level,
+                detect_counts_by_computer_and_level,
+                detect_counts_by_rule_and_level,
+            )
+        };
+        AfterfactInfo {
+            detect_infos: vec![],
+            tl_starttime: Option::None,
+            tl_endtime: Option::None,
+            record_cnt: 0,
+            recover_record_cnt: 0,
+            detected_record_idset: HashSet::new(),
+            total_detect_counts_by_level: vec![0; 6],
+            unique_detect_counts_by_level: vec![0; 6],
+            detect_counts_by_date_and_level,
+            detect_counts_by_computer_and_level,
+            detect_counts_by_rule_and_level,
+            detect_rule_authors: HashMap::new(),
+            rule_title_path_map: HashMap::new(),
+            rule_author_counter: HashMap::new(),
+            timestamps: vec![],
+        }
     }
 }
 
@@ -2176,7 +2178,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -2509,7 +2511,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output_with_multiline_opt() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -2830,7 +2832,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output_with_remove_duplicate_opt() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -3160,7 +3162,7 @@ mod tests {
 
     #[test]
     fn test_emit_json_output_with_remove_duplicate_opt() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -3564,7 +3566,7 @@ mod tests {
 
     #[test]
     fn test_emit_json_output_with_multiple_data_in_details() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -3914,7 +3916,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_json_output() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -4188,7 +4190,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_jsonl_output() {
-        let mut additional_afterfact = AfterfactInfo::new();
+        let mut additional_afterfact = AfterfactInfo::default();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -47,7 +47,7 @@ pub struct Colors {
 }
 
 /// level_color.txtファイルを読み込み対応する文字色のマッピングを返却する関数
-pub fn set_output_color(no_color_flag: bool) -> HashMap<CompactString, Colors> {
+pub fn create_output_color_map(no_color_flag: bool) -> HashMap<CompactString, Colors> {
     let read_result = utils::read_csv(
         utils::check_setting_path(
             &CURRENT_EXE_PATH.to_path_buf(),
@@ -199,7 +199,7 @@ pub fn after_fact(
         // stdoutput (termcolor crate color output is not csv writer)
         Box::new(BufWriter::new(io::stdout()))
     };
-    let color_map = set_output_color(no_color_flag);
+    let color_map = create_output_color_map(no_color_flag);
     if let Err(err) = emit_csv(
         &mut target,
         displayflag,
@@ -563,20 +563,6 @@ fn emit_csv<W: std::io::Write>(
     }
 
     disp_wtr_buf.clear();
-    let level_abbr: Nested<Vec<CompactString>> = Nested::from_iter(
-        [
-            [CompactString::from("critical"), CompactString::from("crit")].to_vec(),
-            [CompactString::from("high"), CompactString::from("high")].to_vec(),
-            [CompactString::from("medium"), CompactString::from("med ")].to_vec(),
-            [CompactString::from("low"), CompactString::from("low ")].to_vec(),
-            [
-                CompactString::from("informational"),
-                CompactString::from("info"),
-            ]
-            .to_vec(),
-        ]
-        .iter(),
-    );
 
     output_summary(
         stored_static,
@@ -2003,7 +1989,7 @@ fn _output_html_computer_by_mitre_attck(html_output_stock: &mut Nested<String>) 
 
 #[cfg(test)]
 mod tests {
-    use super::set_output_color;
+    use super::create_output_color_map;
     use crate::afterfact::emit_csv;
     use crate::afterfact::format_time;
     use crate::afterfact::Colors;
@@ -3771,7 +3757,7 @@ mod tests {
     /// To confirm that empty character color mapping data is returned when the no_color flag is given.
     fn test_set_output_color_no_color_flag() {
         let expect: HashMap<CompactString, Colors> = HashMap::new();
-        check_hashmap_data(set_output_color(true), expect);
+        check_hashmap_data(create_output_color_map(true), expect);
     }
 
     #[test]

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -3539,7 +3539,6 @@ mod tests {
 
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_remove_duplicate.json").unwrap());
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -23,7 +23,7 @@ use csv::{QuoteStyle, WriterBuilder};
 use itertools::Itertools;
 use krapslog::{build_sparkline, build_time_markers};
 use nested::Nested;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 use yaml_rust::YamlLoader;
 
@@ -173,8 +173,6 @@ fn _print_timeline_hist(timestamps: &Vec<i64>, length: usize, side_margin_size: 
 
 pub fn after_fact(
     all_record_cnt: usize,
-    output_option: &Option<PathBuf>,
-    no_color_flag: bool,
     stored_static: &StoredStatic,
     tl: Timeline,
     recover_records_cnt: usize,
@@ -185,7 +183,7 @@ pub fn after_fact(
     };
 
     let mut displayflag = false;
-    let mut target: Box<dyn io::Write> = if let Some(path) = &output_option {
+    let mut target: Box<dyn io::Write> = if let Some(path) = &stored_static.output_path {
         // output to file
         match File::create(path) {
             Ok(file) => Box::new(BufWriter::new(file)),
@@ -199,7 +197,7 @@ pub fn after_fact(
         // stdoutput (termcolor crate color output is not csv writer)
         Box::new(BufWriter::new(io::stdout()))
     };
-    let color_map = create_output_color_map(no_color_flag);
+    let color_map = create_output_color_map(stored_static.common_options.no_color);
     if let Err(err) = emit_csv(
         &mut target,
         displayflag,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -167,12 +167,7 @@ impl AfterfactInfo {
     ) -> Vec<usize> {
         let output_option = stored_static.output_option.as_ref().unwrap();
         if !output_option.remove_duplicate_detections {
-            return self
-                .detect_infos
-                .iter()
-                .enumerate()
-                .map(|(i, _)| i)
-                .collect();
+            return (0..self.detect_infos.len()).collect();
         }
 
         // filtet duplicate event

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -162,52 +162,56 @@ impl AfterfactInfo {
     }
 
     pub fn get_removed_duplicate_detect_info_idx(
-        &self,
+        mut self,
         stored_static: &StoredStatic,
-    ) -> Vec<usize> {
+    ) -> Self {
         let output_option = stored_static.output_option.as_ref().unwrap();
         if !output_option.remove_duplicate_detections {
-            return self
-                .detect_infos
-                .iter()
-                .enumerate()
-                .map(|(i, _)| i)
-                .collect();
+            return self;
         }
 
         // filtet duplicate event
-        let mut filtered_detect_infos = vec![];
-        let mut prev_detect_infos = HashSet::new();
-        for (i, detect_info) in self.detect_infos.iter().enumerate() {
-            if filtered_detect_infos.is_empty() {
-                filtered_detect_infos.push(i);
-                continue;
+        let mut filtered_detect_infos:std::collections::HashSet<usize> = std::collections::HashSet::new();
+        {
+            let mut prev_detect_infos = HashSet::new();
+            for (i, detect_info) in self.detect_infos.iter().enumerate() {
+                if i == 0 {
+                    filtered_detect_infos.insert(i);
+                    continue;
+                }
+    
+                let prev_detect_info = &self.detect_infos[i-1];
+                if prev_detect_info
+                    .detected_time
+                    .cmp(&detect_info.detected_time)
+                    != Ordering::Equal
+                {
+                    filtered_detect_infos.insert(i);
+                    prev_detect_infos.clear();
+                    continue;
+                }
+    
+                let fields: Vec<&(CompactString, Profile)> = detect_info
+                    .ext_field
+                    .iter()
+                    .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
+                    .collect();
+                if prev_detect_infos.get(&fields).is_some() {
+                    continue;
+                }
+                prev_detect_infos.insert(fields);
+                filtered_detect_infos.insert(i);
             }
-
-            let prev_detect_info_idx = *filtered_detect_infos.last().unwrap();
-            let prev_detect_info = &self.detect_infos[prev_detect_info_idx];
-            if prev_detect_info
-                .detected_time
-                .cmp(&detect_info.detected_time)
-                != Ordering::Equal
-            {
-                filtered_detect_infos.push(i);
-                prev_detect_infos.clear();
-                continue;
-            }
-
-            let fields: Vec<&(CompactString, Profile)> = detect_info
-                .ext_field
-                .iter()
-                .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
-                .collect();
-            if prev_detect_infos.get(&fields).is_some() {
-                continue;
-            }
-            prev_detect_infos.insert(fields);
-            filtered_detect_infos.push(i);
         }
-        return filtered_detect_infos;
+
+        self.detect_infos = self.detect_infos.into_iter().enumerate().filter_map(|(i, detect_info)| {
+            if filtered_detect_infos.contains(&i) {
+                return Some(detect_info);
+            } else {
+                return Option::None;
+            }
+        }).collect();
+        return self;
     }
 }
 
@@ -456,12 +460,10 @@ fn output_afterfact<W: std::io::Write>(
     additional_afterfact.sort_detect_info();
 
     // filtet duplicate event
-    let detect_infos_idxes =
-        additional_afterfact.get_removed_duplicate_detect_info_idx(stored_static);
+    additional_afterfact = additional_afterfact.get_removed_duplicate_detect_info_idx(stored_static);
 
     // emit csv
-    for idx in detect_infos_idxes.iter() {
-        let detect_info = &additional_afterfact.detect_infos[*idx];
+    for detect_info in additional_afterfact.detect_infos.iter() {
         if displayflag && !(json_output_flag || jsonl_output_flag) {
             // 標準出力の場合
             if plus_header {
@@ -587,8 +589,7 @@ fn output_afterfact<W: std::io::Write>(
     let mut detected_rule_files: HashSet<CompactString> = HashSet::new();
     let mut detected_rule_ids: HashSet<CompactString> = HashSet::new();
     let mut detected_computer_and_rule_names: HashSet<CompactString> = HashSet::new();
-    for idx in detect_infos_idxes.iter() {
-        let detect_info = &additional_afterfact.detect_infos[*idx];
+    for detect_info in additional_afterfact.detect_infos.iter() {
         if !detect_info.is_condition {
             additional_afterfact
                 .detected_record_idset

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -449,7 +449,6 @@ fn output_afterfact<W: std::io::Write>(
         println!();
     }
     let mut plus_header = true;
-    let mut author_list_cache: HashMap<CompactString, Nested<String>> = HashMap::new();
 
     // remove duplicate dataのための前レコード分の情報を保持する変数
     let mut prev_message: HashMap<CompactString, Profile> = HashMap::new();
@@ -587,9 +586,32 @@ fn output_afterfact<W: std::io::Write>(
     }
 
     // calculate statistic information
+    additional_afterfact = calc_statistic_info(additional_afterfact, stored_static);
+
+    if displayflag {
+        println!();
+    } else {
+        wtr.flush()?;
+    }
+
+    disp_wtr_buf.clear();
+
+    output_additional_afterfact(
+        stored_static,
+        &disp_wtr,
+        disp_wtr_buf,
+        &additional_afterfact,
+    );
+
+    Ok(())
+}
+
+fn calc_statistic_info( mut additional_afterfact: AfterfactInfo,stored_static: &StoredStatic,) -> AfterfactInfo {
     let mut detected_rule_files: HashSet<CompactString> = HashSet::new();
     let mut detected_rule_ids: HashSet<CompactString> = HashSet::new();
     let mut detected_computer_and_rule_names: HashSet<CompactString> = HashSet::new();
+    let mut author_list_cache: HashMap<CompactString, Nested<String>> = HashMap::new();
+    let output_option = stored_static.output_option.as_ref().unwrap();
     for detect_info in additional_afterfact.detect_infos.iter() {
         if !detect_info.is_condition {
             additional_afterfact
@@ -655,23 +677,7 @@ fn output_afterfact<W: std::io::Write>(
             additional_afterfact.total_detect_counts_by_level[level_suffix] += 1;
         }
     }
-
-    if displayflag {
-        println!();
-    } else {
-        wtr.flush()?;
-    }
-
-    disp_wtr_buf.clear();
-
-    output_additional_afterfact(
-        stored_static,
-        &disp_wtr,
-        disp_wtr_buf,
-        &additional_afterfact,
-    );
-
-    Ok(())
+    return additional_afterfact; 
 }
 
 fn output_additional_afterfact(

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -2097,6 +2097,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -2194,8 +2195,6 @@ mod tests {
         )
         .unwrap_or_default();
         {
-            let messages = &message::MESSAGES;
-            messages.clear();
             let val = r#"
                 {
                     "Event": {
@@ -2304,7 +2303,7 @@ mod tests {
                 .to_str()
                 .unwrap(),
             );
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -2320,15 +2319,15 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
 
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -2344,15 +2343,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
-            let multi = message::MESSAGES.get(&expect_time).unwrap();
-            let (_, detect_infos) = multi.pair();
-
-            println!("message: {detect_infos:?}");
+            additional_afterfact.detect_infos.push(detect_info);
         }
         let expect =
             "\"Timestamp\",\"Computer\",\"Channel\",\"Level\",\"EventID\",\"MitreAttack\",\"RecordID\",\"RuleTitle\",\"Details\",\"RecordInformation\",\"RuleFile\",\"EvtxFile\",\"Tags\"\n\""
@@ -2412,7 +2407,6 @@ mod tests {
                 + "\"\n";
         let mut file: Box<dyn io::Write> = Box::new(File::create("./test_emit_csv.csv").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
@@ -2436,6 +2430,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output_with_multiline_opt() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -2533,8 +2528,6 @@ mod tests {
         )
         .unwrap_or_default();
         {
-            let messages = &message::MESSAGES;
-            messages.clear();
             let val = r#"
                 {
                     "Event": {
@@ -2642,7 +2635,7 @@ mod tests {
                 .to_str()
                 .unwrap(),
             );
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -2658,15 +2651,15 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
 
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -2682,15 +2675,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
-            let multi = message::MESSAGES.get(&expect_time).unwrap();
-            let (_, detect_infos) = multi.pair();
-
-            println!("message: {detect_infos:?}");
+            additional_afterfact.detect_infos.push(detect_info);
         }
         let expect =
             "\"Timestamp\",\"Computer\",\"Channel\",\"EventID\",\"Level\",\"Tags\",\"RecordID\",\"RuleTitle\",\"Details\",\"AllFieldInfo\"\n\""
@@ -2739,7 +2728,6 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_multiline.csv").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
@@ -2763,6 +2751,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_output_with_remove_duplicate_opt() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -2860,8 +2849,6 @@ mod tests {
         )
         .unwrap_or_default();
         {
-            let messages = &message::MESSAGES;
-            messages.clear();
             let val = r#"
                 {
                     "Event": {
@@ -2970,7 +2957,7 @@ mod tests {
                 .to_str()
                 .unwrap(),
             );
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -2986,15 +2973,15 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
 
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -3010,15 +2997,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, false),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
-            let multi = message::MESSAGES.get(&expect_time).unwrap();
-            let (_, detect_infos) = multi.pair();
-
-            println!("message: {detect_infos:?}");
+            additional_afterfact.detect_infos.push(detect_info);
         }
         let expect =
             "\"Timestamp\",\"Computer\",\"Channel\",\"Level\",\"EventID\",\"MitreAttack\",\"RecordID\",\"RuleTitle\",\"Details\",\"RecordInformation\",\"RuleFile\",\"EvtxFile\",\"Tags\"\n\""
@@ -3075,7 +3058,6 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_remove_duplicate.csv").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
@@ -3099,6 +3081,7 @@ mod tests {
 
     #[test]
     fn test_emit_json_output_with_remove_duplicate_opt() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -3196,8 +3179,6 @@ mod tests {
         )
         .unwrap_or_default();
         {
-            let messages = &message::MESSAGES;
-            messages.clear();
             let val = r#"
                 {
                     "Event": {
@@ -3308,7 +3289,7 @@ mod tests {
             );
             let details_convert_map: HashMap<CompactString, Vec<CompactString>> =
                 HashMap::from_iter([("#AllFieldInfo".into(), vec![test_recinfo.into()])]);
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -3324,15 +3305,15 @@ mod tests {
                     is_condition: false,
                     details_convert_map,
                 },
-                expect_time,
                 &profile_converter,
                 (false, true),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
 
-            message::insert(
+            let detect_info2 = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -3348,15 +3329,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map: HashMap::default(),
                 },
-                expect_time,
                 &profile_converter,
                 (false, true),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
-            let multi = message::MESSAGES.get(&expect_time).unwrap();
-            let (_, detect_infos) = multi.pair();
-
-            println!("message: {detect_infos:?}");
+            additional_afterfact.detect_infos.push(detect_info2);
         }
 
         let expect_target = [
@@ -3509,6 +3486,7 @@ mod tests {
 
     #[test]
     fn test_emit_json_output_with_multiple_data_in_details() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -3605,8 +3583,6 @@ mod tests {
         )
         .unwrap_or_default();
         {
-            let messages = &message::MESSAGES;
-            messages.clear();
             let val = r#"
                 {
                     "Event": {
@@ -3718,7 +3694,7 @@ mod tests {
             );
             let details_convert_map: HashMap<CompactString, Vec<CompactString>> =
                 HashMap::from_iter([("#AllFieldInfo".into(), vec![test_recinfo.into()])]);
-            message::insert(
+            let detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -3734,11 +3710,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map,
                 },
-                expect_time,
                 &profile_converter,
                 (false, true),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
         }
@@ -3819,7 +3795,6 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_multiple_data_in_details.json").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
@@ -3861,6 +3836,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_json_output() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -4066,11 +4042,9 @@ mod tests {
                 .to_str()
                 .unwrap(),
             );
-            let messages = &message::MESSAGES;
-            messages.clear();
             let details_convert_map: HashMap<CompactString, Vec<CompactString>> =
                 HashMap::from_iter([("#AllFieldInfo".into(), vec![test_recinfo.into()])]);
-            message::insert(
+            let message_detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -4086,11 +4060,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map,
                 },
-                expect_time,
                 &profile_converter,
                 (false, true),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(message_detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
         }
@@ -4113,7 +4087,7 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_json.json").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
+
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
@@ -4137,6 +4111,7 @@ mod tests {
 
     #[test]
     fn test_emit_csv_jsonl_output() {
+        let mut additional_afterfact = AfterfactInfo::new();
         let mock_ch_filter = message::create_output_filter_config(
             "test_files/config/channel_abbreviations.txt",
             true,
@@ -4344,9 +4319,8 @@ mod tests {
                 .to_str()
                 .unwrap(),
             );
-            let messages = &message::MESSAGES;
-            messages.clear();
-            message::insert(
+
+            let message_detect_info = message::create_message(
                 &event,
                 CompactString::new(output),
                 DetectInfo {
@@ -4362,11 +4336,11 @@ mod tests {
                     is_condition: false,
                     details_convert_map,
                 },
-                expect_time,
                 &profile_converter,
                 (false, true),
                 (&eventkey_alias, &FieldDataMapKey::default(), &None),
             );
+            additional_afterfact.detect_infos.push(message_detect_info);
             *profile_converter.get_mut("Computer").unwrap() =
                 Profile::Computer(test_computername.into());
         }
@@ -4389,7 +4363,6 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_jsonl.jsonl").unwrap());
 
-        let mut additional_afterfact = AfterfactInfo::new();
         additional_afterfact.record_cnt = 1;
         additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -342,7 +342,7 @@ fn _print_timeline_hist(timestamps: &Vec<i64>, length: usize, side_margin_size: 
     buf_wtr.print(&wtr).ok();
 }
 
-pub fn after_fact(stored_static: &StoredStatic, mut afterfact_info: AfterfactInfo) {
+pub fn after_fact(stored_static: &StoredStatic, afterfact_info: AfterfactInfo) {
     let fn_output_afterfact_err = |err: Box<dyn Error>| {
         AlertMessage::alert(&format!("Failed to write CSV. {err}")).ok();
         process::exit(1);

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -161,48 +161,56 @@ impl AfterfactInfo {
         });
     }
 
-    pub fn get_removed_duplicate_detect_info_idx(
-        &self,
-        stored_static: &StoredStatic,
-    ) -> Vec<usize> {
-        let output_option = stored_static.output_option.as_ref().unwrap();
-        if !output_option.remove_duplicate_detections {
-            return (0..self.detect_infos.len()).collect();
-        }
+    pub fn removed_duplicate_detect_infos(
+        &mut self
+    ) {
+        // https://qiita.com/quasardtm/items/b54a48c1accd675e0bf1
+        let mut tmp_detect_infos = vec![];
+        std::mem::swap(&mut self.detect_infos, &mut tmp_detect_infos);
 
         // filtet duplicate event
-        let mut filtered_detect_infos = vec![];
-        let mut prev_detect_infos = HashSet::new();
-        for (i, detect_info) in self.detect_infos.iter().enumerate() {
-            if filtered_detect_infos.is_empty() {
-                filtered_detect_infos.push(i);
-                continue;
+        let mut filtered_detect_infos:std::collections::HashSet<usize> = std::collections::HashSet::new();
+        {
+            let mut prev_detect_infos = HashSet::new();
+            for (i, detect_info) in tmp_detect_infos.iter().enumerate() {
+                if i == 0 {
+                    filtered_detect_infos.insert(i);
+                    continue;
+                }
+    
+                let prev_detect_info = &tmp_detect_infos[i-1];
+                if prev_detect_info
+                    .detected_time
+                    .cmp(&detect_info.detected_time)
+                    != Ordering::Equal
+                {
+                    filtered_detect_infos.insert(i);
+                    prev_detect_infos.clear();
+                    continue;
+                }
+    
+                let fields: Vec<&(CompactString, Profile)> = detect_info
+                    .ext_field
+                    .iter()
+                    .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
+                    .collect();
+                if prev_detect_infos.get(&fields).is_some() {
+                    continue;
+                }
+                prev_detect_infos.insert(fields);
+                filtered_detect_infos.insert(i);
             }
-
-            let prev_detect_info_idx = *filtered_detect_infos.last().unwrap();
-            let prev_detect_info = &self.detect_infos[prev_detect_info_idx];
-            if prev_detect_info
-                .detected_time
-                .cmp(&detect_info.detected_time)
-                != Ordering::Equal
-            {
-                filtered_detect_infos.push(i);
-                prev_detect_infos.clear();
-                continue;
-            }
-
-            let fields: Vec<&(CompactString, Profile)> = detect_info
-                .ext_field
-                .iter()
-                .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
-                .collect();
-            if prev_detect_infos.get(&fields).is_some() {
-                continue;
-            }
-            prev_detect_infos.insert(fields);
-            filtered_detect_infos.push(i);
         }
-        return filtered_detect_infos;
+
+        tmp_detect_infos = tmp_detect_infos.into_iter().enumerate().filter_map(|(i, detect_info)| {
+            if filtered_detect_infos.contains(&i) {
+                return Some(detect_info);
+            } else {
+                return Option::None;
+            }
+        }).collect();
+
+        std::mem::swap(&mut self.detect_infos, &mut tmp_detect_infos);
     }
 }
 
@@ -451,12 +459,12 @@ fn output_afterfact<W: std::io::Write>(
     additional_afterfact.sort_detect_info();
 
     // filtet duplicate event
-    let detect_infos_idxes =
-        additional_afterfact.get_removed_duplicate_detect_info_idx(stored_static);
+    if output_option.remove_duplicate_detections {
+        additional_afterfact.removed_duplicate_detect_infos();
+    }
 
     // emit csv
-    for idx in detect_infos_idxes.iter() {
-        let detect_info = &additional_afterfact.detect_infos[*idx];
+    for detect_info in additional_afterfact.detect_infos.iter() {
         if displayflag && !(json_output_flag || jsonl_output_flag) {
             // 標準出力の場合
             if plus_header {
@@ -582,8 +590,7 @@ fn output_afterfact<W: std::io::Write>(
     let mut detected_rule_files: HashSet<CompactString> = HashSet::new();
     let mut detected_rule_ids: HashSet<CompactString> = HashSet::new();
     let mut detected_computer_and_rule_names: HashSet<CompactString> = HashSet::new();
-    for idx in detect_infos_idxes.iter() {
-        let detect_info = &additional_afterfact.detect_infos[*idx];
+    for detect_info in additional_afterfact.detect_infos.iter() {
         if !detect_info.is_condition {
             additional_afterfact
                 .detected_record_idset

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -197,11 +197,9 @@ pub fn after_fact(
         // stdoutput (termcolor crate color output is not csv writer)
         Box::new(BufWriter::new(io::stdout()))
     };
-    let color_map = create_output_color_map(stored_static.common_options.no_color);
     if let Err(err) = emit_csv(
         &mut target,
         displayflag,
-        color_map,
         (all_record_cnt as u128, recover_records_cnt as u128),
         stored_static.profiles.as_ref().unwrap(),
         stored_static,
@@ -214,7 +212,6 @@ pub fn after_fact(
 fn emit_csv<W: std::io::Write>(
     writer: &mut W,
     displayflag: bool,
-    color_map: HashMap<CompactString, Colors>,
     (all_record_cnt, recover_records_cnt): (u128, u128),
     profile: &[(CompactString, Profile)],
     stored_static: &StoredStatic,
@@ -331,6 +328,7 @@ fn emit_csv<W: std::io::Write>(
     // remove duplicate dataのための前レコード分の情報を保持する変数
     let mut prev_message: HashMap<CompactString, Profile> = HashMap::new();
     let mut prev_details_convert_map: HashMap<CompactString, Vec<CompactString>> = HashMap::new();
+    let color_map = create_output_color_map(stored_static.common_options.no_color);
     for (message_idx, time) in MESSAGEKEYS
         .lock()
         .unwrap()
@@ -574,7 +572,6 @@ fn emit_csv<W: std::io::Write>(
         detected_record_idset,
         total_detect_counts_by_level,
         unique_detect_counts_by_level,
-        color_map,
         detect_counts_by_date_and_level,
         detect_counts_by_computer_and_level,
         detect_counts_by_rule_and_level,
@@ -597,7 +594,6 @@ fn output_summary(
     detected_record_idset: HashSet<CompactString>,
     total_detect_counts_by_level: Vec<u128>,
     unique_detect_counts_by_level: Vec<u128>,
-    color_map: HashMap<CompactString, Colors>,
     detect_counts_by_date_and_level: HashMap<CompactString, HashMap<CompactString, i128>>,
     detect_counts_by_computer_and_level: HashMap<CompactString, HashMap<CompactString, i128>>,
     detect_counts_by_rule_and_level: HashMap<CompactString, HashMap<CompactString, i128>>,
@@ -850,6 +846,7 @@ fn output_summary(
             ));
         }
 
+        let color_map = create_output_color_map(stored_static.common_options.no_color);
         _print_unique_results(
             total_detect_counts_by_level,
             unique_detect_counts_by_level,
@@ -2335,7 +2332,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -2657,7 +2653,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -2988,7 +2983,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -3394,7 +3388,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -3724,7 +3717,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -4013,7 +4005,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,
@@ -4284,7 +4275,6 @@ mod tests {
         assert!(emit_csv(
             &mut file,
             false,
-            HashMap::new(),
             (1, 0),
             &output_profile,
             &stored_static,

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -2,14 +2,13 @@ use crate::detections::configs::{
     Action, OutputOption, StoredStatic, CONTROL_CHAT_REPLACE_MAP, CURRENT_EXE_PATH, GEOIP_DB_PARSER,
 };
 use crate::detections::message::{
-    self, AlertMessage, COMPUTER_MITRE_ATTCK_MAP, LEVEL_FULL, MESSAGEKEYS,
+    AlertMessage, DetectInfo, COMPUTER_MITRE_ATTCK_MAP, LEVEL_FULL
 };
 use crate::detections::utils::{
     self, format_time, get_writable_color, output_and_data_stack_for_html, write_color_buffer,
 };
 use crate::options::htmlreport;
 use crate::options::profile::Profile;
-use crate::timeline::timelines::Timeline;
 use crate::yaml::ParseYaml;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use chrono::{DateTime, Local, TimeZone, Utc};
@@ -30,7 +29,7 @@ use yaml_rust::YamlLoader;
 use comfy_table::*;
 use hashbrown::{HashMap, HashSet};
 use num_format::{Locale, ToFormattedString};
-use std::cmp::{self, min};
+use std::cmp::{self, min, Ordering};
 use std::error::Error;
 
 use std::io::{self, BufWriter, Write};
@@ -46,11 +45,12 @@ pub struct Colors {
     pub table_color: comfy_table::Color,
 }
 
-pub struct AdditionalAfterfact {
+pub struct AfterfactInfo {
+    pub detect_infos: Vec<DetectInfo>,
     pub tl_starttime: Option<DateTime<Utc>>,
     pub tl_endtime: Option<DateTime<Utc>>,
-    pub all_record_cnt: u128,
-    pub recover_records_cnt: u128,
+    pub record_cnt: u128,
+    pub recover_record_cnt: u128,
     pub detected_record_idset: HashSet<CompactString>,
     pub total_detect_counts_by_level: Vec<u128>,
     pub unique_detect_counts_by_level: Vec<u128>,
@@ -63,18 +63,19 @@ pub struct AdditionalAfterfact {
     pub timestamps: Vec<i64>,
 }
 
-impl AdditionalAfterfact {
-    pub fn new() -> AdditionalAfterfact {
+impl AfterfactInfo {
+    pub fn new() -> AfterfactInfo {
         let (
             detect_counts_by_date_and_level,
             detect_counts_by_computer_and_level,
             detect_counts_by_rule_and_level,
-        ) = AdditionalAfterfact::init_level_map();
-        AdditionalAfterfact {
+        ) = AfterfactInfo::init_level_map();
+        AfterfactInfo {
+            detect_infos: vec![],
             tl_starttime: Option::None,
             tl_endtime: Option::None,
-            all_record_cnt: 0,
-            recover_records_cnt: 0,
+            record_cnt: 0,
+            recover_record_cnt: 0,
             detected_record_idset: HashSet::new(),
             total_detect_counts_by_level: vec![0; 6],
             unique_detect_counts_by_level: vec![0; 6],
@@ -248,10 +249,8 @@ fn _print_timeline_hist(timestamps: &Vec<i64>, length: usize, side_margin_size: 
 }
 
 pub fn after_fact(
-    all_record_cnt: usize,
     stored_static: &StoredStatic,
-    tl: Timeline,
-    recover_records_cnt: usize,
+    afterfact_info: AfterfactInfo,
 ) {
     let fn_emit_csv_err = |err: Box<dyn Error>| {
         AlertMessage::alert(&format!("Failed to write CSV. {err}")).ok();
@@ -273,18 +272,13 @@ pub fn after_fact(
         // stdoutput (termcolor crate color output is not csv writer)
         Box::new(BufWriter::new(io::stdout()))
     };
-    let mut additinal_afterfact = AdditionalAfterfact::new();
-    additinal_afterfact.all_record_cnt = all_record_cnt as u128;
-    additinal_afterfact.recover_records_cnt = recover_records_cnt as u128;
-    additinal_afterfact.tl_starttime = tl.stats.start_time;
-    additinal_afterfact.tl_starttime = tl.stats.end_time;
 
     if let Err(err) = emit_csv(
         &mut target,
         displayflag,
         stored_static.profiles.as_ref().unwrap(),
         stored_static,
-        additinal_afterfact,
+        afterfact_info,
     ) {
         fn_emit_csv_err(Box::new(err));
     }
@@ -295,7 +289,7 @@ fn emit_csv<W: std::io::Write>(
     displayflag: bool,
     profile: &[(CompactString, Profile)],
     stored_static: &StoredStatic,
-    mut additional_afterfact: AdditionalAfterfact,
+    mut additional_afterfact: AfterfactInfo,
 ) -> io::Result<()> {
     let output_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("🛂r", "\r"), ("🛂n", "\n"), ("🛂t", "\t")]);
@@ -386,73 +380,72 @@ fn emit_csv<W: std::io::Write>(
     let mut prev_message: HashMap<CompactString, Profile> = HashMap::new();
     let mut prev_details_convert_map: HashMap<CompactString, Vec<CompactString>> = HashMap::new();
     let color_map = create_output_color_map(stored_static.common_options.no_color);
-    for (_, time) in MESSAGEKEYS
-        .lock()
-        .unwrap()
-        .iter()
-        .sorted_unstable()
-        .enumerate()
-    {
-        let multi = message::MESSAGES.get(time).unwrap();
-        let (_, detect_infos) = multi.pair();
-        let mut prev_detect_infos = HashSet::new();
-        additional_afterfact
-            .timestamps
-            .push(_get_timestamp(output_option, time));
-        for detect_info in detect_infos.iter().sorted_by(|a, b| {
-            Ord::cmp(
-                &format!(
-                    "{}:{}:{}:{}",
-                    get_level_suffix(a.level.as_str()),
-                    a.eventid,
-                    a.rulepath,
-                    a.computername
-                ),
-                &format!(
-                    "{}:{}:{}:{}",
-                    get_level_suffix(b.level.as_str()),
-                    b.eventid,
-                    b.rulepath,
-                    b.computername
-                ),
-            )
-        }) {
-            if output_option.remove_duplicate_detections && detect_infos.len() > 1 {
-                let fields: Vec<&(CompactString, Profile)> = detect_info
-                    .ext_field
-                    .iter()
-                    .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
-                    .collect();
-                if prev_detect_infos.get(&fields).is_some() {
-                    continue;
-                }
-                prev_detect_infos.insert(fields);
-            }
-            if displayflag && !(json_output_flag || jsonl_output_flag) {
-                // 標準出力の場合
-                if plus_header {
-                    // ヘッダーのみを出力
-                    _get_serialized_disp_output(
-                        &disp_wtr,
-                        profile,
-                        true,
-                        (&output_replacer, &output_replaced_maps),
-                        (&output_remover, &removed_replaced_maps),
-                        stored_static.common_options.no_color,
-                        get_writable_color(
-                            _get_output_color(
-                                &color_map,
-                                LEVEL_FULL.get(detect_info.level.as_str()).unwrap_or(&""),
-                            ),
-                            stored_static.common_options.no_color,
-                        ),
-                    );
-                    plus_header = false;
-                }
+
+
+    additional_afterfact.detect_infos.sort_unstable_by(|a, b| {
+        let cmp_time = a.detected_time.cmp(&b.detected_time);
+        if cmp_time != Ordering::Equal {
+            return cmp_time;
+        }
+
+        let a_level = get_level_suffix(a.level.as_str());
+        let b_level = get_level_suffix(b.level.as_str());
+        let level_cmp = a_level.cmp(&b_level);
+        if level_cmp != Ordering::Equal {
+            return level_cmp;
+        }
+
+        let event_id_cmp = a.eventid.cmp(&b.eventid);
+        if event_id_cmp != Ordering::Equal {
+            return event_id_cmp;
+        }
+
+        let rulepath_cmp = a.rulepath.cmp(&b.rulepath);
+        if rulepath_cmp != Ordering::Equal {
+            return rulepath_cmp;
+        }
+
+        return a.computername.cmp(&b.computername);
+    });
+
+    // filtet duplicate event
+    let mut filtered_detect_infos = vec![];
+    let mut prev_detect_infos = HashSet::new();
+    for detect_info in additional_afterfact.detect_infos.iter() {
+        if filtered_detect_infos.is_empty() {
+            filtered_detect_infos.push(detect_info);
+            continue;
+        }
+
+        let prev_detect_info = filtered_detect_infos.last().unwrap();
+        if prev_detect_info.detected_time.cmp(&detect_info.detected_time) != Ordering::Equal {
+            filtered_detect_infos.push(detect_info);
+            prev_detect_infos.clear();
+            continue;
+        }
+
+        let fields: Vec<&(CompactString, Profile)> = detect_info
+            .ext_field
+            .iter()
+            .filter(|(_, profile)| !matches!(profile, Profile::EvtxFile(_)))
+            .collect();
+        if prev_detect_infos.get(&fields).is_some() {
+            continue;
+        }
+        prev_detect_infos.insert(fields);
+        filtered_detect_infos.push(detect_info);
+    }
+
+    // emit csv
+    for detect_info in filtered_detect_infos.iter() {
+        if displayflag && !(json_output_flag || jsonl_output_flag) {
+            // 標準出力の場合
+            if plus_header {
+                // ヘッダーのみを出力
                 _get_serialized_disp_output(
                     &disp_wtr,
-                    &detect_info.ext_field,
-                    false,
+                    profile,
+                    true,
                     (&output_replacer, &output_replaced_maps),
                     (&output_remover, &removed_replaced_maps),
                     stored_static.common_options.no_color,
@@ -464,156 +457,176 @@ fn emit_csv<W: std::io::Write>(
                         stored_static.common_options.no_color,
                     ),
                 );
-            } else if jsonl_output_flag {
-                // JSONL output format
-                let result = output_json_str(
-                    &detect_info.ext_field,
-                    prev_message,
-                    jsonl_output_flag,
-                    GEOIP_DB_PARSER.read().unwrap().is_some(),
-                    remove_duplicate_data_flag,
-                    detect_info.is_condition,
-                    &[&detect_info.details_convert_map, &prev_details_convert_map],
-                );
-                prev_message = result.1;
-                prev_details_convert_map = detect_info.details_convert_map.clone();
-                if displayflag {
-                    write_color_buffer(&disp_wtr, None, &format!("{{ {} }}", &result.0), true).ok();
-                } else {
-                    wtr.write_field(format!("{{ {} }}", &result.0))?;
-                }
-            } else if json_output_flag {
-                // JSON output
-                let result = output_json_str(
-                    &detect_info.ext_field,
-                    prev_message,
-                    jsonl_output_flag,
-                    GEOIP_DB_PARSER.read().unwrap().is_some(),
-                    remove_duplicate_data_flag,
-                    detect_info.is_condition,
-                    &[&detect_info.details_convert_map, &prev_details_convert_map],
-                );
-                prev_message = result.1;
-                prev_details_convert_map = detect_info.details_convert_map.clone();
-                if displayflag {
-                    write_color_buffer(&disp_wtr, None, &format!("{{\n{}\n}}", &result.0), true)
-                        .ok();
-                } else {
-                    wtr.write_field("{")?;
-                    wtr.write_field(&result.0)?;
-                    wtr.write_field("}")?;
-                }
+                plus_header = false;
+            }
+            _get_serialized_disp_output(
+                &disp_wtr,
+                &detect_info.ext_field,
+                false,
+                (&output_replacer, &output_replaced_maps),
+                (&output_remover, &removed_replaced_maps),
+                stored_static.common_options.no_color,
+                get_writable_color(
+                    _get_output_color(
+                        &color_map,
+                        LEVEL_FULL.get(detect_info.level.as_str()).unwrap_or(&""),
+                    ),
+                    stored_static.common_options.no_color,
+                ),
+            );
+        } else if jsonl_output_flag {
+            // JSONL output format
+            let result = output_json_str(
+                &detect_info.ext_field,
+                prev_message,
+                jsonl_output_flag,
+                GEOIP_DB_PARSER.read().unwrap().is_some(),
+                remove_duplicate_data_flag,
+                detect_info.is_condition,
+                &[&detect_info.details_convert_map, &prev_details_convert_map],
+            );
+            prev_message = result.1;
+            prev_details_convert_map = detect_info.details_convert_map.clone();
+            if displayflag {
+                write_color_buffer(&disp_wtr, None, &format!("{{ {} }}", &result.0), true).ok();
             } else {
-                // csv output format
-                if plus_header {
-                    wtr.write_record(detect_info.ext_field.iter().map(|x| x.0.trim()))?;
-                    plus_header = false;
-                }
-                wtr.write_record(detect_info.ext_field.iter().map(|x| {
-                    match x.1 {
-                        Profile::Details(_)
-                        | Profile::AllFieldInfo(_)
-                        | Profile::ExtraFieldInfo(_) => {
-                            let ret = if remove_duplicate_data_flag
-                                && x.1.to_value()
-                                    == prev_message
-                                        .get(&x.0)
-                                        .unwrap_or(&Profile::Literal("-".into()))
-                                        .to_value()
-                            {
-                                "DUP".to_string()
-                            } else {
-                                output_remover.replace_all(
-                                    &output_replacer
-                                        .replace_all(
-                                            &x.1.to_value(),
-                                            &output_replaced_maps.values().collect_vec(),
-                                        )
-                                        .split_whitespace()
-                                        .join(" "),
-                                    &removed_replaced_maps.values().collect_vec(),
-                                )
-                            };
-                            prev_message.insert(x.0.clone(), x.1.clone());
-                            ret
-                        }
-                        _ => output_remover.replace_all(
-                            &output_replacer
-                                .replace_all(
-                                    &x.1.to_value(),
-                                    &output_replaced_maps.values().collect_vec(),
-                                )
-                                .split_whitespace()
-                                .join(" "),
-                            &removed_replaced_maps.values().collect_vec(),
-                        ),
+                wtr.write_field(format!("{{ {} }}", &result.0))?;
+            }
+        } else if json_output_flag {
+            // JSON output
+            let result = output_json_str(
+                &detect_info.ext_field,
+                prev_message,
+                jsonl_output_flag,
+                GEOIP_DB_PARSER.read().unwrap().is_some(),
+                remove_duplicate_data_flag,
+                detect_info.is_condition,
+                &[&detect_info.details_convert_map, &prev_details_convert_map],
+            );
+            prev_message = result.1;
+            prev_details_convert_map = detect_info.details_convert_map.clone();
+            if displayflag {
+                write_color_buffer(&disp_wtr, None, &format!("{{\n{}\n}}", &result.0), true)
+                    .ok();
+            } else {
+                wtr.write_field("{")?;
+                wtr.write_field(&result.0)?;
+                wtr.write_field("}")?;
+            }
+        } else {
+            // csv output format
+            if plus_header {
+                wtr.write_record(detect_info.ext_field.iter().map(|x| x.0.trim()))?;
+                plus_header = false;
+            }
+            wtr.write_record(detect_info.ext_field.iter().map(|x| {
+                match x.1 {
+                    Profile::Details(_)
+                    | Profile::AllFieldInfo(_)
+                    | Profile::ExtraFieldInfo(_) => {
+                        let ret = if remove_duplicate_data_flag
+                            && x.1.to_value()
+                                == prev_message
+                                    .get(&x.0)
+                                    .unwrap_or(&Profile::Literal("-".into()))
+                                    .to_value()
+                        {
+                            "DUP".to_string()
+                        } else {
+                            output_remover.replace_all(
+                                &output_replacer
+                                    .replace_all(
+                                        &x.1.to_value(),
+                                        &output_replaced_maps.values().collect_vec(),
+                                    )
+                                    .split_whitespace()
+                                    .join(" "),
+                                &removed_replaced_maps.values().collect_vec(),
+                            )
+                        };
+                        prev_message.insert(x.0.clone(), x.1.clone());
+                        ret
                     }
-                }))?;
+                    _ => output_remover.replace_all(
+                        &output_replacer
+                            .replace_all(
+                                &x.1.to_value(),
+                                &output_replaced_maps.values().collect_vec(),
+                            )
+                            .split_whitespace()
+                            .join(" "),
+                        &removed_replaced_maps.values().collect_vec(),
+                    ),
+                }
+            }))?;
+        }
+    }
+
+    // calculate statistic information
+    for detect_info in filtered_detect_infos.iter() {
+        // 各種集計作業
+        if !detect_info.is_condition {
+            additional_afterfact
+                .detected_record_idset
+                .insert(CompactString::from(format!(
+                    "{}_{}",
+                    detect_info.detected_time, detect_info.eventid
+                )));
+        }
+
+        if !output_option.no_summary {
+            let level_suffix = get_level_suffix(detect_info.level.as_str());
+            let author_list = author_list_cache
+                .entry(detect_info.rulepath.clone())
+                .or_insert_with(|| extract_author_name(&detect_info.rulepath))
+                .clone();
+            let author_str = author_list.iter().join(", ");
+            additional_afterfact
+                .detect_rule_authors
+                .insert(detect_info.rulepath.to_owned(), author_str.into());
+
+            if !detected_rule_files.contains(&detect_info.rulepath) {
+                detected_rule_files.insert(detect_info.rulepath.to_owned());
+                for author in author_list.iter() {
+                    *additional_afterfact
+                        .rule_author_counter
+                        .entry(CompactString::from(author))
+                        .or_insert(0) += 1;
+                }
             }
-            // 各種集計作業
-            if !detect_info.is_condition {
-                additional_afterfact
-                    .detected_record_idset
-                    .insert(CompactString::from(format!(
-                        "{}_{}",
-                        time, detect_info.eventid
-                    )));
+            if !detected_rule_ids.contains(&detect_info.ruleid) {
+                detected_rule_ids.insert(detect_info.ruleid.to_owned());
+                additional_afterfact.unique_detect_counts_by_level[level_suffix] += 1;
             }
 
-            if !output_option.no_summary {
-                let level_suffix = get_level_suffix(detect_info.level.as_str());
-                let author_list = author_list_cache
-                    .entry(detect_info.rulepath.clone())
-                    .or_insert_with(|| extract_author_name(&detect_info.rulepath))
-                    .clone();
-                let author_str = author_list.iter().join(", ");
-                additional_afterfact
-                    .detect_rule_authors
-                    .insert(detect_info.rulepath.to_owned(), author_str.into());
-
-                if !detected_rule_files.contains(&detect_info.rulepath) {
-                    detected_rule_files.insert(detect_info.rulepath.to_owned());
-                    for author in author_list.iter() {
-                        *additional_afterfact
-                            .rule_author_counter
-                            .entry(CompactString::from(author))
-                            .or_insert(0) += 1;
-                    }
-                }
-                if !detected_rule_ids.contains(&detect_info.ruleid) {
-                    detected_rule_ids.insert(detect_info.ruleid.to_owned());
-                    additional_afterfact.unique_detect_counts_by_level[level_suffix] += 1;
-                }
-
-                let computer_rule_check_key = CompactString::from(format!(
-                    "{}|{}",
-                    &detect_info.computername, &detect_info.rulepath
-                ));
-                if !detected_computer_and_rule_names.contains(&computer_rule_check_key) {
-                    detected_computer_and_rule_names.insert(computer_rule_check_key);
-                    countup_aggregation(
-                        &mut additional_afterfact.detect_counts_by_computer_and_level,
-                        &detect_info.level,
-                        &detect_info.computername,
-                    );
-                }
-                additional_afterfact.rule_title_path_map.insert(
-                    detect_info.ruletitle.to_owned(),
-                    detect_info.rulepath.to_owned(),
-                );
-
+            let computer_rule_check_key = CompactString::from(format!(
+                "{}|{}",
+                &detect_info.computername, &detect_info.rulepath
+            ));
+            if !detected_computer_and_rule_names.contains(&computer_rule_check_key) {
+                detected_computer_and_rule_names.insert(computer_rule_check_key);
                 countup_aggregation(
-                    &mut additional_afterfact.detect_counts_by_date_and_level,
+                    &mut additional_afterfact.detect_counts_by_computer_and_level,
                     &detect_info.level,
-                    &format_time(time, true, output_option),
+                    &detect_info.computername,
                 );
-                countup_aggregation(
-                    &mut additional_afterfact.detect_counts_by_rule_and_level,
-                    &detect_info.level,
-                    &detect_info.ruletitle,
-                );
-                additional_afterfact.total_detect_counts_by_level[level_suffix] += 1;
             }
+            additional_afterfact.rule_title_path_map.insert(
+                detect_info.ruletitle.to_owned(),
+                detect_info.rulepath.to_owned(),
+            );
+
+            countup_aggregation(
+                &mut additional_afterfact.detect_counts_by_date_and_level,
+                &detect_info.level,
+                &format_time(&detect_info.detected_time, true, output_option),
+            );
+            countup_aggregation(
+                &mut additional_afterfact.detect_counts_by_rule_and_level,
+                &detect_info.level,
+                &detect_info.ruletitle,
+            );
+            additional_afterfact.total_detect_counts_by_level[level_suffix] += 1;
         }
     }
 
@@ -625,7 +638,7 @@ fn emit_csv<W: std::io::Write>(
 
     disp_wtr_buf.clear();
 
-    output_additional_afterfact(stored_static, &disp_wtr, disp_wtr_buf, additional_afterfact);
+    output_additional_afterfact(stored_static, &disp_wtr, disp_wtr_buf, &additional_afterfact);
 
     Ok(())
 }
@@ -634,7 +647,7 @@ fn output_additional_afterfact(
     stored_static: &StoredStatic,
     disp_wtr: &BufferWriter,
     mut disp_wtr_buf: Buffer,
-    additional_afterfact: AdditionalAfterfact,
+    additional_afterfact: &AfterfactInfo,
 ) {
     let terminal_width = match terminal_size() {
         Some((Width(w), _)) => w as usize,
@@ -686,7 +699,7 @@ fn output_additional_afterfact(
         } else {
             6
         };
-        output_detected_rule_authors(additional_afterfact.rule_author_counter, table_column_num);
+        output_detected_rule_authors(&additional_afterfact.rule_author_counter, table_column_num);
     }
 
     println!();
@@ -739,12 +752,12 @@ fn output_additional_afterfact(
             println!();
         }
 
-        let reducted_record_cnt: u128 = additional_afterfact.all_record_cnt
+        let reducted_record_cnt: u128 = additional_afterfact.record_cnt
             - additional_afterfact.detected_record_idset.len() as u128;
-        let reducted_percent = if additional_afterfact.all_record_cnt == 0 {
+        let reducted_percent = if additional_afterfact.record_cnt == 0 {
             0 as f64
         } else {
-            (reducted_record_cnt as f64) / (additional_afterfact.all_record_cnt as f64) * 100.0
+            (reducted_record_cnt as f64) / (additional_afterfact.record_cnt as f64) * 100.0
         };
         write_color_buffer(
             &disp_wtr,
@@ -780,7 +793,7 @@ fn output_additional_afterfact(
             false,
         )
         .ok();
-        let saved_alerts_output = (additional_afterfact.all_record_cnt - reducted_record_cnt)
+        let saved_alerts_output = (additional_afterfact.record_cnt - reducted_record_cnt)
             .to_formatted_string(&Locale::en);
         write_color_buffer(
             &disp_wtr,
@@ -801,7 +814,7 @@ fn output_additional_afterfact(
         .ok();
 
         let all_record_output = additional_afterfact
-            .all_record_cnt
+            .record_cnt
             .to_formatted_string(&Locale::en);
         write_color_buffer(
             &disp_wtr,
@@ -862,7 +875,7 @@ fn output_additional_afterfact(
             )
             .ok();
             let recovered_record_output = additional_afterfact
-                .recover_records_cnt
+                .recover_record_cnt
                 .to_formatted_string(&Locale::en);
             write_color_buffer(
                 &disp_wtr,
@@ -884,15 +897,15 @@ fn output_additional_afterfact(
             html_output_stock.push(format!(
                 "- Recovered events analyzed: {}",
                 &additional_afterfact
-                    .recover_records_cnt
+                    .recover_record_cnt
                     .to_formatted_string(&Locale::en)
             ));
         }
 
         let color_map = create_output_color_map(stored_static.common_options.no_color);
         _print_unique_results(
-            additional_afterfact.total_detect_counts_by_level,
-            additional_afterfact.unique_detect_counts_by_level,
+            &additional_afterfact.total_detect_counts_by_level,
+            &additional_afterfact.unique_detect_counts_by_level,
             (
                 CompactString::from("Total | Unique"),
                 CompactString::from("detections"),
@@ -905,7 +918,7 @@ fn output_additional_afterfact(
         println!();
 
         _print_detection_summary_by_date(
-            additional_afterfact.detect_counts_by_date_and_level,
+            &additional_afterfact.detect_counts_by_date_and_level,
             &color_map,
             &level_abbr,
             &mut html_output_stock,
@@ -918,7 +931,7 @@ fn output_additional_afterfact(
         }
 
         _print_detection_summary_by_computer(
-            additional_afterfact.detect_counts_by_computer_and_level,
+            &additional_afterfact.detect_counts_by_computer_and_level,
             &color_map,
             &level_abbr,
             &mut html_output_stock,
@@ -930,11 +943,11 @@ fn output_additional_afterfact(
         }
 
         _print_detection_summary_tables(
-            additional_afterfact.detect_counts_by_rule_and_level,
+            &additional_afterfact.detect_counts_by_rule_and_level,
             &color_map,
             (
-                additional_afterfact.rule_title_path_map,
-                additional_afterfact.detect_rule_authors,
+                &additional_afterfact.rule_title_path_map,
+                &additional_afterfact.detect_rule_authors,
             ),
             &level_abbr,
             &mut html_output_stock,
@@ -1127,8 +1140,8 @@ fn _format_cellpos(colval: &str, column: ColPos) -> String {
 
 /// output info which unique detection count and all detection count information(separated by level and total) to stdout.
 fn _print_unique_results(
-    mut counts_by_level: Vec<u128>,
-    mut unique_counts_by_level: Vec<u128>,
+    counts_by_level: &Vec<u128>,
+    unique_counts_by_level: &Vec<u128>,
     head_and_tail_word: (CompactString, CompactString),
     color_map: &HashMap<CompactString, Colors>,
     level_abbr: &Nested<Vec<CompactString>>,
@@ -1136,8 +1149,8 @@ fn _print_unique_results(
     html_output_flag: bool,
 ) {
     // the order in which are registered and the order of levels to be displayed are reversed
-    counts_by_level.reverse();
-    unique_counts_by_level.reverse();
+    let mut counts_by_level_rev = counts_by_level.iter().rev();
+    let mut unique_counts_by_level_rev = unique_counts_by_level.iter().rev();
 
     let total_count = counts_by_level.iter().sum::<u128>();
     let unique_total_count = unique_counts_by_level.iter().sum::<u128>();
@@ -1160,13 +1173,15 @@ fn _print_unique_results(
     let mut unique_detect_md = vec!["- Unique detections:".to_string()];
 
     for (i, level_name) in level_abbr.iter().enumerate() {
+        let count_by_level = *counts_by_level_rev.next().unwrap();
+        let unique_count_by_level = *unique_counts_by_level_rev.next().unwrap();
         if "undefined" == level_name[0] {
             continue;
         }
         let percent = if total_count == 0 {
             0 as f64
         } else {
-            (counts_by_level[i] as f64) / (total_count as f64) * 100.0
+            (count_by_level as f64) / (total_count as f64) * 100.0
         };
         let unique_percent = if unique_total_count == 0 {
             0 as f64
@@ -1177,13 +1192,13 @@ fn _print_unique_results(
             total_detect_md.push(format!(
                 "    - {}: {} ({:.2}%)",
                 level_name[0],
-                counts_by_level[i].to_formatted_string(&Locale::en),
+                count_by_level.to_formatted_string(&Locale::en),
                 percent
             ));
             unique_detect_md.push(format!(
                 "    - {}: {} ({:.2}%)",
                 level_name[0],
-                unique_counts_by_level[i].to_formatted_string(&Locale::en),
+                unique_count_by_level.to_formatted_string(&Locale::en),
                 unique_percent
             ));
         }
@@ -1192,9 +1207,9 @@ fn _print_unique_results(
             head_and_tail_word.0,
             level_name[0],
             head_and_tail_word.1,
-            counts_by_level[i].to_formatted_string(&Locale::en),
+            count_by_level.to_formatted_string(&Locale::en),
             percent,
-            unique_counts_by_level[i].to_formatted_string(&Locale::en),
+            unique_count_by_level.to_formatted_string(&Locale::en),
             unique_percent
         );
         write_color_buffer(
@@ -1213,7 +1228,7 @@ fn _print_unique_results(
 
 /// 各レベル毎で最も高い検知数を出した日付を出力する
 fn _print_detection_summary_by_date(
-    detect_counts_by_date: HashMap<CompactString, HashMap<CompactString, i128>>,
+    detect_counts_by_date: &HashMap<CompactString, HashMap<CompactString, i128>>,
     color_map: &HashMap<CompactString, Colors>,
     level_abbr: &Nested<Vec<CompactString>>,
     html_output_stock: &mut Nested<String>,
@@ -1269,7 +1284,7 @@ fn _print_detection_summary_by_date(
 
 /// 各レベル毎で最も高い検知数を出したコンピュータ名を出力する
 fn _print_detection_summary_by_computer(
-    detect_counts_by_computer: HashMap<CompactString, HashMap<CompactString, i128>>,
+    detect_counts_by_computer: &HashMap<CompactString, HashMap<CompactString, i128>>,
     color_map: &HashMap<CompactString, Colors>,
     level_abbr: &Nested<Vec<CompactString>>,
     html_output_stock: &mut Nested<String>,
@@ -1339,11 +1354,11 @@ fn _print_detection_summary_by_computer(
 
 /// 各レベルごとで検出数が多かったルールを表形式で出力する関数
 fn _print_detection_summary_tables(
-    detect_counts_by_rule_and_level: HashMap<CompactString, HashMap<CompactString, i128>>,
+    detect_counts_by_rule_and_level: &HashMap<CompactString, HashMap<CompactString, i128>>,
     color_map: &HashMap<CompactString, Colors>,
     (rule_title_path_map, rule_detect_author_map): (
-        HashMap<CompactString, CompactString>,
-        HashMap<CompactString, CompactString>,
+        &HashMap<CompactString, CompactString>,
+        &HashMap<CompactString, CompactString>,
     ),
     level_abbr: &Nested<Vec<CompactString>>,
     html_output_stock: &mut Nested<String>,
@@ -1906,7 +1921,7 @@ pub fn output_json_str(
 
 /// output detected rule author name function.
 fn output_detected_rule_authors(
-    rule_author_counter: HashMap<CompactString, i128>,
+    rule_author_counter: &HashMap<CompactString, i128>,
     table_column_num: usize,
 ) {
     let mut sorted_authors: Vec<(&CompactString, &i128)> = rule_author_counter.iter().collect();
@@ -2033,7 +2048,7 @@ mod tests {
     use super::create_output_color_map;
     use crate::afterfact::emit_csv;
     use crate::afterfact::format_time;
-    use crate::afterfact::AdditionalAfterfact;
+    use crate::afterfact::AfterfactInfo;
     use crate::afterfact::Colors;
     use crate::detections::configs::load_eventkey_alias;
     use crate::detections::configs::Action;
@@ -2378,9 +2393,9 @@ mod tests {
                 + "\"\n";
         let mut file: Box<dyn io::Write> = Box::new(File::create("./test_emit_csv.csv").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -2705,9 +2720,9 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_multiline.csv").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -3041,9 +3056,9 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_remove_duplicate.csv").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -3451,9 +3466,9 @@ mod tests {
 
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_remove_duplicate.json").unwrap());
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -3785,9 +3800,9 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_multiple_data_in_details.json").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -4079,9 +4094,9 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_json.json").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(
@@ -4355,9 +4370,9 @@ mod tests {
         let mut file: Box<dyn io::Write> =
             Box::new(File::create("./test_emit_csv_jsonl.jsonl").unwrap());
 
-        let mut additional_afterfact = AdditionalAfterfact::new();
-        additional_afterfact.all_record_cnt = 1;
-        additional_afterfact.recover_records_cnt = 0;
+        let mut additional_afterfact = AfterfactInfo::new();
+        additional_afterfact.record_cnt = 1;
+        additional_afterfact.recover_record_cnt = 0;
         additional_afterfact.tl_starttime = Some(expect_tz);
         additional_afterfact.tl_endtime = Some(expect_tz);
         assert!(emit_csv(

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -90,6 +90,7 @@ pub struct StoredStatic {
     pub no_pwsh_field_extraction: bool,
     pub enable_recover_records: bool,
     pub timeline_offset: Option<String>,
+    pub is_low_memory: bool,
 }
 impl StoredStatic {
     /// main.rsでパースした情報からデータを格納する関数
@@ -558,6 +559,7 @@ impl StoredStatic {
         };
 
         let mut ret = StoredStatic {
+            is_low_memory: false,
             config: input_config.as_ref().unwrap().to_owned(),
             config_path: config_path.to_path_buf(),
             ch_config: create_output_filter_config(
@@ -692,6 +694,7 @@ impl StoredStatic {
             .unwrap(),
             Some(&ret),
         );
+        ret.is_low_memory = false;
         ret
     }
     /// detailsのdefault値をファイルから読み取る関数

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -209,7 +209,7 @@ impl Detection {
             }
         }
 
-        return ret;
+        ret
     }
 
     // 複数のイベントレコードに対して、ルールを1個実行します。
@@ -248,7 +248,7 @@ impl Detection {
             }
         }
 
-        return (rule, ret);
+        (rule, ret)
     }
 
     /// create log record
@@ -743,7 +743,8 @@ impl Detection {
             is_condition: false,
             details_convert_map: HashMap::default(),
         };
-        let detect_info = message::create_message(
+
+        message::create_message(
             &record_info.record,
             CompactString::new(details_fmt_str),
             detect_info,
@@ -754,9 +755,7 @@ impl Detection {
                 &field_data_map_key,
                 &stored_static.field_data_map,
             ),
-        );
-
-        return detect_info;
+        )
     }
 
     fn create_agg_log_record(
@@ -980,7 +979,7 @@ impl Detection {
             (true, is_json_timeline),
             (eventkey_alias, &field_data_map_key, &None),
         );
-        return detect_info;
+        detect_info
     }
 
     /// rule内のtagsの内容を配列として返却する関数

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -731,6 +731,7 @@ impl Detection {
             }
         };
         let detect_info = DetectInfo {
+            detected_time: time,
             rulepath: CompactString::from(&rule.rulepath),
             ruleid: CompactString::from(rule.yaml["id"].as_str().unwrap_or("-")),
             ruletitle: CompactString::from(rule.yaml["title"].as_str().unwrap_or("-")),
@@ -962,6 +963,7 @@ impl Detection {
         }
         let str_level = level.as_str();
         let detect_info = DetectInfo {
+            detected_time: agg_result.start_timedate,
             rulepath: CompactString::from(&rule.rulepath),
             ruleid: CompactString::from(rule.yaml["id"].as_str().unwrap_or("-")),
             ruletitle: CompactString::from(rule.yaml["title"].as_str().unwrap_or("-")),

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -66,11 +66,7 @@ impl Detection {
         Detection { rules: rule_nodes }
     }
 
-    pub fn start(
-        self,
-        rt: &Runtime,
-        records: Vec<EvtxRecordInfo>,
-    ) -> (Self, Vec<DetectInfo>) {
+    pub fn start(self, rt: &Runtime, records: Vec<EvtxRecordInfo>) -> (Self, Vec<DetectInfo>) {
         rt.block_on(self.execute_rules(records))
     }
 
@@ -162,10 +158,7 @@ impl Detection {
     }
 
     // 複数のイベントレコードに対して、複数のルールを1個実行します。
-    async fn execute_rules(
-        mut self,
-        records: Vec<EvtxRecordInfo>,
-    ) -> (Self, Vec<DetectInfo>) {
+    async fn execute_rules(mut self, records: Vec<EvtxRecordInfo>) -> (Self, Vec<DetectInfo>) {
         let records_arc = Arc::new(records);
         // // 各rule毎にスレッドを作成して、スレッドを起動する。
         let rules = self.rules;
@@ -204,10 +197,7 @@ impl Detection {
         return rt.block_on(self.add_aggcondition_msg(stored_static));
     }
 
-    async fn add_aggcondition_msg(
-        &self,
-        stored_static: &StoredStatic,
-    ) -> Vec<DetectInfo> {
+    async fn add_aggcondition_msg(&self, stored_static: &StoredStatic) -> Vec<DetectInfo> {
         let mut ret = vec![];
         for rule in &self.rules {
             if !rule.has_agg_condition() {
@@ -1615,8 +1605,7 @@ mod tests {
                 let rule = &dummy_rule;
                 let record_info = &input_evtxrecord;
                 let stored_static = &stored_static;
-                let detect_info =
-                    Detection::create_log_record(rule, record_info, stored_static);
+                let detect_info = Detection::create_log_record(rule, record_info, stored_static);
 
                 let expect_geo_ip_data: Vec<(CompactString, Profile)> = vec![
                     ("SrcASN".into(), Profile::SrcASN("Bredband2 AB".into())),
@@ -1634,7 +1623,6 @@ mod tests {
                     assert!(ext_field.contains(expect));
                 }
             };
-
         }
     }
 
@@ -1753,8 +1741,7 @@ mod tests {
                 let rule = &dummy_rule;
                 let record_info = &input_evtxrecord;
                 let stored_static = &stored_static;
-                let detect_info =
-                    Detection::create_log_record(rule, record_info, stored_static);
+                let detect_info = Detection::create_log_record(rule, record_info, stored_static);
                 let expect_geo_ip_data: Vec<(CompactString, Profile)> = vec![
                     ("SrcASN".into(), Profile::SrcASN("-".into())),
                     ("SrcCountry".into(), Profile::SrcCountry("-".into())),
@@ -1766,7 +1753,7 @@ mod tests {
                 let ext_field = detect_info.ext_field.clone();
                 for expect in expect_geo_ip_data.iter() {
                     assert!(ext_field.contains(expect));
-                }  
+                }
             };
         }
     }
@@ -1902,12 +1889,13 @@ mod tests {
                 let rule = &rule_node;
                 let record_info = &input_evtxrecord;
                 let stored_static: &StoredStatic = &stored_static.clone();
-                let detect_info =
-                    Detection::create_log_record(rule, record_info, stored_static);
+                let detect_info = Detection::create_log_record(rule, record_info, stored_static);
 
                 let expect_extra_field_data: Vec<(CompactString, Profile)> = vec![(
                     "ExtraFieldInfo".into(),
-                    Profile::ExtraFieldInfo("CommandRLine: hoge ¦ DestAddress: 2.125.160.216".into()),
+                    Profile::ExtraFieldInfo(
+                        "CommandRLine: hoge ¦ DestAddress: 2.125.160.216".into(),
+                    ),
                 )];
                 let ext_field = detect_info.ext_field.clone();
                 for expect in expect_extra_field_data.iter() {
@@ -2049,8 +2037,7 @@ mod tests {
                 let rule = &rule_node;
                 let record_info = &input_evtxrecord;
                 let stored_static: &StoredStatic = &stored_static.clone();
-                let detect_info =
-                    Detection::create_log_record(rule, record_info, stored_static);
+                let detect_info = Detection::create_log_record(rule, record_info, stored_static);
 
                 println!("{:?}", detect_info.ext_field);
                 assert!(detect_info.ext_field.iter().any(|x| x

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -26,6 +26,9 @@ use termcolor::{BufferWriter, ColorChoice};
 use super::configs::EventKeyAliasConfig;
 use super::utils::remove_sp_char;
 
+/*  
+ * This struct express log record
+*/
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DetectInfo {
     pub rulepath: CompactString,
@@ -113,7 +116,7 @@ pub fn insert_message(detect_info: DetectInfo, event_time: DateTime<Utc>) {
 pub fn insert(
     event_record: &Value,
     output: CompactString,
-    mut detect_info: DetectInfo,
+    detect_info: DetectInfo,
     time: DateTime<Utc>,
     profile_converter: &HashMap<&str, Profile>,
     (is_agg, is_json_timeline): (bool, bool),
@@ -123,6 +126,22 @@ pub fn insert(
         &Option<FieldDataMap>,
     ),
 ) {
+    let detect_info = create_message(&event_record, output, detect_info, profile_converter, (is_agg, is_json_timeline), (eventkey_alias, field_data_map_key, field_data_map));
+    insert_message(detect_info, time)
+}
+
+pub fn create_message(    
+    event_record: &Value,
+    output: CompactString,
+    mut detect_info: DetectInfo,
+    profile_converter: &HashMap<&str, Profile>,
+    (is_agg, is_json_timeline): (bool, bool),
+    (eventkey_alias, field_data_map_key, field_data_map): (
+        &EventKeyAliasConfig,
+        &FieldDataMapKey,
+        &Option<FieldDataMap>,
+    ),) -> DetectInfo
+{
     let mut record_details_info_map = HashMap::new();
     let mut sp_removed_details_in_record = vec![];
     if !is_agg {
@@ -274,7 +293,8 @@ pub fn insert(
     }
     detect_info.ext_field = replaced_profiles;
     detect_info.details_convert_map = record_details_info_map;
-    insert_message(detect_info, time)
+
+    return detect_info;
 }
 
 /// メッセージ内の%で囲まれた箇所をエイリアスとしてレコード情報を参照して置き換える関数

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -48,8 +48,6 @@ pub struct AlertMessage {}
 
 lazy_static! {
     #[derive(Debug,PartialEq, Eq, Ord, PartialOrd)]
-    pub static ref MESSAGES: DashMap<DateTime<Utc>, Vec<DetectInfo>> = DashMap::new();
-    pub static ref MESSAGEKEYS: Mutex<HashSet<DateTime<Utc>>> = Mutex::new(HashSet::new());
     pub static ref ALIASREGEX: Regex = Regex::new(r"%[a-zA-Z0-9-_\[\]]+%").unwrap();
     pub static ref SUFFIXREGEX: Regex = Regex::new(r"\[([0-9]+)\]").unwrap();
     pub static ref ERROR_LOG_STACK: Mutex<Nested<String>> = Mutex::new(Nested::<String>::new());
@@ -103,39 +101,6 @@ pub fn create_output_filter_config(
         );
     });
     ret
-}
-
-/// メッセージの設定を行う関数。aggcondition対応のためrecordではなく出力をする対象時間がDatetime形式での入力としている
-pub fn insert_message(detect_info: DetectInfo, event_time: DateTime<Utc>) {
-    MESSAGEKEYS.lock().unwrap().insert(event_time);
-    let mut v = MESSAGES.entry(event_time).or_default();
-    let (_, info) = v.pair_mut();
-    info.push(detect_info);
-}
-
-/// メッセージを設定 TODO 要リファクタリング
-pub fn insert(
-    event_record: &Value,
-    output: CompactString,
-    detect_info: DetectInfo,
-    time: DateTime<Utc>,
-    profile_converter: &HashMap<&str, Profile>,
-    (is_agg, is_json_timeline): (bool, bool),
-    (eventkey_alias, field_data_map_key, field_data_map): (
-        &EventKeyAliasConfig,
-        &FieldDataMapKey,
-        &Option<FieldDataMap>,
-    ),
-) {
-    let detect_info = create_message(
-        &event_record,
-        output,
-        detect_info,
-        profile_converter,
-        (is_agg, is_json_timeline),
-        (eventkey_alias, field_data_map_key, field_data_map),
-    );
-    insert_message(detect_info, time)
 }
 
 pub fn create_message(
@@ -397,14 +362,6 @@ pub fn parse_message(
     (return_message, details_key_and_value)
 }
 
-/// メッセージを返す
-pub fn get(time: DateTime<Utc>) -> Vec<DetectInfo> {
-    match MESSAGES.get(&time) {
-        Some(v) => v.to_vec(),
-        None => Vec::new(),
-    }
-}
-
 pub fn get_event_time(event_record: &Value, json_input_flag: bool) -> Option<DateTime<Utc>> {
     let system_time = if json_input_flag {
         &event_record["Event"]["System"]["@timestamp"]
@@ -474,16 +431,12 @@ impl AlertMessage {
 mod tests {
     use crate::detections::configs::{load_eventkey_alias, StoredStatic, CURRENT_EXE_PATH};
     use crate::detections::field_data_map::FieldDataMapKey;
-    use crate::detections::message::{get, insert_message, AlertMessage, DetectInfo};
-    use crate::detections::message::{parse_message, MESSAGES};
+    use crate::detections::message::{parse_message, AlertMessage};
     use crate::detections::utils;
-    use chrono::Utc;
+
     use compact_str::CompactString;
     use hashbrown::HashMap;
-    use rand::Rng;
     use serde_json::Value;
-    use std::thread;
-    use std::time::Duration;
 
     use super::create_output_filter_config;
 
@@ -502,7 +455,6 @@ mod tests {
     #[test]
     /// outputで指定されているキー(eventkey_alias.txt内で設定済み)から対象のレコード内の情報でメッセージをパースしているか確認する関数
     fn test_parse_message() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -545,7 +497,6 @@ mod tests {
 
     #[test]
     fn test_parse_message_auto_search() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -583,7 +534,6 @@ mod tests {
     #[test]
     /// outputで指定されているキーが、eventkey_alias.txt内で設定されていない場合の出力テスト
     fn test_parse_message_not_exist_key_in_output() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -625,7 +575,6 @@ mod tests {
     #[test]
     /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
     fn test_parse_message_not_exist_value_in_record() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -667,7 +616,6 @@ mod tests {
     #[test]
     /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
     fn test_parse_message_multiple_no_suffix_in_record() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -714,7 +662,6 @@ mod tests {
     #[test]
     /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
     fn test_parse_message_multiple_with_suffix_in_record() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -761,7 +708,6 @@ mod tests {
     #[test]
     /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
     fn test_parse_message_multiple_no_exist_in_record() {
-        MESSAGES.clear();
         let json_str = r#"
         {
             "Event": {
@@ -851,49 +797,5 @@ mod tests {
         for (k, v) in expected.iter() {
             assert!(actual.get(k).unwrap_or(&CompactString::default()) == v);
         }
-    }
-
-    #[test]
-    fn test_insert_message_race_condition() {
-        MESSAGES.clear();
-
-        // Setup test detect_info before starting threads.
-        let mut sample_detects = vec![];
-        let mut rng = rand::thread_rng();
-        let sample_event_time = Utc::now();
-        for i in 1..2001 {
-            let detect_info = DetectInfo {
-                detected_time: sample_event_time,
-                rulepath: CompactString::default(),
-                ruleid: CompactString::default(),
-                ruletitle: CompactString::default(),
-                level: CompactString::default(),
-                computername: CompactString::default(),
-                eventid: CompactString::from(i.to_string()),
-                detail: CompactString::default(),
-                ext_field: vec![],
-                is_condition: false,
-                details_convert_map: HashMap::default(),
-            };
-            sample_detects.push((sample_event_time, detect_info, rng.gen_range(0..10)));
-        }
-
-        // Starting threads and randomly insert_message in parallel.
-        let mut handles = vec![];
-        for (event_time, detect_info, random_num) in sample_detects {
-            let handle = thread::spawn(move || {
-                thread::sleep(Duration::from_micros(random_num));
-                insert_message(detect_info, event_time);
-            });
-            handles.push(handle);
-        }
-
-        // Wait for all threads execution completion.
-        for handle in handles {
-            handle.join().unwrap();
-        }
-
-        // Expect all sample_detects to be included, but the len() size will be different each time I run it
-        assert_eq!(get(sample_event_time).len(), 2000)
     }
 }

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -267,7 +267,7 @@ pub fn create_message(
     detect_info.ext_field = replaced_profiles;
     detect_info.details_convert_map = record_details_info_map;
 
-    return detect_info;
+    detect_info
 }
 
 /// メッセージ内の%で囲まれた箇所をエイリアスとしてレコード情報を参照して置き換える関数

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -26,7 +26,7 @@ use termcolor::{BufferWriter, ColorChoice};
 use super::configs::EventKeyAliasConfig;
 use super::utils::remove_sp_char;
 
-/*  
+/*
  * This struct express log record
 */
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -126,11 +126,18 @@ pub fn insert(
         &Option<FieldDataMap>,
     ),
 ) {
-    let detect_info = create_message(&event_record, output, detect_info, profile_converter, (is_agg, is_json_timeline), (eventkey_alias, field_data_map_key, field_data_map));
+    let detect_info = create_message(
+        &event_record,
+        output,
+        detect_info,
+        profile_converter,
+        (is_agg, is_json_timeline),
+        (eventkey_alias, field_data_map_key, field_data_map),
+    );
     insert_message(detect_info, time)
 }
 
-pub fn create_message(    
+pub fn create_message(
     event_record: &Value,
     output: CompactString,
     mut detect_info: DetectInfo,
@@ -140,8 +147,8 @@ pub fn create_message(
         &EventKeyAliasConfig,
         &FieldDataMapKey,
         &Option<FieldDataMap>,
-    ),) -> DetectInfo
-{
+    ),
+) -> DetectInfo {
     let mut record_details_info_map = HashMap::new();
     let mut sp_removed_details_in_record = vec![];
     if !is_agg {

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -31,6 +31,7 @@ use super::utils::remove_sp_char;
 */
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DetectInfo {
+    pub detected_time: DateTime<Utc>,
     pub rulepath: CompactString,
     pub ruleid: CompactString,
     pub ruletitle: CompactString,
@@ -862,6 +863,7 @@ mod tests {
         let sample_event_time = Utc::now();
         for i in 1..2001 {
             let detect_info = DetectInfo {
+                detected_time: sample_event_time,
                 rulepath: CompactString::default(),
                 ruleid: CompactString::default(),
                 ruletitle: CompactString::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1615,7 +1615,8 @@ impl App {
                 || stored_static.search_flag)
             {
                 // ruleファイルの検知
-                detection = detection.start(&self.rt, records_per_detect);
+                let (detection_tmp, log_records) = detection.start(&self.rt, records_per_detect);
+                detection = detection_tmp;
             }
         }
         tl.total_record_cnt += record_cnt;
@@ -1794,7 +1795,8 @@ impl App {
                 || stored_static.search_flag)
             {
                 // ruleファイルの検知
-                detection = detection.start(&self.rt, records_per_detect);
+                let (detection_tmp, log_records) = detection.start(&self.rt, records_per_detect);
+                detection = detection_tmp;
             }
         }
         tl.total_record_cnt += record_cnt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use hayabusa::detections::configs::{
     TargetIds, CURRENT_EXE_PATH, STORED_EKEY_ALIAS, STORED_STATIC,
 };
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
-use hayabusa::detections::message::{self, AlertMessage, DetectInfo, ERROR_LOG_STACK};
+use hayabusa::detections::message::{AlertMessage, DetectInfo, ERROR_LOG_STACK};
 use hayabusa::detections::rule::{get_detection_keys, RuleNode};
 use hayabusa::detections::utils::{
     check_setting_path, get_writable_color, output_and_data_stack_for_html, output_duration,
@@ -1468,13 +1468,8 @@ impl App {
             || stored_static.computer_metrics_flag)
         {
             println!();
-            let log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
-            if stored_static.is_low_memory {
-            } else {
-                for (detect_info, event_time) in log_records {
-                    message::insert_message(detect_info, event_time);
-                }
-            }
+            let mut log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
+            afterfact_info.detect_infos.append(&mut log_records);
 
             afterfact_info.tl_starttime = tl.stats.start_time;
             afterfact_info.tl_endtime = tl.stats.end_time;
@@ -2040,7 +2035,6 @@ mod tests {
                 TargetIds, STORED_EKEY_ALIAS, STORED_STATIC,
             },
             detection,
-            message::{MESSAGEKEYS, MESSAGES},
             rule::create_rule,
         }, options::htmlreport::HTML_REPORTER, timeline::timelines::Timeline
     };
@@ -2205,12 +2199,12 @@ mod tests {
             &stored_static,
         );
         assert_eq!(actual.1, 2);
-        assert_eq!(MESSAGES.len(), 2);
+        // TODO add check
+        //assert_eq!(MESSAGES.len(), 2);
     }
 
     #[test]
     fn test_same_file_output_csv_exit() {
-        MESSAGES.clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -2287,7 +2281,8 @@ mod tests {
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
         let mut config_reader = ConfigReader::new();
         app.exec(&mut config_reader.app, &mut stored_static);
-        assert_eq!(MESSAGES.len(), 0);
+        // TODO add check
+        // assert_eq!(MESSAGES.len(), 0);
 
         // テストファイルの作成
         remove_file("overwrite.csv").ok();
@@ -2295,8 +2290,6 @@ mod tests {
 
     #[test]
     fn test_overwrite_csv() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -2373,14 +2366,14 @@ mod tests {
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
         let mut config_reader = ConfigReader::new();
         app.exec(&mut config_reader.app, &mut stored_static);
-        assert_ne!(MESSAGES.len(), 0);
+        // TODO add check
+        // assert_ne!(MESSAGES.len(), 0);
         // テストファイルの作成
         remove_file("overwrite.csv").ok();
     }
 
     #[test]
     fn test_same_file_output_json_exit() {
-        MESSAGES.clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite.json").ok();
@@ -2457,7 +2450,8 @@ mod tests {
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
         let mut config_reader = ConfigReader::new();
         app.exec(&mut config_reader.app, &mut stored_static);
-        assert_eq!(MESSAGES.len(), 0);
+        // TODO add check
+        // assert_eq!(MESSAGES.len(), 0);
 
         // テストファイルの作成
         remove_file("overwrite.json").ok();
@@ -2465,8 +2459,6 @@ mod tests {
 
     #[test]
     fn test_overwrite_json() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -2543,14 +2535,14 @@ mod tests {
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
         let mut config_reader = ConfigReader::new();
         app.exec(&mut config_reader.app, &mut stored_static);
-        assert_ne!(MESSAGES.len(), 0);
+        // TODO add check
+        // assert_ne!(MESSAGES.len(), 0);
         // テストファイルの削除
         remove_file("overwrite.json").ok();
     }
 
     #[test]
     fn test_same_file_output_metric_csv_exit() {
-        MESSAGES.clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-metric.csv").ok();
@@ -2605,8 +2597,6 @@ mod tests {
 
     #[test]
     fn test_same_file_output_metric_csv() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-metric.csv").ok();
@@ -2660,7 +2650,6 @@ mod tests {
 
     #[test]
     fn test_same_file_output_logon_summary_csv_exit() {
-        MESSAGES.clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-metric-successful.csv").ok();
@@ -2717,8 +2706,6 @@ mod tests {
 
     #[test]
     fn test_same_file_output_logon_summary_csv() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-metric-successful.csv").ok();
@@ -2774,8 +2761,6 @@ mod tests {
 
     #[test]
     fn test_same_file_output_computer_metrics_exit() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-computer-metrics.csv").ok();
@@ -2818,8 +2803,6 @@ mod tests {
 
     #[test]
     fn test_same_file_output_computer_metrics_csv() {
-        MESSAGES.clear();
-        MESSAGEKEYS.lock().unwrap().clear();
         // 先に空ファイルを作成する
         let mut app = App::new(None);
         File::create("overwrite-computer-metrics.csv").ok();
@@ -2862,7 +2845,6 @@ mod tests {
 
     #[test]
     fn test_analysis_json_file_include_eid() {
-        MESSAGES.clear();
         let mut app = App::new(None);
         let mut stored_static = create_dummy_stored_static();
         *STORED_EKEY_ALIAS.write().unwrap() = Some(stored_static.eventkey_alias.clone());
@@ -2898,12 +2880,11 @@ mod tests {
             &stored_static,
         );
         assert_eq!(actual.1, 2);
-        assert_eq!(MESSAGES.len(), 1);
+        assert_eq!(actual.4.len(), 1);
     }
 
     #[test]
     fn test_analysis_json_file_exclude_eid() {
-        MESSAGES.clear();
         let mut app = App::new(None);
         let mut stored_static = create_dummy_stored_static();
         *STORED_EKEY_ALIAS.write().unwrap() = Some(stored_static.eventkey_alias.clone());
@@ -2939,6 +2920,6 @@ mod tests {
             &stored_static,
         );
         assert_eq!(actual.1, 2);
-        assert_eq!(MESSAGES.len(), 0);
+        assert_eq!(actual.4.len(), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use hayabusa::detections::configs::{
     TargetIds, CURRENT_EXE_PATH, STORED_EKEY_ALIAS, STORED_STATIC,
 };
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
-use hayabusa::detections::message::{AlertMessage, ERROR_LOG_STACK};
+use hayabusa::detections::message::{self, AlertMessage, ERROR_LOG_STACK};
 use hayabusa::detections::rule::{get_detection_keys, RuleNode};
 use hayabusa::detections::utils::{
     check_setting_path, get_writable_color, output_and_data_stack_for_html, output_duration,
@@ -1467,7 +1467,14 @@ impl App {
             || stored_static.computer_metrics_flag)
         {
             println!();
-            detection.add_aggcondition_msges(&self.rt, stored_static);
+            let log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
+            if (stored_static.is_low_memory) {
+            } else {
+                for (detect_info, event_time) in log_records {
+                    message::insert_message(detect_info, event_time);
+                }
+            }
+
             after_fact(
                 total_records,
                 &stored_static.output_path,
@@ -1616,6 +1623,12 @@ impl App {
             {
                 // ruleファイルの検知
                 let (detection_tmp, log_records) = detection.start(&self.rt, records_per_detect);
+                if stored_static.is_low_memory {
+                } else {
+                    for (detect_info, event_time) in log_records {
+                        message::insert_message(detect_info, event_time)
+                    }
+                }
                 detection = detection_tmp;
             }
         }
@@ -1796,6 +1809,12 @@ impl App {
             {
                 // ruleファイルの検知
                 let (detection_tmp, log_records) = detection.start(&self.rt, records_per_detect);
+                if stored_static.is_low_memory {
+                } else {
+                    for (detect_info, event_time) in log_records {
+                        message::insert_message(detect_info, event_time)
+                    }
+                }
                 detection = detection_tmp;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1409,7 +1409,7 @@ impl App {
 
         *STORED_EKEY_ALIAS.write().unwrap() = Some(stored_static.eventkey_alias.clone());
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
-        let mut afterfact_info = AfterfactInfo::new();
+        let mut afterfact_info = AfterfactInfo::default();
         for evtx_file in evtx_files {
             let pb_msg = format!(
                 "{:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1417,26 +1417,26 @@ impl App {
             );
             pb.set_message(pb_msg);
 
-            let (detection_tmp, cnt_tmp, tl_tmp, recover_cnt_tmp, mut detect_infos) = if evtx_file.extension().unwrap() == "json"
-            {
-                self.analysis_json_file(
-                    evtx_file,
-                    detection,
-                    time_filter,
-                    tl.to_owned(),
-                    target_event_ids,
-                    stored_static,
-                )
-            } else {
-                self.analysis_file(
-                    evtx_file,
-                    detection,
-                    time_filter,
-                    tl.to_owned(),
-                    target_event_ids,
-                    stored_static,
-                )
-            };
+            let (detection_tmp, cnt_tmp, tl_tmp, recover_cnt_tmp, mut detect_infos) =
+                if evtx_file.extension().unwrap() == "json" {
+                    self.analysis_json_file(
+                        evtx_file,
+                        detection,
+                        time_filter,
+                        tl.to_owned(),
+                        target_event_ids,
+                        stored_static,
+                    )
+                } else {
+                    self.analysis_file(
+                        evtx_file,
+                        detection,
+                        time_filter,
+                        tl.to_owned(),
+                        target_event_ids,
+                        stored_static,
+                    )
+                };
             detection = detection_tmp;
             tl = tl_tmp;
             afterfact_info.record_cnt += cnt_tmp as u128;
@@ -1491,12 +1491,18 @@ impl App {
         mut tl: Timeline,
         target_event_ids: &TargetIds,
         stored_static: &StoredStatic,
-    ) -> (detection::Detection, usize, Timeline, usize, Vec<DetectInfo>) {
+    ) -> (
+        detection::Detection,
+        usize,
+        Timeline,
+        usize,
+        Vec<DetectInfo>,
+    ) {
         let path = evtx_filepath.display();
         let parser = self.evtx_to_jsons(&evtx_filepath, stored_static.enable_recover_records);
         let mut record_cnt = 0;
         let mut recover_records_cnt = 0;
-        let mut detect_infos:  Vec<DetectInfo> = vec![];
+        let mut detect_infos: Vec<DetectInfo> = vec![];
         if parser.is_none() {
             return (detection, record_cnt, tl, 0, detect_infos);
         }
@@ -1614,7 +1620,8 @@ impl App {
                 || stored_static.search_flag)
             {
                 // ruleファイルの検知
-                let (detection_tmp, mut log_records) = detection.start(&self.rt, records_per_detect);
+                let (detection_tmp, mut log_records) =
+                    detection.start(&self.rt, records_per_detect);
                 detect_infos.append(&mut log_records);
                 detection = detection_tmp;
             }
@@ -1632,7 +1639,13 @@ impl App {
         mut tl: Timeline,
         target_event_ids: &TargetIds,
         stored_static: &StoredStatic,
-    ) -> (detection::Detection, usize, Timeline, usize, Vec<DetectInfo>) {
+    ) -> (
+        detection::Detection,
+        usize,
+        Timeline,
+        usize,
+        Vec<DetectInfo>,
+    ) {
         let path = filepath.display();
         let mut record_cnt = 0;
         let recover_records_cnt = 0;
@@ -1796,7 +1809,8 @@ impl App {
                 || stored_static.search_flag)
             {
                 // ruleファイルの検知
-                let (detection_tmp, mut log_records) = detection.start(&self.rt, records_per_detect);
+                let (detection_tmp, mut log_records) =
+                    detection.start(&self.rt, records_per_detect);
                 detect_infos.append(&mut log_records);
                 detection = detection_tmp;
             }
@@ -2027,7 +2041,7 @@ mod tests {
     use chrono::Local;
     use hashbrown::HashSet;
     use hayabusa::{
-         detections::{
+        detections::{
             configs::{
                 Action, CommonOptions, ComputerMetricsOption, Config, ConfigReader,
                 CsvOutputOption, DetectCommonOption, EidMetricsOption, InputOption,
@@ -2036,7 +2050,9 @@ mod tests {
             },
             detection,
             rule::create_rule,
-        }, options::htmlreport::HTML_REPORTER, timeline::timelines::Timeline
+        },
+        options::htmlreport::HTML_REPORTER,
+        timeline::timelines::Timeline,
     };
     use itertools::Itertools;
     use yaml_rust::YamlLoader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1475,14 +1475,7 @@ impl App {
                 }
             }
 
-            after_fact(
-                total_records,
-                &stored_static.output_path,
-                stored_static.common_options.no_color,
-                stored_static,
-                tl,
-                recover_records,
-            );
+            after_fact(total_records, stored_static, tl, recover_records);
         }
         CHECKPOINT
             .lock()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1468,7 +1468,7 @@ impl App {
         {
             println!();
             let log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
-            if (stored_static.is_low_memory) {
+            if stored_static.is_low_memory {
             } else {
                 for (detect_info, event_time) in log_records {
                     message::insert_message(detect_info, event_time);

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -201,7 +201,7 @@ mod tests {
 
         let header = ["\"Computer\"", "\"Events\""];
 
-        let expect = vec![vec!["\"HAYABUSA-DESKTOP\"", "1"], vec!["\"FALCON\"", "1"]];
+        let expect = vec![vec!["\"FALCON\"", "1"], vec!["\"HAYABUSA-DESKTOP\"", "1"]];
         let expect_str =
             header.join(",") + "\n" + &expect.join(&"\n").join(",").replace(",\n,", "\n") + "\n";
         match read_to_string("./test_computer_metrics.csv") {

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use num::FromPrimitive;
 use num_format::{Locale, ToFormattedString};
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
@@ -72,10 +73,15 @@ pub fn computer_metrics_dsp_msg(
 
     // Write contents
     for ((computer_name, _), count) in result_list.into_iter().sorted_unstable_by(|a, b| {
-        Ord::cmp(
+        let count_cmp = Ord::cmp(
             &-i64::from_usize(*a.1).unwrap_or_default(),
             &-i64::from_usize(*b.1).unwrap_or_default(),
-        )
+        );
+        if count_cmp != Ordering::Equal {
+            return count_cmp;
+        }
+
+        return a.0.cmp(b.0);
     }) {
         let count_str = if output.is_some() {
             format!("{count}")

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -81,7 +81,7 @@ pub fn computer_metrics_dsp_msg(
             return count_cmp;
         }
 
-        return a.0.cmp(b.0);
+        a.0.cmp(b.0)
     }) {
         let count_str = if output.is_some() {
             format!("{count}")


### PR DESCRIPTION
This is just a refactoring for low memory option and I'm going to add low memory option in a next pull request.

## What Changed
I've refactored the current code for creating low memory option as follows
- remove MESSAGES and MESSAGEKEYS from message.rs not to store log record in static field
- refactor afterfact.rs
- delete testcases that check the behavior of message::MESSAGES

## Evidence

Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.
