### PR TITLE
feat: add support for `Data[x]` notation and `Provider_name` mapping (field mapping feature)

### DIFF
--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -716,8 +716,9 @@ impl Detection {
             FieldDataMapKey::default()
         } else {
             FieldDataMapKey {
-                channel: CompactString::from(ch_str.clone().to_lowercase()),
+                channel: CompactString::from(ch_str.to_lowercase()),
                 event_id: eid.clone(),
+                provider: CompactString::from(provider.to_lowercase()),
             }
         };
         let detect_info = DetectInfo {

--- a/src/detections/field_data_map.rs
+++ b/src/detections/field_data_map.rs
@@ -17,10 +17,11 @@ pub enum FieldDataConverter {
     ReplaceStr((AhoCorasick, Vec<String>)),
 }
 
-#[derive(Debug, Eq, Hash, PartialEq, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct FieldDataMapKey {
     pub channel: CompactString,
     pub event_id: CompactString,
+    pub provider: CompactString,
 }
 
 impl FieldDataMapKey {
@@ -37,6 +38,12 @@ impl FieldDataMapKey {
                     .as_i64()
                     .unwrap_or_default()
                     .to_string(),
+            ),
+            provider: CompactString::from(
+                yaml_data["Provider_Name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_lowercase(),
             ),
         }
     }
@@ -189,6 +196,7 @@ mod tests {
         let key = FieldDataMapKey {
             channel: CompactString::from("Security".to_lowercase()),
             event_id: CompactString::from("4625".to_string()),
+            provider: CompactString::from(""),
         };
         map.insert(key.clone(), HashMap::new());
         let r = convert_field_data(&map, &key, "", "");

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -314,6 +314,7 @@ pub fn parse_message(
                 .unwrap_or(tmp_event_record)
                 .get((suffix - 1) as usize)
                 .unwrap_or(tmp_event_record);
+            field = target_str;
         }
         let hash_value = get_serde_number_to_string(tmp_event_record, false);
         if hash_value.is_some() {


### PR DESCRIPTION
## What Changed
- Closed #1350 
    - From this PR, `Provider_Name` must be specified explicitly in the data_mapping file.
    - Related PR: https://github.com/Yamato-Security/hayabusa-rules/pull/667

## Evidence
Using the PR branch below, I confirmed that Data[x] filed data conversion works as follows.
https://github.com/Yamato-Security/hayabusa-rules/pull/666
```
% ./hayabusa-new csv-timeline -d ../hayabusa-sample-evtx -D -n -u -w -C -q -o test.csv --include-eid 1033
...
"2016-09-02 05:50:28.000 +09:00","MSI Install","info","IE10Win7","App",1033,1795,"App: EMET 5.51 ¦ Ver: 5.51 ¦ Lang: English ¦ StatusCode: 0","Binary: 7B41383630384530462D353642382D343635432D413736322D3836443638464634464337327D3030303065313034636234326138383837393837373364376662393066336263643466343030303030393034 ¦ Data: ¦ Data: (NULL) ¦ Data: 1033 ¦ Data: Microsoft Corporation"
```

## Test
Using the PR branch below, I confirmed that there is no difference between main and the results as follows.
https://github.com/Yamato-Security/hayabusa-rules/pull/667
```
% ./hayabusa-new csv-timeline -d ../hayabusa-sample-evtx -D -n -u -w -C -q -o new.csv
% ./hayabusa-old csv-timeline -d ../hayabusa-sample-evtx -D -n -u -w -C -q -o old.csv
% diff new.csv old.csv
%
```
I would appreciate it if you could check it out when you have time🙏