### PR TITLE
reorder `search` result fields

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -8,6 +8,7 @@
 - 未使用のクレートを削除した。(@YamatoSecurity)
 - SplunkからエクスポートしたJSONファイルの入力に対応した。 (#1083) (@hitenkoku)
 - パフォーマンスの改善 (#1277, #1278) (@fukusuket)
+- `csv-timeline`コマンドの結果と同様になるようにするために、`search`コマンドの結果の表示順番を変更した。 (#1297) (@hitenkoku)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Removed unused crates. (@YamatoSecurity)
 - JSON input now supports the format exported from Splunk. (#1083) (@hitenkoku)
 - Performance enchancements. (#1277, #1278) (@fukusuket)
+- Reordered `search` result fields to look similar to the `csv-timeline` command results. (#1297) (@hitenkoku)
 
 **Bug Fixes:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,6 @@ impl App {
                     "Saved results",
                     &stored_static.html_report_flag,
                 );
-                println!();
             }
             Action::ComputerMetrics(_) => {
                 if let Some(path) = &stored_static.output_path {

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -352,11 +352,11 @@ pub fn search_result_dsp_msg(
 ) {
     let header = vec![
         "Timestamp",
+        "EventTitle",
         "Hostname",
         "Channel",
         "Event ID",
         "Record ID",
-        "EventTitle",
         "AllFieldInfo",
         "EvtxFile",
     ];
@@ -436,11 +436,11 @@ pub fn search_result_dsp_msg(
         };
         let record_data = vec![
             timestamp.as_str(),
+            event_title.as_str(),
             hostname.as_str(),
             abbr_channel.as_str(),
             event_id.as_str(),
             record_id.as_str(),
-            event_title.as_str(),
             all_field_info.as_str(),
             evtx_file.as_str(),
         ];
@@ -538,7 +538,7 @@ pub fn search_result_dsp_msg(
                             .ok();
                         }
                     }
-                } else if record_field_idx == 0 || record_field_idx == 5 {
+                } else if record_field_idx == 0 || record_field_idx == 1 {
                     //タイムスタンプとイベントタイトルは同じ色で表示
                     write_color_buffer(
                         disp_wtr.as_mut().unwrap(),
@@ -568,5 +568,6 @@ pub fn search_result_dsp_msg(
                 }
             }
         }
+        println!();
     }
 }

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -436,8 +436,11 @@ impl Timeline {
                 .ok();
             } else {
                 sammsges.push(format!(
-                    "\n\nTotal findings: {}\n",
-                    self.event_search.search_result.len()
+                    "\nTotal findings: {}",
+                    self.event_search
+                        .search_result
+                        .len()
+                        .to_formatted_string(&Locale::en)
                 ));
             }
             let search_result = self.event_search.search_result.clone();


### PR DESCRIPTION
## What Changed

- Reordered `search` result fields to look similar to the `csv-timeline` command results.
