### PR TITLE
fix: add jsonl to `--JSON-input` target extensions

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -15,6 +15,7 @@
 **バグ修正:**
 
 - レコードIDが出力されるとき、`csv-timeline`によるソートが完璧に行われなかった。 (#1519) (@fukusuket)
+- `J, --JSON-input`は、`.json`ファイルしか対応していなかったので、`.jsonl`ファイルにも対応した。 (#1530) (@fukusuket)
 
 ## 2.19.0 [2024/11/26] - "Every Day Is A Good Day" Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Bug Fixes:**
 
 - Sorting with `csv-timeline` was not done perfectly when record IDs were outputted. (#1519) (@fukusuket)
+- `-J, --JSON-input` would only accept `.json` files, not `.jsonl` files so now both are supported. (#1530) (@fukusuket)
 
 ## 2.19.0 [2024/11/26] - "Every Day Is A Good Day" Release
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -2323,6 +2323,7 @@ pub fn get_target_extensions(arg: Option<&Vec<String>>, json_input_flag: bool) -
     let mut target_file_extensions: HashSet<String> = convert_option_vecs_to_hs(arg);
     if json_input_flag {
         target_file_extensions.insert(String::from("json"));
+        target_file_extensions.insert(String::from("jsonl"));
     } else {
         target_file_extensions.insert(String::from("evtx"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1875,7 +1875,9 @@ impl App {
             }
 
             let (detection_tmp, cnt_tmp, tl_tmp, recover_cnt_tmp, mut detect_infos) =
-                if evtx_file.extension().unwrap() == "json" {
+                if evtx_file.extension().unwrap() == "json"
+                    || evtx_file.extension().unwrap() == "jsonl"
+                {
                     self.analysis_json_file(
                         (evtx_file, time_filter, target_event_ids, stored_static),
                         detection,


### PR DESCRIPTION
## What Changed

- Closed #1530 

## Evidence
### Integration-Test
https://github.com/Yamato-Security/hayabusa/actions/runs/12362528975

I would appreciate it if you could check it out when you have time🙏