### PR TITLE
perf: use slice instead of `replacen` in AggegationConditionCompiler.tokenize()

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -6,6 +6,7 @@
 
 - 指定した`status`のルールのみを利用する`--include-status`オプションを追加した。 (#1193) (@hitenkoku)
 - 未使用のクレートを削除した。(@YamatoSecurity)
+- パフォーマンスの改善 (#1277, #1278) (@fukusuket)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `--include-status` option: You can specify rules based on their `status`. (#1193) (@hitenkoku)
 - Removed unused crates. (@YamatoSecurity)
+- Performance enchancements. (#1277, #1278) (@fukusuket)
 
 **Bug Fixes:**
 

--- a/src/detections/rule/aggregation_parser.rs
+++ b/src/detections/rule/aggregation_parser.rs
@@ -88,29 +88,29 @@ impl AggegationConditionCompiler {
         &self,
         condition_str: String,
     ) -> Result<Vec<AggregationConditionToken>, String> {
-        let mut cur_condition_str = condition_str;
+        let mut cur_condition_str = condition_str.as_str();
 
         let mut tokens = Vec::new();
         while !cur_condition_str.is_empty() {
             let captured = self::AGGREGATION_REGEXMAP.iter().find_map(|regex| {
-                return regex.captures(cur_condition_str.as_str());
+                return regex.captures(cur_condition_str);
             });
             if captured.is_none() {
                 // トークンにマッチしないのはありえないという方針でパースしています。
                 return Result::Err("An unusable character was found.".to_string());
             }
 
-            let mached_str = captured.unwrap().get(0).unwrap().as_str();
-            let token = self.to_enum(mached_str.to_string());
+            let matched_str = captured.unwrap().get(0).unwrap().as_str();
+            let token = self.to_enum(matched_str);
 
             if let AggregationConditionToken::Space = token {
                 // 空白は特に意味ないので、読み飛ばす。
-                cur_condition_str = cur_condition_str.replacen(mached_str, "", 1);
+                cur_condition_str = &cur_condition_str[matched_str.len()..];
                 continue;
             }
 
             tokens.push(token);
-            cur_condition_str = cur_condition_str.replacen(mached_str, "", 1);
+            cur_condition_str = &cur_condition_str[matched_str.len()..];
         }
 
         Result::Ok(tokens)
@@ -226,7 +226,7 @@ impl AggegationConditionCompiler {
     }
 
     /// 文字列をConditionTokenに変換する。
-    fn to_enum(&self, token: String) -> AggregationConditionToken {
+    fn to_enum(&self, token: &str) -> AggregationConditionToken {
         if token.starts_with("count(") {
             let count_field = token
                 .replacen("count(", "", 1)
@@ -248,7 +248,7 @@ impl AggegationConditionCompiler {
         } else if token == ">" {
             AggregationConditionToken::GT
         } else {
-            AggregationConditionToken::Keyword(token)
+            AggregationConditionToken::Keyword(token.to_string())
         }
     }
 }


### PR DESCRIPTION
## What Changed

- Closed #1278

## Evidence
### Environment
- OS: macOS Sonoma version 14.2.1
- Hayabusa v2.14.0-dev
- rustc 1.76.0

I confirmed that there are no differences in the resulting CSV as shown below before after fix.
```
% ./hayabusa-new csv-timeline -d ../hayabusa-sample-evtx -o new.csv -w --debug -C -q
% ./hayabusa-main csv-timeline -d ../hayabusa-sample-evtx -o main.csv -w --debug -C -q
% diff main.csv new.csv
%
```

I also confirmed that there were no rule parsing errors and that the number of rules(4077) loaded was the same.

#### main
```
% ./hayabusa-main csv-timeline -d ../hayabusa-sample-evtx -o main.csv -w --debug -C -q
Start time: 2024/02/27 23:41

Total event log files: 583
Total file size: 137.1 MB

Loading detection rules. Please wait.

Excluded rules: 26
Noisy rules: 12 (Disabled)

Deprecated rules: 202 (4.95%) (Disabled)
Experimental rules: 1091 (26.76%)
Stable rules: 240 (5.89%)
Test rules: 2746 (67.35%)
Unsupported rules: 45 (1.10%) (Disabled)

Hayabusa rules: 162
Sigma rules: 3915
Total enabled detection rules: 4077
```

#### ThisPR
```
% ./hayabusa-new csv-timeline -d ../hayabusa-sample-evtx -o new.csv -w --debug -C -q
Start time: 2024/02/27 23:58

Total event log files: 583
Total file size: 137.1 MB

Loading detection rules. Please wait.

Excluded rules: 26
Noisy rules: 12 (Disabled)

Deprecated rules: 202 (4.95%) (Disabled)
Experimental rules: 1091 (26.76%)
Stable rules: 240 (5.89%)
Test rules: 2746 (67.35%)
Unsupported rules: 45 (1.10%) (Disabled)

Hayabusa rules: 162
Sigma rules: 3915
Total enabled detection rules: 4077
```

I would appreciate it if you could check it out when you have time🙏