### PR TITLE
fix: not output stdout err msg when timestamp parse error in metrics cmd

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -20,6 +20,7 @@
 - `hayabusa-evtx`クレートをバージョン`0.8.12`に更新した。(@yamatosecurity)
   - JSONフィールドの出力順序が元のXMLに従って保持されるようになった。(omerbenamram/evtx #241)
   - 属性と同じ名前を持つ複数のサブノードは上書きされ、最後の1つだけが出力されていた。(omerbenamram/evtx #245)
+- `logon-summary`と`eid-metrics`が複数のプログレスバーを出力することがあった。 #1479 (@fukusuket)
 
 ## 2.18.0 [2024/10/23] - SecTor Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Updated `hayabusa-evtx` crate to `0.8.12`. (@yamatosecurity)
   - JSON field output order is now preserved according to the original XML. (omerbenamram/evtx #241)
   - Multiple sub-nodes with attributes and the same name would be overwritten and only the last one kept. (omerbenamram/evtx #245)
+- `logon-summary` and `eid-metrics` would sometimes output multiple progress bars. #1479 (@fukusuket)
 
 ## 2.18.0 [2024/10/23] - SecTor Release
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1914,7 +1914,7 @@ impl App {
             )),
             Err(e) => {
                 AlertMessage::alert(&format!(
-                    "timestamp parse error. filepath:{},{} {}",
+                    "Timestamp parse error. Filepath: {},{} {}",
                     path,
                     &target_timestamp
                         .to_string()
@@ -2030,7 +2030,7 @@ impl App {
                             }
                             Err(e) => {
                                 AlertMessage::warn(&format!(
-                                    "timestamp parse error. filepath:{},{} {}",
+                                    "Timestamp parse error. Filepath: {},{} {}",
                                     path,
                                     &splunk_api_record["Event"]["System"]["SystemTime"]
                                         .to_string()

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -106,7 +106,8 @@ impl EventMetrics {
                             DateTime::<Utc>::from_naive_utc_and_offset(splunk_json_datetime, Utc),
                         ),
                         Err(e) => {
-                            let errmsg = format!("Timestamp parse error.\nInput: {evttime}\nError: {e}\n");
+                            let errmsg =
+                                format!("Timestamp parse error.\nInput: {evttime}\nError: {e}\n");
                             if stored_static.verbose_flag {
                                 AlertMessage::alert(&errmsg).ok();
                             }

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -106,7 +106,7 @@ impl EventMetrics {
                             DateTime::<Utc>::from_naive_utc_and_offset(splunk_json_datetime, Utc),
                         ),
                         Err(e) => {
-                            let errmsg = format!("Timestamp parse error. Input: {evttime} {e}");
+                            let errmsg = format!("Timestamp parse error.\nInput: {evttime}\nError:{e}\n");
                             if stored_static.verbose_flag {
                                 AlertMessage::alert(&errmsg).ok();
                             }
@@ -130,7 +130,7 @@ impl EventMetrics {
                 } else {
                     // evtxがリリースされた2007/1/30以前の日付データは不正な形式データ扱いとする
                     ERROR_LOG_STACK.lock().unwrap().push(format!(
-                        "[ERROR] Invalid record found. EventFile:{} Timestamp:{}",
+                        "[ERROR] Invalid record found.\nEventFile:{}\nTimestamp:{}\n",
                         self.filepath,
                         timestamp.unwrap()
                     ));

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -106,7 +106,7 @@ impl EventMetrics {
                             DateTime::<Utc>::from_naive_utc_and_offset(splunk_json_datetime, Utc),
                         ),
                         Err(e) => {
-                            let errmsg = format!("Timestamp parse error.\nInput: {evttime}\nError:{e}\n");
+                            let errmsg = format!("Timestamp parse error.\nInput: {evttime}\nError: {e}\n");
                             if stored_static.verbose_flag {
                                 AlertMessage::alert(&errmsg).ok();
                             }
@@ -232,7 +232,7 @@ impl EventMetrics {
                     )
                     .unwrap_or("n/a".into());
                     let errmsg = format!(
-                        "Failed to parse EventID from EventFile: {}, EventRecordID: {}",
+                        "Failed to parse event ID from event file: {}\nEvent record ID: {}\n",
                         &record.evtx_filepath, rec_id
                     );
                     if stored_static.verbose_flag {

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -106,7 +106,7 @@ impl EventMetrics {
                             DateTime::<Utc>::from_naive_utc_and_offset(splunk_json_datetime, Utc),
                         ),
                         Err(e) => {
-                            let errmsg = format!("timestamp parse error. input: {evttime} {e}");
+                            let errmsg = format!("Timestamp parse error. Input: {evttime} {e}");
                             if stored_static.verbose_flag {
                                 AlertMessage::alert(&errmsg).ok();
                             }


### PR DESCRIPTION
## What Changed
- Closed #1479 

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/11752599729

I would appreciate it if you could check it out when you have time🙏