### PR TITLE
fix: copy all .git commit history by specifying fetch-depth 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
           }
           - {
             os: "ubuntu-24.04",
-            target: "x86_64-unknown-linux-musl",
+            target: "aarch64-unknown-linux-gnu",
             cross: true,
           }
           - {
             os: "ubuntu-22.04",
-            target: "aarch64-unknown-linux-gnu",
+            target: "x86_64-unknown-linux-musl",
             cross: true,
           }
           - {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: Yamato-Security/hayabusa-rules
+          fetch-depth: 0
           path: hayabusa-rules
 
       - name: Set up Rust toolchain


### PR DESCRIPTION
## What Changed

- Closed #1429 

## Evidence

I will check if `update-rules` can be executed when there is a new commit in `hayabusa_rules`.
- https://github.com/Yamato-Security/hayabusa/actions/runs/11254983192

```
fukusuke@fukusukenoMacBook-Air hayabusa-2.18.0-mac-arm % ./hayabusa-2.18.0-mac-aarch64 update-rules -q
Start time: 2024/10/10 07:31

 - Renamed Powershell Under Powershell Channel (Modified: 2024-10-08 | Path: rules/sigma/builtin/powershell/powershell_classic/posh_pc_renamed_powershell.yml)
 - CodeIntegrity - Unmet Signing Level Requirements By File Under Validation (Modified: 2024-10-08 | Path: rules/sigma/builtin/code_integrity/win_codeintegrity_attempted_dll_load.yml)
 - Antivirus Password Dumper Detection (Modified: 2024-10-08 | Path: rules/sigma/builtin/category/antivirus/av_password_dumper.yml)
 - Alternate PowerShell Hosts Pipe (Modified: 2024-10-07 | Path: rules/sigma/sysmon/pipe_created/pipe_created_powershell_alternate_host_pipe.yml)
 - Suspicious Non PowerShell WSMAN COM Provider (Modified: 2024-10-08 | Path: rules/sigma/builtin/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml)
 - HackTool - Certipy Execution (Modified: 2024-10-08 | Path: rules/sigma/builtin/process_creation/proc_creation_win_hktl_certipy.yml)
 - HackTool - Certipy Execution (Modified: 2024-10-08 | Path: rules/sigma/sysmon/process_creation/proc_creation_win_hktl_certipy.yml)

Updated Sigma rules: 7
Rules updated successfully.
```
I have confirmed that update-rules can be run with today's update of hayabusa_rules.

I would appreciate it if you could check it out when you have time🙏