### PR TITLE
feat: `utf16/utf16be/utf16le/wide` modifiers 

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -12,6 +12,11 @@
   * eid-metrics
   * log-metrics
   * search
+- `utf16/utf16be/utf16le/wide`フィールドモディファイアが`base64offset|contains`フィールドモディファイアと一緒に使えるようになった。 (#1432) (@fukusuket)
+  * `utf16|base64offset|contains`
+  * `utf16be|base64offset|contains`
+  * `utf16le|base64offset|contains`
+  * `wide|base64offset|contains`
 
 **改善:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,11 +7,11 @@
 - `gt`、`gte`、`lt`、`lte`のフィールドモディファイアに対応した。(#1433) (@fukusuket)
 - 新しい`log-metrics`コマンドで`.evtx`ファイルの情報を取得できるようになった。(コンピュータ名、イベント数、最初のタイムスタンプ、最後のタイムスタンプ、チャネル、プロバイダ) (#1474) (@fukusuket)
 - 以下のコマンドに`Channel`と`Provider`の略称を無効にする`-b, --disable-abbreviations`オプションを追加した。元の値を確認したい時に便利。 (#1485) (@fukusuket)
-  * csv-timeline
-  * json-timeline
-  * eid-metrics
-  * log-metrics
-  * search
+  * `csv-timeline`
+  * `json-timeline`
+  * `eid-metrics`
+  * `log-metrics`
+  * `search`
 - `utf16/utf16be/utf16le/wide`フィールドモディファイアが`base64offset|contains`フィールドモディファイアと一緒に使えるようになった。 (#1432) (@fukusuket)
   * `utf16|base64offset|contains`
   * `utf16be|base64offset|contains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   * eid-metrics
   * log-metrics
   * search
+- Support for `utf16/utf16be/utf16le/wide` field modifiers to be used with the `base64offset|contains` field modifier. (#1432) (@fukusuket)
+  * `utf16|base64offset|contains`
+  * `utf16be|base64offset|contains`
+  * `utf16le|base64offset|contains`
+  * `wide|base64offset|contains`
 
 **Enhancements:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
 - Support for the `gt`, `gte`, `lt`, `lte` field modifiers. (#1433) (@fukusuket)
 - New `log-metrics` command to get information about `.evtx` files. (computer names, event count, first timestamp, last timestamp, channels, providers) (#1474) (@fukusuket)
 - New `-b, --disable-abbreviations` options for the following commands to disable `Channel` and `Provider` abbreviations for when you want to check the original values. (#1485) (@fukusuket)
-  * csv-timeline
-  * json-timeline
-  * eid-metrics
-  * log-metrics
-  * search
+  * `csv-timeline`
+  * `json-timeline`
+  * `eid-metrics`
+  * `log-metrics`
+  * `search`
 - Support for `utf16/utf16be/utf16le/wide` field modifiers to be used with the `base64offset|contains` field modifier. (#1432) (@fukusuket)
   * `utf16|base64offset|contains`
   * `utf16be|base64offset|contains`

--- a/src/detections/rule/base64_match.rs
+++ b/src/detections/rule/base64_match.rs
@@ -1,0 +1,106 @@
+use crate::detections::rule::fast_match::{convert_to_fast_match, FastMatch};
+use base64::engine::general_purpose;
+use base64::Engine;
+
+pub fn convert_to_base64_str(val: &str, err_msges: &mut Vec<String>) -> Option<Vec<FastMatch>> {
+    // |base64offset|containsの場合
+    let mut fastmatches = vec![];
+    for i in 0..3 {
+        let mut b64_result = vec![];
+        let mut target_byte = vec![];
+        target_byte.resize_with(i, || 0b0);
+        target_byte.extend_from_slice(val.as_bytes());
+        b64_result.resize_with(target_byte.len() * 4 / 3 + 4, || 0b0);
+        general_purpose::STANDARD
+            .encode_slice(target_byte, &mut b64_result)
+            .ok();
+        let convstr_b64 = String::from_utf8(b64_result);
+        if let Ok(b64_str) = convstr_b64 {
+            // ここでContainsのfastmatch対応を行う
+            let b64_s_null_filtered = b64_str.replace('\0', "");
+            let b64_offset_contents = base64_offset(i, b64_str, b64_s_null_filtered);
+            if let Some(fm) = convert_to_fast_match(&format!("*{b64_offset_contents}*"), false) {
+                fastmatches.extend(fm);
+            }
+        } else {
+            err_msges.push(format!(
+                "Failed base64 encoding: {}",
+                convstr_b64.unwrap_err()
+            ));
+        }
+    }
+    if fastmatches.is_empty() {
+        return None;
+    }
+    Some(fastmatches)
+}
+
+fn base64_offset(offset: usize, b64_str: String, b64_str_null_filtered: String) -> String {
+    match b64_str.find('=').unwrap_or_default() % 4 {
+        2 => {
+            if offset == 0 {
+                b64_str_null_filtered[..b64_str_null_filtered.len() - 3].to_string()
+            } else {
+                b64_str_null_filtered[(offset + 1)..b64_str_null_filtered.len() - 3].to_string()
+            }
+        }
+        3 => {
+            if offset == 0 {
+                b64_str_null_filtered[..b64_str_null_filtered.len() - 2].to_string()
+            } else {
+                b64_str_null_filtered.replace('\0', "")
+                    [(offset + 1)..b64_str_null_filtered.len() - 2]
+                    .to_string()
+            }
+        }
+        _ => {
+            if offset == 0 {
+                b64_str_null_filtered
+            } else {
+                b64_str_null_filtered[(offset + 1)..].to_string()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base64_offset() {
+        let b64_str = "aGVsbG8gd29ybGQ=".to_string();
+        let b64_str_null_filtered = "aGVsbG8gd29ybGQ=".to_string();
+        assert_eq!(
+            base64_offset(0, b64_str.clone(), b64_str_null_filtered.clone()),
+            "aGVsbG8gd29ybG"
+        );
+        assert_eq!(
+            base64_offset(1, b64_str.clone(), b64_str_null_filtered.clone()),
+            "VsbG8gd29ybG"
+        );
+        assert_eq!(
+            base64_offset(2, b64_str.clone(), b64_str_null_filtered.clone()),
+            "sbG8gd29ybG"
+        );
+    }
+
+    #[test]
+    fn test_convert_to_base64_str() {
+        let mut err_msges = vec![];
+        let val = "Hello, world!";
+        let fastmatches = convert_to_base64_str(val, &mut err_msges).unwrap();
+        assert_eq!(
+            fastmatches[0],
+            FastMatch::Contains("SGVsbG8sIHdvcmxkI".to_string())
+        );
+        assert_eq!(
+            fastmatches[1],
+            FastMatch::Contains("hlbGxvLCB3b3JsZC".to_string())
+        );
+        assert_eq!(
+            fastmatches[2],
+            FastMatch::Contains("IZWxsbywgd29ybGQh".to_string())
+        );
+    }
+}

--- a/src/detections/rule/fast_match.rs
+++ b/src/detections/rule/fast_match.rs
@@ -1,0 +1,239 @@
+use crate::detections::configs::WINDASH_CHARACTERS;
+use crate::detections::rule::matchers::PipeElement;
+use crate::detections::utils;
+
+// 正規表現マッチは遅いため、できるだけ高速なstd::stringのlen/starts_with/ends_with/containsでマッチ判定するためのenum
+#[derive(PartialEq, Debug)]
+pub enum FastMatch {
+    Exact(String),
+    StartsWith(String),
+    EndsWith(String),
+    Contains(String),
+    AllOnly(String),
+}
+
+pub fn eq_ignore_case(event_value_str: &str, match_str: &str) -> bool {
+    if match_str.len() == event_value_str.len() {
+        return match_str.eq_ignore_ascii_case(event_value_str);
+    }
+    false
+}
+
+pub fn starts_with_ignore_case(event_value_str: &str, match_str: &str) -> Option<bool> {
+    let len = match_str.len();
+    if len > event_value_str.len() {
+        return Some(false);
+    }
+    // マルチバイト文字を含む場合は、index out of boundsになるため、asciiのみ
+    if event_value_str.is_ascii() {
+        let match_result = match_str.eq_ignore_ascii_case(&event_value_str[0..len]);
+        return Some(match_result);
+    }
+    None
+}
+
+pub fn ends_with_ignore_case(event_value_str: &str, match_str: &str) -> Option<bool> {
+    let len1 = match_str.len();
+    let len2 = event_value_str.len();
+    if len1 > len2 {
+        return Some(false);
+    }
+    // マルチバイト文字を含む場合は、index out of boundsになるため、asciiのみ
+    if event_value_str.is_ascii() {
+        let match_result = match_str.eq_ignore_ascii_case(&event_value_str[len2 - len1..]);
+        return Some(match_result);
+    }
+    None
+}
+
+// ワイルドカードマッチを高速なstd::stringのlen/starts_with/ends_withに変換するための関数
+pub fn convert_to_fast_match(s: &str, ignore_case: bool) -> Option<Vec<FastMatch>> {
+    let wildcard_count = s.chars().filter(|c| *c == '*').count();
+    let is_literal_asterisk = |s: &str| s.ends_with(r"\*") && !s.ends_with(r"\\*");
+    if utils::contains_str(s, "?")
+        || s.ends_with(r"\\\*")
+        || (!s.is_ascii() && utils::contains_str(s, "*"))
+    {
+        // 高速なマッチに変換できないパターンは、正規表現マッチのみ
+        return None;
+    } else if s.starts_with("allOnly*") && s.ends_with('*') && wildcard_count == 2 {
+        let removed_asterisk = s[8..(s.len() - 1)].replace(r"\\", r"\");
+        if ignore_case {
+            return Some(vec![FastMatch::AllOnly(removed_asterisk.to_lowercase())]);
+        }
+        return Some(vec![FastMatch::AllOnly(removed_asterisk)]);
+    } else if s.starts_with('*')
+        && s.ends_with('*')
+        && wildcard_count == 2
+        && !is_literal_asterisk(s)
+    {
+        let removed_asterisk = s[1..(s.len() - 1)].replace(r"\\", r"\");
+        // *が先頭と末尾だけは、containsに変換
+        if ignore_case {
+            return Some(vec![FastMatch::Contains(removed_asterisk.to_lowercase())]);
+        }
+        return Some(vec![FastMatch::Contains(removed_asterisk)]);
+    } else if s.starts_with('*') && wildcard_count == 1 && !is_literal_asterisk(s) {
+        // *が先頭は、ends_withに変換
+        return Some(vec![FastMatch::EndsWith(s[1..].replace(r"\\", r"\"))]);
+    } else if s.ends_with('*') && wildcard_count == 1 && !is_literal_asterisk(s) {
+        // *が末尾は、starts_withに変換
+        return Some(vec![FastMatch::StartsWith(
+            s[..(s.len() - 1)].replace(r"\\", r"\"),
+        )]);
+    } else if utils::contains_str(s, "*") {
+        // *が先頭・末尾以外にあるパターンは、starts_with/ends_withに変換できないため、正規表現マッチのみ
+        return None;
+    }
+    // *を含まない場合は、文字列長マッチに変換
+    Some(vec![FastMatch::Exact(s.replace(r"\\", r"\"))])
+}
+
+pub fn check_fast_match(
+    pipes: &[PipeElement],
+    event_value_str: &str,
+    fast_matcher: &[FastMatch],
+) -> Option<bool> {
+    let windash_chars = WINDASH_CHARACTERS.as_slice();
+    if fast_matcher.len() == 1 {
+        match &fast_matcher[0] {
+            FastMatch::Exact(s) => Some(eq_ignore_case(event_value_str, s)),
+            FastMatch::StartsWith(s) => {
+                if pipes.contains(&PipeElement::Cased) {
+                    Some(event_value_str.starts_with(s))
+                } else {
+                    starts_with_ignore_case(event_value_str, s)
+                }
+            }
+            FastMatch::EndsWith(s) => {
+                if pipes.contains(&PipeElement::Cased) {
+                    Some(event_value_str.ends_with(s))
+                } else {
+                    ends_with_ignore_case(event_value_str, s)
+                }
+            }
+            FastMatch::Contains(s) | FastMatch::AllOnly(s) => {
+                if pipes.contains(&PipeElement::Windash) {
+                    Some(utils::contains_str(
+                        &event_value_str
+                            .replacen(windash_chars, "/", 1)
+                            .to_lowercase(),
+                        s,
+                    ))
+                } else if pipes.contains(&PipeElement::Cased) {
+                    Some(utils::contains_str(event_value_str, s))
+                } else {
+                    Some(utils::contains_str(&event_value_str.to_lowercase(), s))
+                }
+            }
+        }
+    } else {
+        Some(fast_matcher.iter().any(|fm| match fm {
+            FastMatch::Contains(s) => {
+                if pipes.contains(&PipeElement::Windash) {
+                    utils::contains_str(
+                        &event_value_str
+                            .replacen(windash_chars, "/", 1)
+                            .to_lowercase(),
+                        s,
+                    )
+                } else {
+                    utils::contains_str(event_value_str, s)
+                }
+            }
+            _ => false,
+        }))
+    }
+}
+
+pub fn create_fast_match(pipes: &[PipeElement], pattern: &[String]) -> Option<Vec<FastMatch>> {
+    if let Some(element) = pipes.first() {
+        match element {
+            PipeElement::Startswith => {
+                convert_to_fast_match(format!("{}*", pattern[0]).as_str(), true)
+            }
+            PipeElement::Endswith => {
+                convert_to_fast_match(format!("*{}", pattern[0]).as_str(), true)
+            }
+            PipeElement::Contains => {
+                convert_to_fast_match(format!("*{}*", pattern[0]).as_str(), true)
+            }
+            PipeElement::AllOnly => {
+                convert_to_fast_match(format!("allOnly*{}*", pattern[0]).as_str(), true)
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detections::rule::fast_match::{
+        convert_to_fast_match, ends_with_ignore_case, eq_ignore_case, starts_with_ignore_case,
+        FastMatch,
+    };
+
+    #[test]
+    fn test_eq_ignore_case() {
+        assert!(eq_ignore_case("abc", "abc"));
+        assert!(eq_ignore_case("AbC", "abc"));
+        assert!(!eq_ignore_case("abc", "ab"));
+        assert!(!eq_ignore_case("ab", "abc"));
+    }
+
+    #[test]
+    fn test_starts_with_ignore_case() {
+        assert!(starts_with_ignore_case("abc", "ab").unwrap(),);
+        assert!(starts_with_ignore_case("AbC", "ab").unwrap(),);
+        assert!(!starts_with_ignore_case("abc", "abcd").unwrap(),);
+        assert!(!starts_with_ignore_case("aab", "ab").unwrap(),);
+    }
+
+    #[test]
+    fn test_ends_with_ignore_case() {
+        assert!(ends_with_ignore_case("abc", "bc").unwrap());
+        assert!(ends_with_ignore_case("AbC", "bc").unwrap());
+        assert!(!ends_with_ignore_case("bc", "bcd").unwrap());
+        assert!(!ends_with_ignore_case("bcd", "abc").unwrap());
+    }
+
+    #[test]
+    fn test_convert_to_fast_match() {
+        assert_eq!(convert_to_fast_match("ab?", true), None);
+        assert_eq!(convert_to_fast_match("a*c", true), None);
+        assert_eq!(convert_to_fast_match("*a*b", true), None);
+        assert_eq!(convert_to_fast_match("*a*b*", true), None);
+        assert_eq!(convert_to_fast_match(r"a\*", true), None);
+        assert_eq!(convert_to_fast_match(r"a\\\*", true), None);
+        assert_eq!(
+            convert_to_fast_match("abc*", true).unwrap(),
+            vec![FastMatch::StartsWith("abc".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match(r"abc\\*", true).unwrap(),
+            vec![FastMatch::StartsWith(r"abc\".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match("*abc", true).unwrap(),
+            vec![FastMatch::EndsWith("abc".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match("*abc*", true).unwrap(),
+            vec![FastMatch::Contains("abc".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match("abc", true).unwrap(),
+            vec![FastMatch::Exact("abc".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match("あいう", true).unwrap(),
+            vec![FastMatch::Exact("あいう".to_string())]
+        );
+        assert_eq!(
+            convert_to_fast_match(r"\\\\127.0.0.1\\", true).unwrap(),
+            vec![FastMatch::Exact(r"\\127.0.0.1\".to_string())]
+        );
+    }
+}

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -15,9 +15,11 @@ use self::count::{AggRecordTimeInfo, TimeFrameInfo};
 use self::selectionnodes::{LeafSelectionNode, SelectionNode};
 
 mod aggregation_parser;
+mod base64_match;
 mod condition_parser;
 pub mod correlation_parser;
 pub(crate) mod count;
+mod fast_match;
 mod matchers;
 mod selectionnodes;
 


### PR DESCRIPTION
## What Changed

- Closed #1432 
- Refactoring:
  - Separated `FastMatch` and `base64offset` processing because there was too much processing in `mathers.rs`

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/11977619969

I would appreciate it if you could check it out when you have time🙏