### PR TITLE
Prepare for rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bytesize"
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -653,12 +653,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1213,9 +1213,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.165"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "libgit2-sys"
@@ -1276,9 +1276,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -1820,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "log",
  "once_cell",
@@ -1974,9 +1974,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2203,18 +2203,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "b30e6f97efe1fa43535ee241ee76967d3ff6ff3953ebb430d8d55c5393029e7b"
 dependencies = [
  "base64",
  "flate2",
+ "litemap",
  "log",
  "once_cell",
  "rustls",
  "rustls-pki-types",
  "url",
  "webpki-roots",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
@@ -2584,9 +2587,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2629,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -314,12 +314,13 @@ impl StoredStatic {
             } else {
                 &fs::read_to_string(geo_ip_file_path).unwrap()
             };
-            let geo_ip_mapping = match YamlLoader::load_from_str(contents) { Ok(loaded_yaml) => {
-                loaded_yaml
-            } _ => {
-                AlertMessage::alert("Parse error in geoip_field_mapping.yaml.").ok();
-                YamlLoader::load_from_str("").unwrap()
-            }};
+            let geo_ip_mapping = match YamlLoader::load_from_str(contents) {
+                Ok(loaded_yaml) => loaded_yaml,
+                _ => {
+                    AlertMessage::alert("Parse error in geoip_field_mapping.yaml.").ok();
+                    YamlLoader::load_from_str("").unwrap()
+                }
+            };
             let target_map = &geo_ip_mapping[0];
             let empty_yaml_vec: Vec<Yaml> = vec![];
             *GEOIP_FILTER.write().unwrap() = Some(

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -314,12 +314,12 @@ impl StoredStatic {
             } else {
                 &fs::read_to_string(geo_ip_file_path).unwrap()
             };
-            let geo_ip_mapping = if let Ok(loaded_yaml) = YamlLoader::load_from_str(contents) {
+            let geo_ip_mapping = match YamlLoader::load_from_str(contents) { Ok(loaded_yaml) => {
                 loaded_yaml
-            } else {
+            } _ => {
                 AlertMessage::alert("Parse error in geoip_field_mapping.yaml.").ok();
                 YamlLoader::load_from_str("").unwrap()
-            };
+            }};
             let target_map = &geo_ip_mapping[0];
             let empty_yaml_vec: Vec<Yaml> = vec![];
             *GEOIP_FILTER.write().unwrap() = Some(

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -549,17 +549,16 @@ impl Detection {
                         .insert("RecoveredRecord", RecoveredRecord(recovered_record.into()));
                 }
                 RenderedMessage(_) => {
-                    let convert_value = if let Some(message) =
-                        record_info.record["Event"]["RenderingInfo"]["Message"].as_str()
-                    {
+                    let convert_value = match record_info.record["Event"]["RenderingInfo"]["Message"].as_str()
+                    { Some(message) => {
                         message
                             .replace('\t', "\\t")
                             .split("\r\n")
                             .map(|x| x.trim())
                             .join("\\r\\n")
-                    } else {
+                    } _ => {
                         "n/a".into()
-                    };
+                    }};
                     profile_converter.insert(key.as_str(), RenderedMessage(convert_value.into()));
                 }
                 TgtASN(_) | TgtCountry(_) | TgtCity(_) => {

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -549,16 +549,15 @@ impl Detection {
                         .insert("RecoveredRecord", RecoveredRecord(recovered_record.into()));
                 }
                 RenderedMessage(_) => {
-                    let convert_value = match record_info.record["Event"]["RenderingInfo"]["Message"].as_str()
-                    { Some(message) => {
-                        message
-                            .replace('\t', "\\t")
-                            .split("\r\n")
-                            .map(|x| x.trim())
-                            .join("\\r\\n")
-                    } _ => {
-                        "n/a".into()
-                    }};
+                    let convert_value =
+                        match record_info.record["Event"]["RenderingInfo"]["Message"].as_str() {
+                            Some(message) => message
+                                .replace('\t', "\\t")
+                                .split("\r\n")
+                                .map(|x| x.trim())
+                                .join("\\r\\n"),
+                            _ => "n/a".into(),
+                        };
                     profile_converter.insert(key.as_str(), RenderedMessage(convert_value.into()));
                 }
                 TgtASN(_) | TgtCountry(_) | TgtCity(_) => {

--- a/src/detections/field_data_map.rs
+++ b/src/detections/field_data_map.rs
@@ -47,22 +47,22 @@ impl FieldDataMapKey {
 
 fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry) {
     let rewrite_field_data = yaml_data["RewriteFieldData"].as_hash();
-    let hex2decimal = if let Some(s) = yaml_data["HexToDecimal"].as_str() {
+    let hex2decimal = match yaml_data["HexToDecimal"].as_str() { Some(s) => {
         Some(YamlLoader::load_from_str(s).unwrap_or_default())
-    } else {
+    } _ => {
         yaml_data["HexToDecimal"].as_vec().map(|v| v.to_owned())
-    };
+    }};
     if rewrite_field_data.is_none() && hex2decimal.is_none() {
         return (FieldDataMapKey::default(), FieldDataMapEntry::default());
     }
     let mut providers = HashSet::new();
-    if let Some(providers_yaml) = yaml_data["Provider_Name"].as_vec() {
+    match yaml_data["Provider_Name"].as_vec() { Some(providers_yaml) => {
         for provider in providers_yaml {
             providers.insert(provider.as_str().unwrap_or_default().to_string());
         }
-    } else if let Some(provider_name) = yaml_data["Provider_Name"].as_str() {
+    } _ => { match yaml_data["Provider_Name"].as_str() { Some(provider_name) => {
         providers.insert(provider_name.to_string());
-    }
+    } _ => {}}}}
     let mut mapping = HashMap::new();
     if let Some(x) = rewrite_field_data {
         for (key_yaml, val_yaml) in x.iter() {
@@ -96,9 +96,9 @@ fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry)
 
     if let Some(fields) = hex2decimal {
         for field in fields {
-            if let Some(key) = field.as_str() {
+            match field.as_str() { Some(key) => {
                 mapping.insert(key.to_lowercase(), HexToDecimal);
-            }
+            } _ => {}}
         }
     }
     (FieldDataMapKey::new(yaml_data), mapping)

--- a/src/detections/field_data_map.rs
+++ b/src/detections/field_data_map.rs
@@ -47,22 +47,27 @@ impl FieldDataMapKey {
 
 fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry) {
     let rewrite_field_data = yaml_data["RewriteFieldData"].as_hash();
-    let hex2decimal = match yaml_data["HexToDecimal"].as_str() { Some(s) => {
-        Some(YamlLoader::load_from_str(s).unwrap_or_default())
-    } _ => {
-        yaml_data["HexToDecimal"].as_vec().map(|v| v.to_owned())
-    }};
+    let hex2decimal = match yaml_data["HexToDecimal"].as_str() {
+        Some(s) => Some(YamlLoader::load_from_str(s).unwrap_or_default()),
+        _ => yaml_data["HexToDecimal"].as_vec().map(|v| v.to_owned()),
+    };
     if rewrite_field_data.is_none() && hex2decimal.is_none() {
         return (FieldDataMapKey::default(), FieldDataMapEntry::default());
     }
     let mut providers = HashSet::new();
-    match yaml_data["Provider_Name"].as_vec() { Some(providers_yaml) => {
-        for provider in providers_yaml {
-            providers.insert(provider.as_str().unwrap_or_default().to_string());
+    match yaml_data["Provider_Name"].as_vec() {
+        Some(providers_yaml) => {
+            for provider in providers_yaml {
+                providers.insert(provider.as_str().unwrap_or_default().to_string());
+            }
         }
-    } _ => { match yaml_data["Provider_Name"].as_str() { Some(provider_name) => {
-        providers.insert(provider_name.to_string());
-    } _ => {}}}}
+        _ => match yaml_data["Provider_Name"].as_str() {
+            Some(provider_name) => {
+                providers.insert(provider_name.to_string());
+            }
+            _ => {}
+        },
+    }
     let mut mapping = HashMap::new();
     if let Some(x) = rewrite_field_data {
         for (key_yaml, val_yaml) in x.iter() {
@@ -96,9 +101,12 @@ fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry)
 
     if let Some(fields) = hex2decimal {
         for field in fields {
-            match field.as_str() { Some(key) => {
-                mapping.insert(key.to_lowercase(), HexToDecimal);
-            } _ => {}}
+            match field.as_str() {
+                Some(key) => {
+                    mapping.insert(key.to_lowercase(), HexToDecimal);
+                }
+                _ => {}
+            }
         }
     }
     (FieldDataMapKey::new(yaml_data), mapping)

--- a/src/detections/field_extract.rs
+++ b/src/detections/field_extract.rs
@@ -33,14 +33,14 @@ fn extract_powershell_classic_fields(
                     break;
                 }
             }
-            if let Some(Value::Object(fields)) = extracted_fields {
+            match extracted_fields { Some(Value::Object(fields)) => {
                 for (key, val) in fields {
                     map.insert(key.clone(), val.clone());
-                    if let Value::String(s) = val {
+                    match val { Value::String(s) => {
                         key_2_values.insert(key, s.to_string());
-                    }
+                    } _ => {}}
                 }
-            }
+            } _ => {}}
         }
         Value::Array(vec) => {
             if let Some(val) = vec.get(data_index) {
@@ -51,9 +51,9 @@ fn extract_powershell_classic_fields(
                         .map(|s| s.trim_end_matches("\r\n").trim_end_matches('\r'))
                         .filter_map(|s| s.split_once('='))
                         .collect();
-                    if let Ok(extracted_fields) = serde_json::to_value(fields_data) {
+                    match serde_json::to_value(fields_data) { Ok(extracted_fields) => {
                         return Some(extracted_fields);
-                    }
+                    } _ => {}}
                 }
             }
         }

--- a/src/detections/field_extract.rs
+++ b/src/detections/field_extract.rs
@@ -33,14 +33,20 @@ fn extract_powershell_classic_fields(
                     break;
                 }
             }
-            match extracted_fields { Some(Value::Object(fields)) => {
-                for (key, val) in fields {
-                    map.insert(key.clone(), val.clone());
-                    match val { Value::String(s) => {
-                        key_2_values.insert(key, s.to_string());
-                    } _ => {}}
+            match extracted_fields {
+                Some(Value::Object(fields)) => {
+                    for (key, val) in fields {
+                        map.insert(key.clone(), val.clone());
+                        match val {
+                            Value::String(s) => {
+                                key_2_values.insert(key, s.to_string());
+                            }
+                            _ => {}
+                        }
+                    }
                 }
-            } _ => {}}
+                _ => {}
+            }
         }
         Value::Array(vec) => {
             if let Some(val) = vec.get(data_index) {
@@ -51,9 +57,12 @@ fn extract_powershell_classic_fields(
                         .map(|s| s.trim_end_matches("\r\n").trim_end_matches('\r'))
                         .filter_map(|s| s.split_once('='))
                         .collect();
-                    match serde_json::to_value(fields_data) { Ok(extracted_fields) => {
-                        return Some(extracted_fields);
-                    } _ => {}}
+                    match serde_json::to_value(fields_data) {
+                        Ok(extracted_fields) => {
+                            return Some(extracted_fields);
+                        }
+                        _ => {}
+                    }
                 }
             }
         }

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -197,11 +197,14 @@ pub fn create_message(
                         );
                     }
                 } else {
-                    let recinfos = match record_details_info_map.get("#AllFieldInfo") { Some(c) => {
-                        c.to_owned()
-                    } _ => {
-                        utils::create_recordinfos(event_record, field_data_map_key, field_data_map)
-                    }};
+                    let recinfos = match record_details_info_map.get("#AllFieldInfo") {
+                        Some(c) => c.to_owned(),
+                        _ => utils::create_recordinfos(
+                            event_record,
+                            field_data_map_key,
+                            field_data_map,
+                        ),
+                    };
                     if is_json_timeline {
                         record_details_info_map.insert("#AllFieldInfo".into(), recinfos);
                         replaced_profiles.push((key.to_owned(), AllFieldInfo("".into())));
@@ -347,28 +350,32 @@ pub fn parse_message(
         }
         let hash_value = get_serde_number_to_string(tmp_event_record, false);
         if hash_value.is_some() {
-            match hash_value { Some(hash_value) => {
-                let field_data = if field_data_map.is_none() || field.is_empty() {
-                    hash_value
-                } else {
-                    let converted_str = convert_field_data(
-                        field_data_map.as_ref().unwrap(),
-                        field_data_map_key,
-                        field.to_lowercase().as_str(),
-                        hash_value.as_str(),
-                        event_record,
-                    );
-                    converted_str.unwrap_or(hash_value)
-                };
-                if json_timeline_flag {
-                    hash_map.push((CompactString::from(full_target_str), [field_data].to_vec()));
-                } else {
-                    hash_map.push((
-                        CompactString::from(full_target_str),
-                        [field_data.split_ascii_whitespace().join(" ").into()].to_vec(),
-                    ));
+            match hash_value {
+                Some(hash_value) => {
+                    let field_data = if field_data_map.is_none() || field.is_empty() {
+                        hash_value
+                    } else {
+                        let converted_str = convert_field_data(
+                            field_data_map.as_ref().unwrap(),
+                            field_data_map_key,
+                            field.to_lowercase().as_str(),
+                            hash_value.as_str(),
+                            event_record,
+                        );
+                        converted_str.unwrap_or(hash_value)
+                    };
+                    if json_timeline_flag {
+                        hash_map
+                            .push((CompactString::from(full_target_str), [field_data].to_vec()));
+                    } else {
+                        hash_map.push((
+                            CompactString::from(full_target_str),
+                            [field_data.split_ascii_whitespace().join(" ").into()].to_vec(),
+                        ));
+                    }
                 }
-            } _ => {}}
+                _ => {}
+            }
         } else {
             hash_map.push((
                 CompactString::from(full_target_str),

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -197,11 +197,11 @@ pub fn create_message(
                         );
                     }
                 } else {
-                    let recinfos = if let Some(c) = record_details_info_map.get("#AllFieldInfo") {
+                    let recinfos = match record_details_info_map.get("#AllFieldInfo") { Some(c) => {
                         c.to_owned()
-                    } else {
+                    } _ => {
                         utils::create_recordinfos(event_record, field_data_map_key, field_data_map)
-                    };
+                    }};
                     if is_json_timeline {
                         record_details_info_map.insert("#AllFieldInfo".into(), recinfos);
                         replaced_profiles.push((key.to_owned(), AllFieldInfo("".into())));
@@ -347,7 +347,7 @@ pub fn parse_message(
         }
         let hash_value = get_serde_number_to_string(tmp_event_record, false);
         if hash_value.is_some() {
-            if let Some(hash_value) = hash_value {
+            match hash_value { Some(hash_value) => {
                 let field_data = if field_data_map.is_none() || field.is_empty() {
                     hash_value
                 } else {
@@ -368,7 +368,7 @@ pub fn parse_message(
                         [field_data.split_ascii_whitespace().join(" ").into()].to_vec(),
                     ));
                 }
-            }
+            } _ => {}}
         } else {
             hash_map.push((
                 CompactString::from(full_target_str),

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -136,11 +136,10 @@ impl ConditionCompiler {
         };
 
         let result = self.compile_condition_body(&replaced_condition, name_2_node);
-        match result { Result::Err(msg) => {
-            Result::Err(format!("A condition parse error has occurred. {msg}"))
-        } _ => {
-            result
-        }}
+        match result {
+            Result::Err(msg) => Result::Err(format!("A condition parse error has occurred. {msg}")),
+            _ => result,
+        }
     }
 
     // all of selection* と 1 of selection* を通常のand/orに変換する

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -136,11 +136,11 @@ impl ConditionCompiler {
         };
 
         let result = self.compile_condition_body(&replaced_condition, name_2_node);
-        if let Result::Err(msg) = result {
+        match result { Result::Err(msg) => {
             Result::Err(format!("A condition parse error has occurred. {msg}"))
-        } else {
+        } _ => {
             result
-        }
+        }}
     }
 
     // all of selection* と 1 of selection* を通常のand/orに変換する

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -28,11 +28,14 @@ fn is_referenced_rule(rule_node: &RuleNode, id_or_title: &str) -> bool {
                 return true;
             }
         }
-        match hash.get(&Yaml::String("name".to_string())) { Some(title) => {
-            if title.as_str() == Some(id_or_title) {
-                return true;
+        match hash.get(&Yaml::String("name".to_string())) {
+            Some(title) => {
+                if title.as_str() == Some(id_or_title) {
+                    return true;
+                }
             }
-        } _ => {}}
+            _ => {}
+        }
     }
     false
 }
@@ -78,13 +81,16 @@ fn parse_condition(
 ) -> Result<(AggregationConditionToken, i64, Option<String>), Box<dyn Error>> {
     if let Some(hash) = yaml.as_hash() {
         let rule_type = hash.get(&Yaml::String("type".to_string()));
-        match hash.get(&Yaml::String("condition".to_string())) { Some(condition) => {
-            if let Some(condition_hash) = condition.as_hash() {
-                let pair: Vec<(&Yaml, &Yaml)> = condition_hash.iter().collect();
-                let field = find_condition_field_value(rule_type, pair.clone());
-                return process_condition_pairs(pair, field);
+        match hash.get(&Yaml::String("condition".to_string())) {
+            Some(condition) => {
+                if let Some(condition_hash) = condition.as_hash() {
+                    let pair: Vec<(&Yaml, &Yaml)> = condition_hash.iter().collect();
+                    let field = find_condition_field_value(rule_type, pair.clone());
+                    return process_condition_pairs(pair, field);
+                }
             }
-        } _ => {}}
+            _ => {}
+        }
     }
     Err("Failed to parse condition".into())
 }

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -28,11 +28,11 @@ fn is_referenced_rule(rule_node: &RuleNode, id_or_title: &str) -> bool {
                 return true;
             }
         }
-        if let Some(title) = hash.get(&Yaml::String("name".to_string())) {
+        match hash.get(&Yaml::String("name".to_string())) { Some(title) => {
             if title.as_str() == Some(id_or_title) {
                 return true;
             }
-        }
+        } _ => {}}
     }
     false
 }
@@ -78,13 +78,13 @@ fn parse_condition(
 ) -> Result<(AggregationConditionToken, i64, Option<String>), Box<dyn Error>> {
     if let Some(hash) = yaml.as_hash() {
         let rule_type = hash.get(&Yaml::String("type".to_string()));
-        if let Some(condition) = hash.get(&Yaml::String("condition".to_string())) {
+        match hash.get(&Yaml::String("condition".to_string())) { Some(condition) => {
             if let Some(condition_hash) = condition.as_hash() {
                 let pair: Vec<(&Yaml, &Yaml)> = condition_hash.iter().collect();
                 let field = find_condition_field_value(rule_type, pair.clone());
                 return process_condition_pairs(pair, field);
             }
-        }
+        } _ => {}}
     }
     Err("Failed to parse condition".into())
 }

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -454,15 +454,18 @@ impl LeafMatcher for DefaultMatcher {
             for p in pattern {
                 let pattern = DefaultMatcher::from_pattern_to_regex_str(p, &self.pipes);
                 // Pipeで処理されたパターンを正規表現に変換
-                match Regex::new(&pattern) { Ok(re_result) => {
-                    re_result_vec.push(re_result);
-                } _ => {
-                    let errmsg = format!(
-                        "Cannot parse regex. [regex:{pattern}, key:{}]",
-                        utils::concat_selection_key(key_list)
-                    );
-                    return Err(vec![errmsg]);
-                }}
+                match Regex::new(&pattern) {
+                    Ok(re_result) => {
+                        re_result_vec.push(re_result);
+                    }
+                    _ => {
+                        let errmsg = format!(
+                            "Cannot parse regex. [regex:{pattern}, key:{}]",
+                            utils::concat_selection_key(key_list)
+                        );
+                        return Err(vec![errmsg]);
+                    }
+                }
             }
             self.re = Some(re_result_vec);
         }

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -454,15 +454,15 @@ impl LeafMatcher for DefaultMatcher {
             for p in pattern {
                 let pattern = DefaultMatcher::from_pattern_to_regex_str(p, &self.pipes);
                 // Pipeで処理されたパターンを正規表現に変換
-                if let Ok(re_result) = Regex::new(&pattern) {
+                match Regex::new(&pattern) { Ok(re_result) => {
                     re_result_vec.push(re_result);
-                } else {
+                } _ => {
                     let errmsg = format!(
                         "Cannot parse regex. [regex:{pattern}, key:{}]",
                         utils::concat_selection_key(key_list)
                     );
                     return Err(vec![errmsg]);
-                }
+                }}
             }
             self.re = Some(re_result_vec);
         }

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -228,11 +228,11 @@ impl DetectionNode {
         let mut err_msgs = vec![];
         let compiler = condition_parser::ConditionCompiler::new();
         let compile_result = compiler.compile_condition(condition_str, &self.name_to_selection);
-        if let Result::Err(err_msg) = compile_result {
+        match compile_result { Result::Err(err_msg) => {
             err_msgs.extend(vec![err_msg]);
-        } else {
+        } _ => {
             self.condition = Option::Some(compile_result.unwrap());
-        }
+        }}
 
         // aggregation condition(conditionのパイプ以降の部分)をパース
         let agg_compiler = aggregation_parser::AggegationConditionCompiler::new();
@@ -286,7 +286,7 @@ impl DetectionNode {
 
             // パースして、エラーメッセージがあれば配列にためて、戻り値で返す。
             let selection_node = self.parse_selection(&detection_hash[key]);
-            if let Some(node) = selection_node {
+            match selection_node { Some(node) => {
                 let mut selection_node = node;
                 let init_result = selection_node.init();
                 if let Err(err_detail) = init_result {
@@ -296,7 +296,7 @@ impl DetectionNode {
                     self.name_to_selection
                         .insert(name.to_string(), rc_selection);
                 }
-            }
+            } _ => {}}
         }
         if !err_msgs.is_empty() {
             return Result::Err(err_msgs);

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -228,11 +228,14 @@ impl DetectionNode {
         let mut err_msgs = vec![];
         let compiler = condition_parser::ConditionCompiler::new();
         let compile_result = compiler.compile_condition(condition_str, &self.name_to_selection);
-        match compile_result { Result::Err(err_msg) => {
-            err_msgs.extend(vec![err_msg]);
-        } _ => {
-            self.condition = Option::Some(compile_result.unwrap());
-        }}
+        match compile_result {
+            Result::Err(err_msg) => {
+                err_msgs.extend(vec![err_msg]);
+            }
+            _ => {
+                self.condition = Option::Some(compile_result.unwrap());
+            }
+        }
 
         // aggregation condition(conditionのパイプ以降の部分)をパース
         let agg_compiler = aggregation_parser::AggegationConditionCompiler::new();
@@ -286,17 +289,20 @@ impl DetectionNode {
 
             // パースして、エラーメッセージがあれば配列にためて、戻り値で返す。
             let selection_node = self.parse_selection(&detection_hash[key]);
-            match selection_node { Some(node) => {
-                let mut selection_node = node;
-                let init_result = selection_node.init();
-                if let Err(err_detail) = init_result {
-                    err_msgs.extend(err_detail);
-                } else {
-                    let rc_selection = Arc::new(selection_node);
-                    self.name_to_selection
-                        .insert(name.to_string(), rc_selection);
+            match selection_node {
+                Some(node) => {
+                    let mut selection_node = node;
+                    let init_result = selection_node.init();
+                    if let Err(err_detail) = init_result {
+                        err_msgs.extend(err_detail);
+                    } else {
+                        let rc_selection = Arc::new(selection_node);
+                        self.name_to_selection
+                            .insert(name.to_string(), rc_selection);
+                    }
                 }
-            } _ => {}}
+                _ => {}
+            }
         }
         if !err_msgs.is_empty() {
             return Result::Err(err_msgs);

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -452,10 +452,10 @@ impl SelectionNode for LeafSelectionNode {
             && !self.key_list.is_empty()
             && !self.key_list[0].contains("|")
         {
-            if let Some(event_id) = self.select_value.as_i64() {
+            match self.select_value.as_i64() { Some(event_id) => {
                 // 正規表現は重いので、数値のEventIDのみ文字列完全一致で判定
                 return event_value.unwrap_or(&String::default()) == &event_id.to_string();
-            }
+            } _ => {}}
         }
         if !self.key_list.is_empty() && self.key_list[0].eq("|all") {
             event_value = Some(&event_record.data_string);

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -452,10 +452,13 @@ impl SelectionNode for LeafSelectionNode {
             && !self.key_list.is_empty()
             && !self.key_list[0].contains("|")
         {
-            match self.select_value.as_i64() { Some(event_id) => {
-                // 正規表現は重いので、数値のEventIDのみ文字列完全一致で判定
-                return event_value.unwrap_or(&String::default()) == &event_id.to_string();
-            } _ => {}}
+            match self.select_value.as_i64() {
+                Some(event_id) => {
+                    // 正規表現は重いので、数値のEventIDのみ文字列完全一致で判定
+                    return event_value.unwrap_or(&String::default()) == &event_id.to_string();
+                }
+                _ => {}
+            }
         }
         if !self.key_list.is_empty() && self.key_list[0].eq("|all") {
             event_value = Some(&event_record.data_string);

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -443,11 +443,19 @@ pub fn create_recordinfos(
         .iter()
         .map(|(key, value)| {
             if let Some(map) = field_data_map.as_ref() {
-                match convert_field_data(map, field_data_map_key, &key.to_lowercase(), value, record)
-                { Some(converted_str) => {
-                    let val = remove_sp_char(converted_str);
-                    return format!("{key}: {val}",).into();
-                } _ => {}}
+                match convert_field_data(
+                    map,
+                    field_data_map_key,
+                    &key.to_lowercase(),
+                    value,
+                    record,
+                ) {
+                    Some(converted_str) => {
+                        let val = remove_sp_char(converted_str);
+                        return format!("{key}: {val}",).into();
+                    }
+                    _ => {}
+                }
             }
             let val = remove_sp_char(value.into());
             format!("{key}: {val}").into()
@@ -536,9 +544,12 @@ fn _collect_recordinfo<'a>(
                             strval.as_str(),
                             org_value,
                         );
-                        match converted_str { Some(converted_str) => {
-                            strval = converted_str.to_string();
-                        } _ => {}}
+                        match converted_str {
+                            Some(converted_str) => {
+                                strval = converted_str.to_string();
+                            }
+                            _ => {}
+                        }
                     }
                     format!("{parent_key}[{i}]")
                 } else {

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -443,12 +443,11 @@ pub fn create_recordinfos(
         .iter()
         .map(|(key, value)| {
             if let Some(map) = field_data_map.as_ref() {
-                if let Some(converted_str) =
-                    convert_field_data(map, field_data_map_key, &key.to_lowercase(), value, record)
-                {
+                match convert_field_data(map, field_data_map_key, &key.to_lowercase(), value, record)
+                { Some(converted_str) => {
                     let val = remove_sp_char(converted_str);
                     return format!("{key}: {val}",).into();
-                }
+                } _ => {}}
             }
             let val = remove_sp_char(value.into());
             format!("{key}: {val}").into()
@@ -537,9 +536,9 @@ fn _collect_recordinfo<'a>(
                             strval.as_str(),
                             org_value,
                         );
-                        if let Some(converted_str) = converted_str {
+                        match converted_str { Some(converted_str) => {
                             strval = converted_str.to_string();
-                        }
+                        } _ => {}}
                     }
                     format!("{parent_key}[{i}]")
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1300,7 +1300,7 @@ impl App {
                             continue;
                         }
                         let mut ret_cnt = 0;
-                        if let Some(target_status_count) = rule_counter_wizard_map.get(s) {
+                        match rule_counter_wizard_map.get(s) { Some(target_status_count) => {
                             target_status_count.iter().for_each(|(rule_level, value)| {
                                 let doc_level_num = level_map
                                     .get(rule_level.to_uppercase().as_str())
@@ -1324,7 +1324,7 @@ impl App {
                             if ret_cnt > 0 {
                                 ret.insert(s.clone(), ret_cnt);
                             }
-                        }
+                        } _ => {}}
                     }
                 }
                 ret
@@ -1456,7 +1456,7 @@ impl App {
                         exclude_tags.push("detection.emerging_threats".into());
                     }
                 }
-                if let Some(th_cnt) = tags_cnt.get("detection.threat_hunting") {
+                match tags_cnt.get("detection.threat_hunting") { Some(th_cnt) => {
                     let prompt_fmt = format!(
                         "Include Threat Hunting rules? ({} rules)",
                         th_cnt.to_formatted_string(&Locale::en)
@@ -1471,7 +1471,7 @@ impl App {
                     if !th_rules_load_flag {
                         exclude_tags.push("detection.threat_hunting".into());
                     }
-                }
+                } _ => {}}
             } else {
                 // If "4. All alert rules" or "5. All event and alert rules" was selected, ask questions about deprecated and unsupported rules.
                 if let Some(dep_cnt) = exclude_noisy_cnt.get("deprecated") {
@@ -1494,7 +1494,7 @@ impl App {
                             .enable_deprecated_rules = true;
                     }
                 }
-                if let Some(unsup_cnt) = exclude_noisy_cnt.get("unsupported") {
+                match exclude_noisy_cnt.get("unsupported") { Some(unsup_cnt) => {
                     // unsupported rules load prompt
                     let prompt_fmt = format!(
                         "Include unsupported rules? ({} rules)",
@@ -1513,7 +1513,7 @@ impl App {
                             .unwrap()
                             .enable_unsupported_rules = true;
                     }
-                }
+                } _ => {}}
             }
 
             CHECKPOINT

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -46,14 +46,14 @@ impl HtmlReporter {
 
         let mut md_data = Nested::<String>::new();
         for section_name in self.section_order.iter() {
-            if let Some(v) = self.md_datas.get(section_name) {
+            match self.md_datas.get(section_name) { Some(v) => {
                 md_data.push(format!("## {}\n", &section_name));
                 if v.is_empty() {
                     md_data.push("not found data.\n");
                 } else {
                     md_data.push(v.iter().collect::<Vec<&str>>().join("\n"));
                 }
-            }
+            } _ => {}}
         }
         let md_str = md_data.iter().collect::<Vec<&str>>().join("\n");
         let parser = Parser::new_ext(&md_str, options);

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -46,14 +46,17 @@ impl HtmlReporter {
 
         let mut md_data = Nested::<String>::new();
         for section_name in self.section_order.iter() {
-            match self.md_datas.get(section_name) { Some(v) => {
-                md_data.push(format!("## {}\n", &section_name));
-                if v.is_empty() {
-                    md_data.push("not found data.\n");
-                } else {
-                    md_data.push(v.iter().collect::<Vec<&str>>().join("\n"));
+            match self.md_datas.get(section_name) {
+                Some(v) => {
+                    md_data.push(format!("## {}\n", &section_name));
+                    if v.is_empty() {
+                        md_data.push("not found data.\n");
+                    } else {
+                        md_data.push(v.iter().collect::<Vec<&str>>().join("\n"));
+                    }
                 }
-            } _ => {}}
+                _ => {}
+            }
         }
         let md_str = md_data.iter().collect::<Vec<&str>>().join("\n");
         let parser = Parser::new_ext(&md_str, options);

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -68,7 +68,7 @@ impl LevelTuning {
 
         // Convert rule files
         for (path, rule) in rulefile_loader.files {
-            if let Some(new_level) = tuning_map.get(rule["id"].as_str().unwrap()) {
+            match tuning_map.get(rule["id"].as_str().unwrap()) { Some(new_level) => {
                 write_color_buffer(
                     &BufferWriter::stdout(ColorChoice::Always),
                     None,
@@ -116,7 +116,7 @@ impl LevelTuning {
                     true,
                 )
                 .ok();
-            }
+            } _ => {}}
         }
         println!();
         Result::Ok(())

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -68,55 +68,58 @@ impl LevelTuning {
 
         // Convert rule files
         for (path, rule) in rulefile_loader.files {
-            match tuning_map.get(rule["id"].as_str().unwrap()) { Some(new_level) => {
-                write_color_buffer(
-                    &BufferWriter::stdout(ColorChoice::Always),
-                    None,
-                    &format!("path: {path}"),
-                    true,
-                )
-                .ok();
-                let mut content = match fs::read_to_string(&path) {
-                    Ok(_content) => _content,
-                    Err(e) => return Result::Err(e.to_string()),
-                };
-                let past_level = "level: ".to_string() + rule["level"].as_str().unwrap();
+            match tuning_map.get(rule["id"].as_str().unwrap()) {
+                Some(new_level) => {
+                    write_color_buffer(
+                        &BufferWriter::stdout(ColorChoice::Always),
+                        None,
+                        &format!("path: {path}"),
+                        true,
+                    )
+                    .ok();
+                    let mut content = match fs::read_to_string(&path) {
+                        Ok(_content) => _content,
+                        Err(e) => return Result::Err(e.to_string()),
+                    };
+                    let past_level = "level: ".to_string() + rule["level"].as_str().unwrap();
 
-                if new_level.starts_with("informational") || new_level.starts_with("info") {
-                    content = content.replace(&past_level, "level: informational");
-                }
-                if new_level.starts_with("low") {
-                    content = content.replace(&past_level, "level: low");
-                }
-                if new_level.starts_with("medium") {
-                    content = content.replace(&past_level, "level: medium");
-                }
-                if new_level.starts_with("high") {
-                    content = content.replace(&past_level, "level: high");
-                }
-                if new_level.starts_with("critical") {
-                    content = content.replace(&past_level, "level: critical");
-                }
+                    if new_level.starts_with("informational") || new_level.starts_with("info") {
+                        content = content.replace(&past_level, "level: informational");
+                    }
+                    if new_level.starts_with("low") {
+                        content = content.replace(&past_level, "level: low");
+                    }
+                    if new_level.starts_with("medium") {
+                        content = content.replace(&past_level, "level: medium");
+                    }
+                    if new_level.starts_with("high") {
+                        content = content.replace(&past_level, "level: high");
+                    }
+                    if new_level.starts_with("critical") {
+                        content = content.replace(&past_level, "level: critical");
+                    }
 
-                let mut file = match File::options().write(true).truncate(true).open(&path) {
-                    Ok(file) => file,
-                    Err(e) => return Result::Err(e.to_string()),
-                };
+                    let mut file = match File::options().write(true).truncate(true).open(&path) {
+                        Ok(file) => file,
+                        Err(e) => return Result::Err(e.to_string()),
+                    };
 
-                file.write_all(content.as_bytes()).unwrap();
-                file.flush().unwrap();
-                write_color_buffer(
-                    &BufferWriter::stdout(ColorChoice::Always),
-                    None,
-                    &format!(
-                        "level: {} -> {}",
-                        rule["level"].as_str().unwrap(),
-                        new_level
-                    ),
-                    true,
-                )
-                .ok();
-            } _ => {}}
+                    file.write_all(content.as_bytes()).unwrap();
+                    file.flush().unwrap();
+                    write_color_buffer(
+                        &BufferWriter::stdout(ColorChoice::Always),
+                        None,
+                        &format!(
+                            "level: {} -> {}",
+                            rule["level"].as_str().unwrap(),
+                            new_level
+                        ),
+                        true,
+                    )
+                    .ok();
+                }
+                _ => {}
+            }
         }
         println!();
         Result::Ok(())

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -42,7 +42,7 @@ impl PivotKeyword {
 pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAliasConfig) {
     if let Some(record_level) = get_event_value("Event.System.Level", event_record, eventkey_alias)
     {
-        if let Some(event_record_str) = get_serde_number_to_string(record_level, false) {
+        match get_serde_number_to_string(record_level, false) { Some(event_record_str) => {
             let exclude_check_str = event_record_str.as_str();
             //levelがlow以上なら続ける
             if exclude_check_str == "infomational"
@@ -51,7 +51,7 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
             {
                 return;
             }
-        }
+        } _ => {}}
     } else {
         return;
     }

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -42,16 +42,19 @@ impl PivotKeyword {
 pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAliasConfig) {
     if let Some(record_level) = get_event_value("Event.System.Level", event_record, eventkey_alias)
     {
-        match get_serde_number_to_string(record_level, false) { Some(event_record_str) => {
-            let exclude_check_str = event_record_str.as_str();
-            //levelがlow以上なら続ける
-            if exclude_check_str == "infomational"
-                || exclude_check_str == "undefined"
-                || exclude_check_str == "-"
-            {
-                return;
+        match get_serde_number_to_string(record_level, false) {
+            Some(event_record_str) => {
+                let exclude_check_str = event_record_str.as_str();
+                //levelがlow以上なら続ける
+                if exclude_check_str == "infomational"
+                    || exclude_check_str == "undefined"
+                    || exclude_check_str == "-"
+                {
+                    return;
+                }
             }
-        } _ => {}}
+            _ => {}
+        }
     } else {
         return;
     }

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -304,12 +304,12 @@ pub fn set_default_profile(
             .profile
             .as_ref()
             .unwrap();
-        if let Ok(mut buf_wtr) = OpenOptions::new()
+        match OpenOptions::new()
             .write(true)
             .truncate(true)
             .open(default_profile_path)
             .map(BufWriter::new)
-        {
+        { Ok(mut buf_wtr) => {
             let prof_all_data = &profile_data[0];
             let overwrite_default_data = &prof_all_data[profile_name.as_str()];
             if !overwrite_default_data.is_badvalue() {
@@ -351,11 +351,11 @@ pub fn set_default_profile(
                     .map(|k| k.as_str().unwrap()).join(", ")
                 ))
             }
-        } else {
+        } _ => {
             Err(format!(
                 "Failed to set the default profile file({profile_path})."
             ))
-        }
+        }}
     } else {
         Err("Failed to set the default profile file. Please specify a profile.".to_string())
     }

--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -74,10 +74,13 @@ impl Update {
                 for mut submodule in submodules {
                     submodule.update(true, None)?;
                     let submodule_repo = submodule.open()?;
-                    match Update::pull_repository(&submodule_repo) { Err(e) => {
-                        AlertMessage::alert(&format!("Failed submodule update. {e}")).ok();
-                        is_success_submodule_update = false;
-                    } _ => {}}
+                    match Update::pull_repository(&submodule_repo) {
+                        Err(e) => {
+                            AlertMessage::alert(&format!("Failed submodule update. {e}")).ok();
+                            is_success_submodule_update = false;
+                        }
+                        _ => {}
+                    }
                 }
                 if is_success_submodule_update {
                     result = Ok("Successed submodule update".to_string());
@@ -219,17 +222,18 @@ impl Update {
         updated_sets: HashMap<String, String>,
         no_color: bool,
     ) -> Result<String, git2::Error> {
-        let diff = updated_sets.iter().filter_map(|(k, v)| {
-            match prev_sets.get(k) { Some(prev_val) => {
-                if prev_val != v {
-                    Some(v)
-                } else {
-                    None
+        let diff = updated_sets
+            .iter()
+            .filter_map(|(k, v)| match prev_sets.get(k) {
+                Some(prev_val) => {
+                    if prev_val != v {
+                        Some(v)
+                    } else {
+                        None
+                    }
                 }
-            } _ => {
-                Some(v)
-            }}
-        });
+                _ => Some(v),
+            });
         let mut update_count_by_rule_type: HashMap<String, u128> = HashMap::new();
         for diff_key in diff {
             let tmp: Vec<&str> = diff_key.split('|').collect();

--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -74,10 +74,10 @@ impl Update {
                 for mut submodule in submodules {
                     submodule.update(true, None)?;
                     let submodule_repo = submodule.open()?;
-                    if let Err(e) = Update::pull_repository(&submodule_repo) {
+                    match Update::pull_repository(&submodule_repo) { Err(e) => {
                         AlertMessage::alert(&format!("Failed submodule update. {e}")).ok();
                         is_success_submodule_update = false;
-                    }
+                    } _ => {}}
                 }
                 if is_success_submodule_update {
                     result = Ok("Successed submodule update".to_string());
@@ -220,15 +220,15 @@ impl Update {
         no_color: bool,
     ) -> Result<String, git2::Error> {
         let diff = updated_sets.iter().filter_map(|(k, v)| {
-            if let Some(prev_val) = prev_sets.get(k) {
+            match prev_sets.get(k) { Some(prev_val) => {
                 if prev_val != v {
                     Some(v)
                 } else {
                     None
                 }
-            } else {
+            } _ => {
                 Some(v)
-            }
+            }}
         });
         let mut update_count_by_rule_type: HashMap<String, u128> = HashMap::new();
         for diff_key in diff {

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -409,12 +409,11 @@ pub fn search_result_dsp_msg(
             .into_iter()
             .sorted_unstable_by(|a, b| Ord::cmp(&a.0, &b.0))
     {
-        let event_title = match event_timeline_config.get_event_id(&channel.to_ascii_lowercase(), &event_id)
-        { Some(event_info) => {
-            CompactString::from(event_info.evttitle.as_str())
-        } _ => {
-            "-".into()
-        }};
+        let event_title =
+            match event_timeline_config.get_event_id(&channel.to_ascii_lowercase(), &event_id) {
+                Some(event_info) => CompactString::from(event_info.evttitle.as_str()),
+                _ => "-".into(),
+            };
         let abbr_channel = stored_static.disp_abbr_generic.replace_all(
             stored_static
                 .ch_config

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -409,13 +409,12 @@ pub fn search_result_dsp_msg(
             .into_iter()
             .sorted_unstable_by(|a, b| Ord::cmp(&a.0, &b.0))
     {
-        let event_title = if let Some(event_info) =
-            event_timeline_config.get_event_id(&channel.to_ascii_lowercase(), &event_id)
-        {
+        let event_title = match event_timeline_config.get_event_id(&channel.to_ascii_lowercase(), &event_id)
+        { Some(event_info) => {
             CompactString::from(event_info.evttitle.as_str())
-        } else {
+        } _ => {
             "-".into()
-        };
+        }};
         let abbr_channel = stored_static.disp_abbr_generic.replace_all(
             stored_static
                 .ch_config

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -218,9 +218,9 @@ impl Timeline {
         }
         if wtr.is_some() {
             for msg in stats_msges.iter() {
-                if let Some(ref mut w) = wtr {
+                match wtr { Some(ref mut w) => {
                     w.write_record(msg.iter().map(|x| x.as_str())).ok();
-                }
+                } _ => {}}
             }
         }
         stats_tb.add_rows(stats_msges.iter());

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -218,9 +218,12 @@ impl Timeline {
         }
         if wtr.is_some() {
             for msg in stats_msges.iter() {
-                match wtr { Some(ref mut w) => {
-                    w.write_record(msg.iter().map(|x| x.as_str())).ok();
-                } _ => {}}
+                match wtr {
+                    Some(ref mut w) => {
+                        w.write_record(msg.iter().map(|x| x.as_str())).ok();
+                    }
+                    _ => {}
+                }
             }
         }
         stats_tb.add_rows(stats_msges.iter());

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -84,13 +84,13 @@ impl ParseYaml {
 
     fn update_correlation_counts(&mut self, yaml_docs: &Vec<Yaml>) {
         for doc in yaml_docs {
-            if let Some(correlation) = doc["correlation"].as_hash() {
+            match doc["correlation"].as_hash() { Some(correlation) => {
                 let entry = self
                     .rule_cor_cnt
                     .entry(CompactString::from("correlation"))
                     .or_insert(0);
                 *entry += 1;
-                if let Some(rules) = correlation.get(&Yaml::String("rules".to_string())) {
+                match correlation.get(&Yaml::String("rules".to_string())) { Some(rules) => {
                     if let Some(rules_list) = rules.as_vec() {
                         for rule in rules_list {
                             if let Some(rule_str) = rule.as_str() {
@@ -103,8 +103,8 @@ impl ParseYaml {
                             }
                         }
                     }
-                }
-            }
+                } _ => {}}
+            } _ => {}}
         }
     }
 
@@ -684,10 +684,10 @@ pub fn count_rules<P: AsRef<Path>>(
                 .collect_vec()
         };
         if rule_id.is_some() {
-            if let Some(v) = exclude_ids
+            match exclude_ids
                 .no_use_rule
                 .get(&rule_id.unwrap_or(&String::default()).to_string())
-            {
+            { Some(v) => {
                 let entry_key = if utils::contains_str(v, "exclude_rule") {
                     "excluded"
                 } else {
@@ -717,10 +717,10 @@ pub fn count_rules<P: AsRef<Path>>(
                         .or_insert(0) += 1;
                 }
                 return;
-            }
+            } _ => {}}
         }
 
-        if let Some(s) = yaml_doc["status"].as_str() {
+        match yaml_doc["status"].as_str() { Some(s) => {
             // wizard用の初期カウンティングではstatusとlevelの内容を確認したうえで以降の処理は行わないようにする
             let counter = result_container.entry(s.into()).or_insert(HashMap::new());
             if included_target_tag_vec.is_empty() {
@@ -763,7 +763,7 @@ pub fn count_rules<P: AsRef<Path>>(
                         .or_insert(0) += 1;
                 }
             }
-        }
+        } _ => {}}
     });
     result_container.to_owned()
 }


### PR DESCRIPTION
As per https://blog.rust-lang.org/2024/11/27/Rust-2024-public-testing.html , I tested to see if Hayabusa was compatible with the new Rust edition 2024 that will be release next Feb. Good news is that all works without any warnings or errors.
Since the changes that it made are backwards compatible to the current 2021 edition I figured we might as well adapt to the new coding style.

@fukusuket Whenever you get time, could you check over these?