### PR TITLE
feat: add support for correlation `name` lookup

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,12 @@
 # 変更点
 
+## x.x.x [xxxx/xx/xx]
+
+**改善:**
+
+- `cidr-utils`クレートを新バージョン0.6.xに対応した。 (#1366) (@hitenkoku)
+- Sigma correlationルールの`name`ルックアップに対応した。 (#1363) (@fukusuket)
+
 ## 2.16.0 [2024/06/11]
 
 **新機能:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## x.x.x [xxxx/xx/xx]
+
+**Enchancements:**
+
+- Support for the newer version 0.6.x `cidr-utils` crate. (#1366) (@hitenkoku)
+- Added support for Sigma correlation rule's `name` lookup. (#1363) (@fukusuket)
+
 ## 2.16.0 [2024/06/11]
 
 **New Features:**

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -23,6 +23,11 @@ fn is_related_rule(rule_node: &RuleNode, id_or_title: &str) -> bool {
                 return true;
             }
         }
+        if let Some(title) = hash.get(&Yaml::String("name".to_string())) {
+            if title.as_str() == Some(id_or_title) {
+                return true;
+            }
+        }
     }
     false
 }


### PR DESCRIPTION
## What Changed
- added support for correlation rule's `name` lookup
- ref: https://blog.sigmahq.io/introducing-sigma-correlations-52fe377f2527

I would appreciate it if you could check it out when you have time🙏