### PR TITLE
update color scheme

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 - `yaml-rust`クレートを`yaml-rust2`に更新した。(#461) (@yamatosecurity)
 - `windash`文字が、`rules/config/windash_characters.txt`から動的に読み込まれるようになった。(#1440) (@fukusuket)
 - `logon-summary`コマンドがRDPイベントからのログオン情報を表示するようになった。注意: ファイルに保存する場合、Hayabusaはより詳細な情報を出力する。(#1468) (@fukusuket)
+- 見やすくなるように色を更新した。 (#1480) (@yamatosecurity)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated the `yaml-rust` crate to `yaml-rust2`. (#461) (@yamatosecurity)
 - `windash` characters are now being dynamically read from `rules/config/windash_characters.txt`. (#1440) (@fukusuket)
 - `logon-summary` command now displays logon information from RDP events. Note: Hayabusa will output more detailed information when saving to a file. (#1468) (@fukusuket)
+- The colors were updated to make it easier to read. (#1480) (@yamatosecurity)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +357,16 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "comfy-table"
@@ -689,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "file-chunker"
@@ -838,11 +857,13 @@ name = "hayabusa"
 version = "2.19.0-dev"
 dependencies = [
  "aho-corasick",
+ "ansi_term",
  "base64",
  "bytesize",
  "chrono",
  "cidr-utils",
  "clap",
+ "colored",
  "comfy-table",
  "compact_str",
  "console",
@@ -1211,9 +1232,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libgit2-sys"
@@ -2064,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2136,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,7 +848,6 @@ name = "hayabusa"
 version = "2.19.0-dev"
 dependencies = [
  "aho-corasick",
- "ansi_term",
  "base64",
  "bytesize",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 aho-corasick = "*"
-ansi_term = "0.*"
 base64 = "*"
 bytesize = "1.*"
 chrono = "0.4.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 aho-corasick = "*"
+ansi_term = "0.*"
 base64 = "*"
 bytesize = "1.*"
 chrono = "0.4.*"
 cidr-utils = "0.6.*"
 clap = { version = "4.*", features = ["derive", "cargo", "color"]}
+colored = "2"
 comfy-table = "7.*"
 compact_str = "0.8.*"
 console = "0.15.*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1244,10 +1244,11 @@ impl App {
                     unpicked_item_prefix: style(" ".to_string()).for_stderr(),
                 }
             } else {
-                let mut c = ColorfulTheme::default();
-                c.active_item_style = Style::new().color256(14);
-                c.values_style = Style::new().color256(46);
-                c
+                ColorfulTheme {
+                    active_item_style: Style::new().color256(14),
+                    values_style: Style::new().color256(46),
+                    ..Default::default()
+                }
             };
             let selected_index = Select::with_theme(&color_theme)
                 .with_prompt("Which set of detection rules would you like to load?")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1245,15 +1245,15 @@ impl App {
                 }
             } else {
                 ColorfulTheme {
-                    active_item_prefix: Style::new().color256(51).apply_to("❯".to_string()),  // cyan
-                    checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()),  // green
+                    active_item_prefix: Style::new().color256(51).apply_to("❯".to_string()), // cyan
+                    checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     picked_item_prefix: Style::new().color256(51).apply_to("❯".to_string()), // cyan
-                    active_item_style: Style::new().color256(51), // cyan
+                    active_item_style: Style::new().color256(51),                            // cyan
                     values_style: Style::new().color256(46), // green
-                    prompt_prefix: Style::new().color256(51).apply_to("?".to_string()),  // cyan
+                    prompt_prefix: Style::new().color256(51).apply_to("?".to_string()), // cyan
                     prompt_suffix: Style::new().color256(51).apply_to("›".to_string()), // cyan
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
-                    success_suffix: Style::new().color256(15).apply_to("·".to_string()),  // white
+                    success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                     error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red
                     ..Default::default()
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1245,8 +1245,16 @@ impl App {
                 }
             } else {
                 ColorfulTheme {
-                    active_item_style: Style::new().color256(14),
-                    values_style: Style::new().color256(46),
+                    active_item_prefix: Style::new().color256(51).apply_to("❯".to_string()),  // cyan
+                    checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()),  // green
+                    picked_item_prefix: Style::new().color256(51).apply_to("❯".to_string()), // cyan
+                    active_item_style: Style::new().color256(51), // cyan
+                    values_style: Style::new().color256(46), // green
+                    prompt_prefix: Style::new().color256(51).apply_to("?".to_string()),  // cyan
+                    prompt_suffix: Style::new().color256(51).apply_to("›".to_string()), // cyan
+                    success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
+                    success_suffix: Style::new().color256(15).apply_to("·".to_string()),  // white
+                    error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red
                     ..Default::default()
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1253,7 +1253,7 @@ impl App {
                     prompt_prefix: Style::new().color256(51).apply_to("?".to_string()), // cyan
                     prompt_suffix: Style::new().color256(51).apply_to("›".to_string()), // cyan
                     defaults_style: Style::new().color256(51), // cyan
-                    hint_style: Style::new().color256(51), // cyan
+                    hint_style: Style::new().color256(51),   // cyan
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                     error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red

--- a/src/main.rs
+++ b/src/main.rs
@@ -1248,12 +1248,12 @@ impl App {
                     active_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
                     checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     picked_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
-                    active_item_style: Style::new().color256(51),                            // cyan
-                    values_style: Style::new().color256(46), // green
+                    active_item_style: Style::new().color256(51), // cyan
+                    values_style: Style::new().color256(46),      // green
                     prompt_prefix: Style::new().color256(214).apply_to("?".to_string()), // orange
                     prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // cyan
-                    defaults_style: Style::new().color256(51), // cyan
-                    hint_style: Style::new().color256(214),   // orange
+                    defaults_style: Style::new().color256(51),    // cyan
+                    hint_style: Style::new().color256(214),       // orange
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                     error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red

--- a/src/main.rs
+++ b/src/main.rs
@@ -1245,15 +1245,15 @@ impl App {
                 }
             } else {
                 ColorfulTheme {
-                    active_item_prefix: Style::new().color256(51).apply_to("❯".to_string()), // cyan
+                    active_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
                     checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
-                    picked_item_prefix: Style::new().color256(51).apply_to("❯".to_string()), // cyan
+                    picked_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
                     active_item_style: Style::new().color256(51),                            // cyan
                     values_style: Style::new().color256(46), // green
-                    prompt_prefix: Style::new().color256(51).apply_to("?".to_string()), // cyan
-                    prompt_suffix: Style::new().color256(51).apply_to("›".to_string()), // cyan
+                    prompt_prefix: Style::new().color256(214).apply_to("?".to_string()), // orange
+                    prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // cyan
                     defaults_style: Style::new().color256(51), // cyan
-                    hint_style: Style::new().color256(51),   // cyan
+                    hint_style: Style::new().color256(214),   // orange
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                     error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use std::{
 use bytesize::ByteSize;
 use chrono::{DateTime, Datelike, Local, NaiveDateTime, Utc};
 use clap::Command;
+use colored::Colorize;
 use compact_str::CompactString;
 use console::{style, Style};
 use dialoguer::Confirm;
@@ -779,7 +780,7 @@ impl App {
                 for profile in profile_list.iter() {
                     write_color_buffer(
                         &BufferWriter::stdout(ColorChoice::Always),
-                        Some(Color::Green),
+                        Some(Color::Rgb(0, 255, 0)),
                         &format!("- {:<25}", &format!("{}:", profile[0])),
                         false,
                     )
@@ -1539,20 +1540,27 @@ impl App {
         }
 
         let template = if stored_static.common_options.no_color {
-            "[{elapsed_precise}] {human_pos} / {human_len} {spinner} [{bar:40}] {percent}%\r\n\r\n{msg}"
+            "[{elapsed_precise}] {human_pos} / {human_len} {spinner} [{bar:40}] {percent}%\r\n\r\n{msg}".to_string()
         } else {
-            "[{elapsed_precise}] {human_pos} / {human_len} {spinner:.green} [{bar:40.green}] {percent}%\r\n\r\n{msg}"
+            let spinner = "{spinner}".truecolor(0, 255, 0).to_string();
+            let bar = "{bar:40}".truecolor(0, 255, 0).to_string();
+            format!(
+                "[{{elapsed_precise}}] {{human_pos}} / {{human_len}} {} [{}] {{percent}}%\r\n\r\n{{msg}}",
+                spinner, bar
+            )
         };
-        let progress_style = ProgressStyle::with_template(template)
+        
+        let progress_style = ProgressStyle::with_template(&template) // Pass `&template` here
             .unwrap()
             .progress_chars("=> ");
+        
         let pb = ProgressBar::with_draw_target(
             Some(evtx_files.len() as u64),
             ProgressDrawTarget::stdout_with_hz(10),
         )
         .with_tab_width(55);
         pb.set_style(progress_style);
-        // I tried progress bar with low memory option(output log on detection) but it seemts that progress bar didn't go well with low memory option.
+        // I tried progress bar with low memory option(output log on detection) but it seems that progress bar didn't go well with low memory option.
         // I disabled progress bar if low memory option is specified.
         let is_show_progress = !stored_static.is_low_memory || stored_static.output_path.is_some();
         if is_show_progress {
@@ -2321,7 +2329,7 @@ impl App {
         let output_color = if stored_static.common_options.no_color {
             None
         } else {
-            Some(Color::Green)
+            Some(Color::Rgb(0,255,0))
         };
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1244,7 +1244,10 @@ impl App {
                     unpicked_item_prefix: style(" ".to_string()).for_stderr(),
                 }
             } else {
-                ColorfulTheme::default()
+                let mut c = ColorfulTheme::default();
+                c.active_item_style = Style::new().color256(14);
+                c.values_style = Style::new().color256(46);
+                c
             };
             let selected_index = Select::with_theme(&color_theme)
                 .with_prompt("Which set of detection rules would you like to load?")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1549,11 +1549,11 @@ impl App {
                 spinner, bar
             )
         };
-        
+
         let progress_style = ProgressStyle::with_template(&template) // Pass `&template` here
             .unwrap()
             .progress_chars("=> ");
-        
+
         let pb = ProgressBar::with_draw_target(
             Some(evtx_files.len() as u64),
             ProgressDrawTarget::stdout_with_hz(10),
@@ -2329,7 +2329,7 @@ impl App {
         let output_color = if stored_static.common_options.no_color {
             None
         } else {
-            Some(Color::Rgb(0,255,0))
+            Some(Color::Rgb(0, 255, 0))
         };
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1252,6 +1252,8 @@ impl App {
                     values_style: Style::new().color256(46), // green
                     prompt_prefix: Style::new().color256(51).apply_to("?".to_string()), // cyan
                     prompt_suffix: Style::new().color256(51).apply_to("›".to_string()), // cyan
+                    defaults_style: Style::new().color256(51), // cyan
+                    hint_style: Style::new().color256(51), // cyan
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                     success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                     error_prefix: Style::new().color256(9).apply_to("✘".to_string()), // red


### PR DESCRIPTION
Closes https://github.com/Yamato-Security/hayabusa/issues/1480

@fukusuket Do you know how to update the colors in the scan wizard? For example, I want to use 0,255,0 green for selected answers, the brighter blue we use for field data unselected answers, etc...