### PR TITLE
fix: make `group-by` optional for correlation

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -15,6 +15,7 @@
 **バグ修正:**
 
 - `search`コマンドの`-o`オプションを使用した際に不要な改行が出力されていた。(#1425) (@fukusuket)
+- Sigma相関ルールの`group-by`フィールドは、必須だったが任意に変えた。(#1442) (@fukusuket)
 
 ## 2.17.0 [2024/08/23] "HITCON Community Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 **Bug Fixes:**
 
 - Unneeded line breaks when using `-o` in the `search` command. (#1425) (@fukusuket)
-- Sigma correlation rules required the `group-by` field but now they are optional. (#1442) (@fukusuket)
+- Sigma correlation rules required the `group-by` field but now it is optional. (#1442) (@fukusuket)
 
 ## 2.17.0 [2024/08/23] "HITCON Community Release"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Bug Fixes:**
 
 - Unneeded line breaks when using `-o` in the `search` command. (#1425) (@fukusuket)
+- Sigma correlation rules required the `group-by` field but now they are optional. (#1442) (@fukusuket)
 
 ## 2.17.0 [2024/08/23] "HITCON Community Release"
 


### PR DESCRIPTION
## What Changed

- Closed #1442 

## Evidence
All commands completed successfully.
https://github.com/Yamato-Security/hayabusa/actions/runs/11313889055

#### CSV timeline and JSON timeline Diff(when rule/config folder exists)
No difference(csv/json) from main branch's results as follows.
https://github.com/Yamato-Security/hayabusa/actions/runs/11313890870

I would appreciate it if you could check it out when you have time🙏