### PR TITLE
feat: add GitHub Actions for auto build packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Hayabusa Release Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_ver:
+        required: true
+        default: "2.x.x"
+      branch_or_tag:
+        required: true
+        default: "main"
+jobs:
+  release:
+    runs-on: ${{ matrix.info.os }}
+    strategy:
+      matrix:
+        info:
+          - {
+            os: "windows-latest",
+            target: "x86_64-pc-windows-msvc",
+            cross: false,
+          }
+          - {
+            os: "windows-2022",
+            target: "i686-pc-windows-msvc",
+            cross: true,
+          }
+          - {
+            os: "windows-2019",
+            target: "aarch64-pc-windows-msvc",
+            cross: true,
+          }
+          - {
+            os: "ubuntu-latest",
+            target: "x86_64-unknown-linux-gnu",
+            cross: false,
+          }
+          - {
+            os: "ubuntu-24.04",
+            target: "x86_64-unknown-linux-musl",
+            cross: true,
+          }
+          - {
+            os: "ubuntu-22.04",
+            target: "aarch64-unknown-linux-gnu",
+            cross: true,
+          }
+          - {
+            os: "ubuntu-20.04",
+            target: "aarch64-unknown-linux-musl",
+            cross: true,
+          }
+          - {
+            os: "macos-latest",
+            target: "aarch64-apple-darwin",
+            cross: false
+          }
+          - {
+            os: "macos-13",
+            target: "x86_64-apple-darwin",
+            cross: false
+          }
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_or_tag }}
+          submodules: 'true'
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.info.target }}
+
+      - name: Build Hayabusa binary
+        run: |
+          cargo run --release -- update-rules -q
+          cargo build --release
+
+      - name: Package and Zip - Windows
+        if: contains(matrix.info.os, 'windows') == true
+        shell: pwsh
+        run: |
+          mkdir -p release-binaries
+          mkdir -p release-binaries/logs
+          Copy-Item -Path ./target/release/hayabusa.exe -Destination release-binaries/
+          Copy-Item -Recurse -Path ./config -Destination release-binaries/
+          Copy-Item -Recurse -Path ./rules -Destination release-binaries/
+          switch ("${{ matrix.info.os }}") {
+              "windows-latest" { mv release-binaries/hayabusa.exe release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-win-x64.exe }
+              "windows-2022" { mv release-binaries/hayabusa.exe release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-win-x86.exe }
+              "windows-2019" { mv release-binaries/hayabusa.exe release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-win-arm.exe }
+          }
+
+      - name: Package and Zip(encoded_rule) - Windows
+        if: contains(matrix.info.os, 'windows') == true
+        shell: pwsh
+        run: |
+          mkdir -p release-binaries-encoded-rules
+          mkdir -p release-binaries-encoded-rules/logs
+          Copy-Item -Path ./target/release/hayabusa.exe -Destination release-binaries-encoded-rules/
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/encoded_rules.yml -OutFile release-binaries-encoded-rules/encoded_rules.yml
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/rules_config_files.txt -OutFile release-binaries-encoded-rules/rules_config_files.txt
+          switch ("${{ matrix.info.os }}") {
+              "windows-latest" { mv release-binaries-encoded-rules/hayabusa.exe release-binaries-encoded-rules/hayabusa-${{ github.event.inputs.release_ver }}-win-x64.exe }
+              "windows-2022" { mv release-binaries-encoded-rules/hayabusa.exe release-binaries-encoded-rules/hayabusa-${{ github.event.inputs.release_ver }}-win-x86.exe }
+              "windows-2019" { mv release-binaries-encoded-rules/hayabusa.exe release-binaries-encoded-rules/hayabusa-${{ github.event.inputs.release_ver }}-win-arm.exe }
+          }
+
+      - name: Package and Zip - Unix
+        if: contains(matrix.info.os, 'windows') == false
+        run: |
+          mkdir -p release-binaries
+          cp ./target/release/hayabusa release-binaries/
+          cp -r ./config release-binaries/config
+          cp -r ./logs release-binaries/logs
+          cp -r ./rules release-binaries/rules
+          case ${{ matrix.info.os }} in
+            'ubuntu-latest')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-lin-intel-x64-gnu ;;
+            'ubuntu-24.04')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-lin-intel-x64-musl ;;
+            'ubuntu-22.04')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-lin-arm-x64-gnu ;;
+            'ubuntu-20.04')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-lin-arm-x64-musl ;;
+            'macos-latest')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-mac-aarch64 ;;
+            'macos-13')
+                mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-mac-x64 ;;
+          esac
+
+      - name: Set Artifact Name
+        id: set_artifact_name
+        shell: bash
+        run: |
+          case "${{ matrix.info.os }}" in
+            'windows-latest')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-x64" >> $GITHUB_OUTPUT ;;
+            'windows-2022')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-x86" >> $GITHUB_OUTPUT ;;
+            'windows-2019')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-arm" >> $GITHUB_OUTPUT ;;
+            'ubuntu-latest')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-linux-intel-gnu" >> $GITHUB_OUTPUT ;;
+            'ubuntu-24.04')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-linux-intel-musl" >> $GITHUB_OUTPUT ;;
+            'ubuntu-22.04')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-linux-arm-gnu" >> $GITHUB_OUTPUT ;;
+            'ubuntu-20.04')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-linux-arm-musl" >> $GITHUB_OUTPUT ;;
+            'macos-latest')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT ;;
+            'macos-13')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Upload Zip Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          path: |
+            release-binaries/*
+
+      - name: Set Artifact Name(encoded_rule)
+        if: contains(matrix.info.os, 'windows') == true
+        id: set_artifact_name_encoded_rule
+        shell: bash
+        run: |
+          case "${{ matrix.info.os }}" in
+            'windows-latest')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-x64-live-response" > $GITHUB_OUTPUT ;;
+            'windows-2022')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-x86-live-response" > $GITHUB_OUTPUT ;;
+            'windows-2019')
+              echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-arm-live-response" > $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Upload Zip Artifacts(encoded_rule)
+        if: contains(matrix.info.os, 'windows') == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name_encoded_rule.outputs.artifact_name }}
+          path: |
+            release-binaries-encoded-rules/*
+
+      - name: Setup node
+        if: matrix.info.os == 'macos-latest'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Create PDF
+        if: matrix.info.os == 'macos-latest'
+        run: |
+          npm i -g md-to-pdf
+          md-to-pdf ./*.md --md-file-encoding utf-8
+          mv ./README.pdf ./README-${{ github.event.inputs.release_ver }}-English.pdf
+          mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
+
+      - name: Upload Document Artifacts
+        if: matrix.info.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: documents
+          path: |
+            ./*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@ on:
       release_ver:
         required: true
         default: "2.x.x"
+        description: "Version of the release"
       branch_or_tag:
         required: true
         default: "main"
+        description: "Branch or Tag to checkout"
 jobs:
-  release:
+  upload:
     runs-on: ${{ matrix.info.os }}
     strategy:
       matrix:
@@ -68,6 +70,13 @@ jobs:
           ref: ${{ github.event.inputs.branch_or_tag }}
           submodules: 'true'
 
+      - name: Clone hayabusa rule repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: Yamato-Security/hayabusa-rules
+          path: hayabusa-rules
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -87,7 +96,12 @@ jobs:
           mkdir -p release-binaries/logs
           Copy-Item -Path ./target/release/hayabusa.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
-          Copy-Item -Recurse -Path ./rules -Destination release-binaries/
+          Remove-Item -Path ./hayabusa-rules/.gitignore -Force
+          Remove-Item -Path ./hayabusa-rules/*.md -Force
+          Remove-Item -Path ./hayabusa-rules/.github -Recurse -Force
+          Remove-Item -Path ./hayabusa-rules/scripts -Recurse -Force
+          Remove-Item -Path ./hayabusa-rules/doc -Recurse -Force
+          Copy-Item -Recurse -Path ./hayabusa-rules/ -Destination release-binaries/rules -Force
           switch ("${{ matrix.info.os }}") {
               "windows-latest" { mv release-binaries/hayabusa.exe release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-win-x64.exe }
               "windows-2022" { mv release-binaries/hayabusa.exe release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-win-x86.exe }
@@ -116,7 +130,12 @@ jobs:
           cp ./target/release/hayabusa release-binaries/
           cp -r ./config release-binaries/config
           cp -r ./logs release-binaries/logs
-          cp -r ./rules release-binaries/rules
+          rm -f ./hayabusa-rules/.gitignore
+          rm -f ./hayabusa-rules/*.md
+          rm -rf ./hayabusa-rules/.github
+          rm -rf ./hayabusa-rules/scripts
+          rm -rf ./hayabusa-rules/doc
+          cp -r ./hayabusa-rules/. release-binaries/rules
           case ${{ matrix.info.os }} in
             'ubuntu-latest')
                 mv release-binaries/hayabusa release-binaries/hayabusa-${{ github.event.inputs.release_ver }}-lin-intel-x64-gnu ;;
@@ -157,12 +176,12 @@ jobs:
               echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT ;;
           esac
 
-      - name: Upload Zip Artifacts
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
-          path: |
-            release-binaries/*
+          path: release-binaries/*
+          include-hidden-files: true
 
       - name: Set Artifact Name(encoded_rule)
         if: contains(matrix.info.os, 'windows') == true
@@ -178,13 +197,13 @@ jobs:
               echo "artifact_name=hayabusa-${{ github.event.inputs.release_ver }}-win-arm-live-response" > $GITHUB_OUTPUT ;;
           esac
 
-      - name: Upload Zip Artifacts(encoded_rule)
+      - name: Upload Artifacts(encoded_rule)
         if: contains(matrix.info.os, 'windows') == true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set_artifact_name_encoded_rule.outputs.artifact_name }}
-          path: |
-            release-binaries-encoded-rules/*
+          path: release-binaries-encoded-rules/*
+          include-hidden-files: true
 
       - name: Setup node
         if: matrix.info.os == 'macos-latest'
@@ -204,6 +223,48 @@ jobs:
         if: matrix.info.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: documents
+          name: hayabusa-documents
           path: |
             ./*.pdf
+
+  upload-all-platforms:
+    needs: upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-packages
+          pattern: hayabusa-*
+          merge-multiple: true
+      - run: |
+          rm -rf all-packages/encoded_rules.yml
+          rm -rf all-packages/rules_config_files.txt
+
+      - name: Upload Artifacts(all-platforms)
+        uses: actions/upload-artifact@v4
+        with:
+          name: hayabusa-${{ github.event.inputs.release_ver }}-all-platforms
+          path: all-packages/*
+          include-hidden-files: true
+
+  all-packages-zip:
+    needs: upload-all-platforms
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-packages
+          pattern: hayabusa-*
+      - run: |
+          ls -lR all-packages
+          cd all-packages
+          for dir in */; do
+            zip -r "${dir%/}.zip" "$dir"
+          done
+      - name: Upload Zip Artifacts(all-packages)
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-packages
+          path: all-packages/*.zip


### PR DESCRIPTION
## What Changed
- Closed #1239 

## How to use
- **Use workflow from** : normally, specify main.
- **release_ver**: target version name (use as zip package and exe name)
- **branch_or_tag** :  target git branch or tag name

<img width="1019" alt="スクリーンショット 2024-10-05 17 18 59" src="https://github.com/user-attachments/assets/5588c2a9-7a5d-4a4b-9b10-4e78e61886aa">

## Action's Artifacts
Tested in the fukusuket repository.

https://github.com/fukusuket/hayabusa/actions/runs/11191344760
<img width="937" alt="スクリーンショット 2024-10-05 17 28 06" src="https://github.com/user-attachments/assets/6026e9d3-e645-405b-8fc4-1f93a00e41ad">


<img width="846" alt="スクリーンショット 2024-10-05 17 17 51" src="https://github.com/user-attachments/assets/8cf860ff-553c-41ed-b14b-0aaeba042682">


I would appreciate it if you could check it out when you have time🙏