### PR TITLE
feat: add `-X, --remove-duplicate-detections` option to `eid-metrics` and `logon-summary`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,6 +2,10 @@
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 
+**新機能:**
+
+- `eid-metrics`と`logon-summary`コマンドに`-X, --remove-duplicate-detections`オプションを追加した。 (#1552) (@fukusuket)
+
 **改善:**
 
 - `search`コマンドに`--timeline-start/--timeline-end`オプションを追加した。 (#1543) (@fukuseket)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 
+**New Features:**
+
+- `-X, --remove-duplicate-detections` option to `eid-metrics` and `logon-summary` commands. (#1552) (@fukusuket)
+
 **Enhancements:**
 
 - Added `--timeline-start/--timeline-end` options to the `search` command. (#1543) (@fukuseket)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3406,6 +3406,7 @@ mod tests {
                 utc: false,
             },
             clobber: false,
+            remove_duplicate_detections: false,
         });
         let config = Some(Config {
             action: Some(action),
@@ -3463,6 +3464,7 @@ mod tests {
                 utc: false,
             },
             clobber: true,
+            remove_duplicate_detections: false,
         });
         let config = Some(Config {
             action: Some(action),
@@ -3520,6 +3522,7 @@ mod tests {
             clobber: false,
             end_timeline: None,
             start_timeline: None,
+            remove_duplicate_detections: false,
         });
         let config = Some(Config {
             action: Some(action),
@@ -3578,6 +3581,7 @@ mod tests {
             clobber: true,
             end_timeline: None,
             start_timeline: None,
+            remove_duplicate_detections: false,
         });
         let config = Some(Config {
             action: Some(action),

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -830,6 +830,7 @@ mod tests {
                 clobber: false,
                 end_timeline: None,
                 start_timeline: None,
+                remove_duplicate_detections: false,
             }));
         dummy_stored_static.logon_summary_flag = true;
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
@@ -1016,6 +1017,7 @@ mod tests {
                 },
                 output: Some(Path::new("./test_tm_stats.csv").to_path_buf()),
                 clobber: false,
+                remove_duplicate_detections: false,
             }));
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
         let mut timeline = Timeline::default();
@@ -1111,6 +1113,7 @@ mod tests {
                 clobber: false,
                 end_timeline: None,
                 start_timeline: None,
+                remove_duplicate_detections: false,
             }));
         dummy_stored_static.logon_summary_flag = true;
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());


### PR DESCRIPTION
## What Changed
- Closed #1478 

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/12927978824

I would appreciate it if you could check it out when you have time🙏