### PR TITLE
Fix: Github Actions hayabusa-rule path

### DIFF
--- a/.github/workflows/supported_modifier.yml
+++ b/.github/workflows/supported_modifier.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           cd hayabusa/scripts/supported_modifiers_check
           poetry install --no-root
-          poetry run python supported-modifier.py ../../../sigma-repo ../../../hayabusa-rules ../../doc/SupportedSigmaFieldModifiers.md
+          poetry run python supported-modifier.py ../../../sigma-repo ../../../hayabusa-rules-repo ../../doc/SupportedSigmaFieldModifiers.md
 
       - name: Create Text
         id: create-text


### PR DESCRIPTION
## What Changed
The path to Actions in supported-modifier was incorrect and has been corrected.
I would appreciate it if you could check it out when you have time🙏