### PR TITLE
low memoption wave2

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -406,9 +406,7 @@ fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
             .quote_style(QuoteStyle::Never)
             .from_writer(target),
         Action::CsvTimeline(_) => WriterBuilder::new()
-            .delimiter(b'\n')
-            .double_quote(false)
-            .quote_style(QuoteStyle::Never)
+            .quote_style(QuoteStyle::NonNumeric)
             .from_writer(target),
         _ => panic!("unknown action is specified!!"),
     };

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -350,7 +350,6 @@ pub fn after_fact(
     if let Err(err) = output_afterfact(
         detect_infos,
         &mut afterfact_writer,
-        stored_static.profiles.as_ref().unwrap(),
         stored_static,
         afterfact_info,
     ) {
@@ -423,7 +422,6 @@ fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
 fn output_afterfact(
     detect_infos: &mut [DetectInfo],
     afterfact_writer: &mut AfterfactWriter,
-    profile: &[(CompactString, Profile)],
     stored_static: &StoredStatic,
     mut afterfact_info: AfterfactInfo,
 ) -> io::Result<()> {
@@ -450,7 +448,6 @@ fn output_afterfact(
         stored_static,
         afterfact_writer,
         &mut afterfact_info,
-        profile,
     )?;
 
     // calculate statistic information
@@ -473,7 +470,6 @@ fn emit_csv(
     stored_static: &StoredStatic,
     afterfact_writer: &mut AfterfactWriter,
     afterfact_info: &mut AfterfactInfo,
-    profile: &[(CompactString, Profile)],
 ) -> io::Result<()> {
     let output_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("🛂r", "\r"), ("🛂n", "\n"), ("🛂t", "\t")]);
@@ -507,6 +503,7 @@ fn emit_csv(
             _ => (false, false, false),
         };
 
+    let profile = stored_static.profiles.as_ref().unwrap();
     for (i, detect_info) in detect_infos.iter().enumerate() {
         if duplicate_idxes.contains(&i) {
             continue;
@@ -2505,7 +2502,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -2612,13 +2608,21 @@ mod tests {
             action: Some(dummy_action),
             debug: false,
         });
-        let stored_static = StoredStatic::create_static_data(dummy_config);
+        let mut stored_static = StoredStatic::create_static_data(dummy_config);
         let output_profile: Vec<(CompactString, Profile)> = load_profile(
             "test_files/config/default_profile.yaml",
             "test_files/config/profiles.yaml",
             Some(&stored_static),
         )
         .unwrap_or_default();
+        stored_static.profiles = Option::Some(
+            load_profile(
+                "test_files/config/default_profile.yaml",
+                "test_files/config/profiles.yaml",
+                Some(&stored_static),
+            )
+            .unwrap_or_default(),
+        );
         {
             let val = r#"
                 {
@@ -2826,7 +2830,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -3156,7 +3159,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -3560,7 +3562,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -3891,7 +3892,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -4183,7 +4183,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )
@@ -4458,7 +4457,6 @@ mod tests {
         assert!(output_afterfact(
             &mut detect_infos,
             &mut writer,
-            &output_profile,
             &stored_static,
             additional_afterfact,
         )

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -152,7 +152,7 @@ pub struct AfterfactWriter {
     disp_wtr: BufferWriter,
     disp_wtr_buf: Buffer,
     csv_writer: Writer<Box<dyn io::Write>>,
-    display_flag: bool,
+    pub display_flag: bool,
 }
 
 pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
@@ -222,6 +222,10 @@ pub fn emit_csv(
     afterfact_writer: &mut AfterfactWriter,
     afterfact_info: &mut AfterfactInfo,
 ) {
+    if detect_infos.is_empty() {
+        return;
+    }
+
     let result = emit_csv_inner(
         detect_infos,
         duplicate_idxes,
@@ -468,9 +472,7 @@ fn emit_csv_inner(
         }
     }
 
-    if afterfact_writer.display_flag {
-        println!();
-    } else {
+    if !afterfact_writer.display_flag {
         afterfact_writer.csv_writer.flush()?;
     }
 
@@ -575,6 +577,10 @@ pub fn output_additional_afterfact(
     afterfact_writer: &mut AfterfactWriter,
     afterfact_info: &AfterfactInfo,
 ) {
+    if afterfact_writer.display_flag {
+        println!();
+    }
+
     let terminal_width = match terminal_size() {
         Some((Width(w), _)) => w as usize,
         None => 100,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,6 @@ use itertools::Itertools;
 use libmimalloc_sys::mi_stats_print_out;
 use mimalloc::MiMalloc;
 use nested::Nested;
-use openssl::x509::store;
 use serde_json::{Map, Value};
 use std::borrow::BorrowMut;
 use std::ffi::{OsStr, OsString};
@@ -1430,23 +1429,17 @@ impl App {
             let (detection_tmp, cnt_tmp, tl_tmp, recover_cnt_tmp, mut detect_infos) =
                 if evtx_file.extension().unwrap() == "json" {
                     self.analysis_json_file(
-                        evtx_file,
+                        (evtx_file, time_filter, target_event_ids, stored_static),
                         detection,
-                        time_filter,
                         tl.to_owned(),
-                        target_event_ids,
-                        stored_static,
                         &mut afterfact_writer,
                         &mut afterfact_info,
                     )
                 } else {
                     self.analysis_file(
-                        evtx_file,
+                        (evtx_file, time_filter, target_event_ids, stored_static),
                         detection,
-                        time_filter,
                         tl.to_owned(),
-                        target_event_ids,
-                        stored_static,
                         &mut afterfact_writer,
                         &mut afterfact_info,
                     )
@@ -1515,12 +1508,14 @@ impl App {
     // Windowsイベントログファイルを1ファイル分解析する。
     fn analysis_file(
         &self,
-        evtx_filepath: PathBuf,
+        (evtx_filepath, time_filter, target_event_ids, stored_static): (
+            PathBuf,
+            &TargetEventTime,
+            &TargetIds,
+            &StoredStatic,
+        ),
         mut detection: detection::Detection,
-        time_filter: &TargetEventTime,
         mut tl: Timeline,
-        target_event_ids: &TargetIds,
-        stored_static: &StoredStatic,
         afterfact_writer: &mut AfterfactWriter,
         afterfact_info: &mut AfterfactInfo,
     ) -> (
@@ -1676,12 +1671,14 @@ impl App {
     // JSON形式のイベントログファイルを1ファイル分解析する。
     fn analysis_json_file(
         &self,
-        filepath: PathBuf,
+        (filepath, time_filter, target_event_ids, stored_static): (
+            PathBuf,
+            &TargetEventTime,
+            &TargetIds,
+            &StoredStatic,
+        ),
         mut detection: detection::Detection,
-        time_filter: &TargetEventTime,
         mut tl: Timeline,
-        target_event_ids: &TargetIds,
-        stored_static: &StoredStatic,
         afterfact_writer: &mut AfterfactWriter,
         afterfact_info: &mut AfterfactInfo,
     ) -> (
@@ -2285,12 +2282,14 @@ mod tests {
         let mut afterfact_writer = afterfact::init_writer(&stored_static);
 
         let actual = app.analysis_json_file(
-            Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+            (
+                Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+                &target_time_filter,
+                &target_event_ids,
+                &stored_static,
+            ),
             detection,
-            &target_time_filter,
             tl,
-            &target_event_ids,
-            &stored_static,
             &mut afterfact_writer,
             &mut afterfact_info,
         );
@@ -2972,12 +2971,14 @@ mod tests {
         let mut afterfact_writer = afterfact::init_writer(&stored_static);
 
         let actual = app.analysis_json_file(
-            Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+            (
+                Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+                &target_time_filter,
+                &target_event_ids,
+                &stored_static,
+            ),
             detection,
-            &target_time_filter,
             tl,
-            &target_event_ids,
-            &stored_static,
             &mut afterfact_writer,
             &mut afterfact_info,
         );
@@ -3016,12 +3017,14 @@ mod tests {
         let mut afterfact_writer = afterfact::init_writer(&stored_static);
 
         let actual = app.analysis_json_file(
-            Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+            (
+                Path::new("test_files/evtx/test.jsonl").to_path_buf(),
+                &target_time_filter,
+                &target_event_ids,
+                &stored_static,
+            ),
             detection,
-            &target_time_filter,
             tl,
-            &target_event_ids,
-            &stored_static,
             &mut afterfact_writer,
             &mut afterfact_info,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1410,6 +1410,7 @@ impl App {
         *STORED_EKEY_ALIAS.write().unwrap() = Some(stored_static.eventkey_alias.clone());
         *STORED_STATIC.write().unwrap() = Some(stored_static.clone());
         let mut afterfact_info = AfterfactInfo::default();
+        let mut all_detect_infos = vec![];
         for evtx_file in evtx_files {
             let pb_msg = format!(
                 "{:?}",
@@ -1441,7 +1442,7 @@ impl App {
             tl = tl_tmp;
             afterfact_info.record_cnt += cnt_tmp as u128;
             afterfact_info.recover_record_cnt += recover_cnt_tmp as u128;
-            afterfact_info.detect_infos.append(&mut detect_infos);
+            all_detect_infos.append(&mut detect_infos);
             pb.inc(1);
         }
         pb.finish_with_message(
@@ -1469,11 +1470,11 @@ impl App {
         {
             println!();
             let mut log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
-            afterfact_info.detect_infos.append(&mut log_records);
+            all_detect_infos.append(&mut log_records);
 
             afterfact_info.tl_starttime = tl.stats.start_time;
             afterfact_info.tl_endtime = tl.stats.end_time;
-            after_fact(stored_static, afterfact_info);
+            after_fact(&mut all_detect_infos, stored_static, afterfact_info);
         }
         CHECKPOINT
             .lock()

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -1,6 +1,7 @@
+use crate::afterfact::AfterfactInfo;
 use crate::detections::configs::{OutputOption, ALLFIELDINFO_SPECIAL_CHARS};
 use crate::detections::field_data_map::FieldDataMapKey;
-use crate::detections::message;
+use crate::detections::message::{self, DetectInfo};
 use crate::detections::utils::format_time;
 use crate::{
     afterfact::output_json_str,
@@ -455,41 +456,47 @@ pub fn search_result_dsp_msg(
                     .map(CompactString::from)
                     .collect_vec(),
             );
+            let mut detect_info = DetectInfo::default();
+            detect_info.ext_field.push((
+                CompactString::from("Timestamp"),
+                Profile::Timestamp(timestamp.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("Hostname"),
+                Profile::Computer(hostname.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("Channel"),
+                Profile::Channel(abbr_channel.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("Event ID"),
+                Profile::EventID(event_id.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("Record ID"),
+                Profile::RecordID(record_id.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("EventTitle"),
+                Profile::Literal(event_title.clone().into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("AllFieldInfo"),
+                Profile::AllFieldInfo(all_field_info.into()),
+            ));
+            detect_info.ext_field.push((
+                CompactString::from("EvtxFile"),
+                Profile::EvtxFile(evtx_file.into()),
+            ));
+            detect_info.details_convert_map = detail_infos;
+            let mut afterfact_info = AfterfactInfo::default();
             let (output_json_str_ret, _) = output_json_str(
-                &vec![
-                    (
-                        "Timestamp".into(),
-                        Profile::Timestamp(timestamp.clone().into()),
-                    ),
-                    (
-                        "Hostname".into(),
-                        Profile::Computer(hostname.clone().into()),
-                    ),
-                    (
-                        "Channel".into(),
-                        Profile::Channel(abbr_channel.clone().into()),
-                    ),
-                    ("Event ID".into(), Profile::EventID(event_id.clone().into())),
-                    (
-                        "Record ID".into(),
-                        Profile::RecordID(record_id.clone().into()),
-                    ),
-                    (
-                        "EventTitle".into(),
-                        Profile::Literal(event_title.clone().into()),
-                    ),
-                    (
-                        "AllFieldInfo".into(),
-                        Profile::AllFieldInfo(all_field_info.into()),
-                    ),
-                    ("EvtxFile".into(), Profile::EvtxFile(evtx_file.into())),
-                ],
-                HashMap::new(),
+                &detect_info,
+                &mut afterfact_info,
                 jsonl_output,
                 false,
                 false,
-                false,
-                &[&detail_infos, &HashMap::default()],
             );
 
             file_wtr


### PR DESCRIPTION
## What Changed
I have implemented low memory mode.
- You can use low memory mode if you set true to is_low_memory.
    - `stored_static.is_low_memory = true`

## remained
* I haven't added low memory mode to command line option so we have to do it in another PR.
* The following features are disabled in low memory option.
   * sort timeline log
   * remove duplicate log 
       * As well as sorting timeline log, it's difficult to remove duplicate log. This is because it's necessary to load all the timeline logs in order to remove dupplicate log.
* I changed analysis_file() in main.rs in order to supress warning but we can do it better.

## Evidence

Please describe the functionality gained by merging this pull-request and the evidence that the bug has been fixed.
