### PR TITLE
test: add GitHub Actions for (json/csv)timeline diff check

### DIFF
--- a/.github/workflows/timeline-diff.yml
+++ b/.github/workflows/timeline-diff.yml
@@ -1,0 +1,57 @@
+name: Check CSV timeline and JSON timeline Diff
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.ref }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Checkout hayabusa-sample-evtx repo
+        uses: actions/checkout@v4
+        with:
+          repository: Yamato-Security/hayabusa-sample-evtx
+          path: hayabusa-sample-evtx
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run on dev branch
+        run: |
+          cargo run --release -- update-rules -q
+          cargo run --release -- csv-timeline -d ./hayabusa-sample-evtx -o dev.csv -p super-verbose -q -w -D -n -u
+          cargo run --release -- json-timeline -d ./hayabusa-sample-evtx -o dev.jsonl -L -p super-verbose -q -w -D -n -u
+
+      - name: Run on main branch
+        run: |
+          git checkout main
+          cargo run --release -- update-rules -q
+          cargo run --release -- csv-timeline -d ./hayabusa-sample-evtx -o main.csv -p super-verbose -q -w -D -n -u
+          cargo run --release -- json-timeline -d ./hayabusa-sample-evtx -o main.jsonl -L -p super-verbose -q -w -D -n -u
+
+
+      - name: Check CSV Timeline diff
+        run: |
+          diff main.csv dev.csv
+          if [ $? -ne 0 ]; then
+            echo "CSV files are different"
+            exit 1
+          fi
+
+      - name: Check JSONL Timeline diff
+        run: |
+          diff main.jsonl dev.jsonl
+          if [ $? -ne 0 ]; then
+            echo "JSON files are different"
+            exit 1
+          fi


### PR DESCRIPTION
## What Changed
Added GitHub Actions for csv/json timeline diff check. This Action does the following for both main/selected branch.
- `checkout <main/selected branch>`
- `cargo run --release -- update-rules -q`
- `cargo run --release -- csv-timeline -d ./hayabusa-sample-evtx -o dev(main).csv -p super-verbose -q -w -D -n -u`
- `cargo run --release -- json-timeline -d ./hayabusa-sample-evtx -o dev(main).jsonl -L -p super-verbose -q -w -D -n -u`

after that execute following diff command.
- `diff dev.csv main.csv`
- `diff dev.jsonl main.jsonl`

If there is a difference in the diff results, the Actions will fail.
The execution trigger for this action is manual, so it does not affect usual workflow, etc.

## How to use
Choose the branch you want to compare with the main branch in the following screen and perform the Action manually.
<img width="1390" alt="スクリーンショット 2024-06-29 17 49 01" src="https://github.com/Yamato-Security/hayabusa/assets/41001169/478961d3-3595-4f32-9344-76b8b1413660">

## Result image

If there is no diff
https://github.com/fukusuket/hayabusa/actions/runs/9722899505/job/26837369428

If there is diff
https://github.com/fukusuket/hayabusa/actions/runs/9722829098/job/26837201558

I would appreciate it if you could check it out when you have time🙏