### PR TITLE
chg: Sigma v2 compliant `MitreTactics` tag format

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -15,6 +15,7 @@
 - 集計ルールのアラートに、複数の結果がある場合でも`Channel`と`EventID`の情報が表示されるようにした。 (#1342) (@fukusuket)
 - JSONタイムラインで`Details`フィールドに情報がない場合、JSONがパースしやすくなるように、デフォルトで出力される`"-"`を`{}`に変更した。(#1386) (@hitenkoku)
 - シグネチャーバイパスを防ぐため、`-` (エンダッシュ)、`-` (エムダッシュ)、`―` (水平バー) 文字を `windash` 修飾子でサポートするようにした。(#1392) (@hitenkoku)
+- MITRE ATT&CKタグをSigmaバージョン2の形式に対応させた。(例: `defense_evasion` => `defense-evasion`) (@fukusuket)
 
 **バグ修正:**
 - Sigmaの相関ルールのカウントが`Events with hits`に表示されていなかった。(#1373) (@fukusuket)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Aggregation rule alerts now show `Channel` and `EventID` information even when there are multiple results. (#1342) (@fukusuket)
 - In the JSON timeline, when there is no information in the `Details` field, we changed the default output of `"-"` to `{}` in order to make parsing easier. (#1386) (@hitenkoku)
 - Added support for the `–` (en dash), `—` (em dash), and `―` (horizontal bar) characters for the `windash` modifier to prevent signature bypass. (#1392) (@hitenkoku)
+- Updated the MITRE ATT&CK tags to support Sigma version 2 format. (Ex: `defense_evasion` => `defense-evasion`) (@fukusuket)
 
 **Bug Fixes:**
 - Sigma correlation rule count was not showing up in `Events with hits`. (#1373) (@fukusuket)

--- a/config/mitre_tactics.txt
+++ b/config/mitre_tactics.txt
@@ -1,15 +1,15 @@
 tag_full_str,tag_output_str,html_tag_output_str
 attack.reconnaissance,Recon,01. Reconnaissance
-attack.resource_development,ResDev,02. Resource Development
-attack.initial_access,InitAccess,03. Initial Access
+attack.resource-development,ResDev,02. Resource Development
+attack.initial-access,InitAccess,03. Initial Access
 attack.execution,Exec,04. Execution
 attack.persistence,Persis,05. Persistence
-attack.privilege_escalation,PrivEsc,06. Privilege Escalation
-attack.defense_evasion,Evas,07. Defense Evasion
-attack.credential_access,CredAccess,08. Credential Access
+attack.privilege-escalation,PrivEsc,06. Privilege Escalation
+attack.defense-evasion,Evas,07. Defense Evasion
+attack.credential-access,CredAccess,08. Credential Access
 attack.discovery,Disc,09. Discovery
-attack.lateral_movement,LatMov,10. Lateral Movement
+attack.lateral-movement,LatMov,10. Lateral Movement
 attack.collection,Collect,11. Collection
-attack.command_and_control,C2,12. C2
+attack.command-and-control,C2,12. C2
 attack.exfiltration,Exfil,13. Exfiltration
 attack.impact,Impact,14. Impact


### PR DESCRIPTION
## What Changed
The following pull request changed the tag format of Sigma's `MitreTactics` from `_` to `-`. So I modified the Hayabusa side to follow that specification.
- https://github.com/SigmaHQ/sigma/pull/4950
  - Example:
    - https://github.com/SigmaHQ/sigma/pull/4950/files#diff-cf3209c2a0484833254ef8c8f77791dc32bd46a005e94971468e41e886e2f456

The above pull request is for today, so it will be merged in today's job in the hayabusa_rules repository.

## Test
I have confirmed that we can output `MitreTactics` for the latest Sigma(https://github.com/SigmaHQ/sigma/commit/760597da11cd5cfde39b64de06efa8175e98ce7a) repository as follows.
```json
{
    "Timestamp": "2021-11-18 16:43:22.487 +09:00",
    "RuleTitle": "EVTX Created In Uncommon Location",
    "Level": "med",
    "Computer": "PC-01.cybercat.local",
    "Channel": "Sysmon",
    "EventID": 11,
    "RuleAuthor": "D3F7A5105",
    "RuleModifiedDate": "2024-03-26",
    "Status": "experimental",
    "RecordID": 13280,
    "Details": {
        "Path": "C:\\Users\\pc1-user\\Desktop\\sysmon.evtx",
        "Proc": "C:\\Windows\\system32\\mmc.exe",
        "PID": 3116,
        "PGUID": "510C1E8A-FFD9-6195-4401-000000000F00"
    },
    "ExtraFieldInfo": {
        "CreationUtcTime": "2021-11-18 07:43:22.460",
        "RuleName": "-",
        "User": "CYBERCAT\\pc1-user",
        "UtcTime": "2021-11-18 07:43:22.460"
    },
    "MitreTactics": [
        "Evas"
    ],
    "MitreTags": [
        "T1562.002"
    ],
    "OtherTags": [
        "sysmon"
    ],
    "Provider": "Sysmon",
    "RuleCreationDate": "2023-01-02",
    "RuleFile": "file_event_win_create_evtx_non_common_locations.yml",
    "EvtxFile": "../hayabusa-sample-evtx/YamatoSecurity/DefenseEvasion/T1218.004_SignedBinaryProxyExecutionInstallUtil_Sysmon.evtx"
}
```

I would appreciate it if you could check it out when you have time🙏