### PR TITLE
fix: not create unnecessary output file in `logon-summary` and `pivot-keywords-list`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -12,6 +12,10 @@
 - チャンネルフィルタリングで `logon-summary` コマンドの速度を大幅に改善した。 (#1544) (@fukusuket)
 - `extract-base64`コマンドが`PowerShell Classic EID 400`イベントも対象するようになった。 (#1549) (@fukusuket)
 
+**バグ修正:**
+
+- `logon-summary`と`pivot-keywords-list`コマンドが不要なファイルを出力していた。 (#1553) (@fukusuket)
+
 ## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
 
 **バグ修正:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Significantly improved the speed of the `logon-summary` command with channel filtering. (#1544) (@fukusuket)
 - The `extract-base64` command now also works on `PowerShell Classic EID 400` events. (#1549) (@fukusuket)
 
+**Bug Fixes:**
+
+- An unneeded file was being created with `logon-summary` and `pivot-keywords-list` commands. (#1553) (@fukusuket)
+
 ## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
 
 **Bug Fixes:**

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -165,12 +165,19 @@ pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
 
     let mut display_flag = false;
     let target: Box<dyn io::Write> = if let Some(path) = &stored_static.output_path {
-        // output to file
-        match File::create(path) {
-            Ok(file) => Box::new(BufWriter::new(file)),
-            Err(err) => {
-                AlertMessage::alert(&format!("Failed to open file. {err}")).ok();
-                process::exit(1);
+        if matches!(
+            stored_static.config.action.as_ref().unwrap(),
+            Action::PivotKeywordsList(_) | Action::LogonSummary(_)
+        ) {
+            Box::new(BufWriter::new(io::stdout()))
+        } else {
+            // output to file
+            match File::create(path) {
+                Ok(file) => Box::new(BufWriter::new(file)),
+                Err(err) => {
+                    AlertMessage::alert(&format!("Failed to open file. {err}")).ok();
+                    process::exit(1);
+                }
             }
         }
     } else {


### PR DESCRIPTION
## What Changed
- Closed #1553 

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/12949605224

I would appreciate it if you could check it out when you have time🙏