### PR TITLE
metrics: handle None value unwrap panic

### DIFF
--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -184,7 +184,7 @@ impl EventMetrics {
             let channel = if let Some(ch) =
                 utils::get_event_value("Channel", &record.record, &stored_static.eventkey_alias)
             {
-                ch.as_str().unwrap()
+                ch.as_str().unwrap_or_else(|| { "None" })
             } else {
                 "-"
             };


### PR DESCRIPTION
## What Changed

- update metrics.rs to handle unwrap() panic on None values

## Evidence

This addresses #1281 which I ran into while running eid-metrics with the latest commit built. Though I don't know if this condition is being hit due to a different/larger issue.