### PR TITLE
add "sort-events" option to search command #1475

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -2407,7 +2407,7 @@ fn extract_search_options(config: &Config) -> Option<SearchOption> {
             disable_abbreviations: option.disable_abbreviations,
             start_timeline: option.start_timeline.clone(),
             end_timeline: option.end_timeline.clone(),
-            sort_events: option.sort_events.clone(),
+            sort_events: option.sort_events,
         }),
         _ => None,
     }

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -3250,6 +3250,7 @@ mod tests {
                 disable_abbreviations: false,
                 start_timeline: None,
                 end_timeline: None,
+                sort_events: true,
             })),
             debug: false,
         }));

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1321,6 +1321,10 @@ pub struct SearchOption {
     /// Disable abbreviations
     #[arg(help_heading = Some("Output"), short='b', long = "disable-abbreviations", display_order = 60)]
     pub disable_abbreviations: bool,
+
+    /// Sort events before saving the file. (warning: this uses much more memory!)
+    #[arg(help_heading = Some("General Options"), short='s', long = "sort-events", display_order = 600)]
+    pub sort_events: bool,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -2403,6 +2407,7 @@ fn extract_search_options(config: &Config) -> Option<SearchOption> {
             disable_abbreviations: option.disable_abbreviations,
             start_timeline: option.start_timeline.clone(),
             end_timeline: option.end_timeline.clone(),
+            sort_events: option.sort_events.clone(),
         }),
         _ => None,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use std::io::{BufRead, BufWriter, Write};
 use std::path::Path;
 use std::ptr::null_mut;
 use std::sync::Arc;
-use std::time::Duration;
 use std::{
     env,
     fs::{self, File},
@@ -1865,11 +1864,17 @@ impl App {
         pb.set_style(progress_style);
         // I tried progress bar with low memory option(output log on detection) but it seems that progress bar didn't go well with low memory option.
         // I disabled progress bar if low memory option is specified.
-        let is_show_progress = !stored_static.is_low_memory || stored_static.output_path.is_some();
-        if is_show_progress {
-            pb.enable_steady_tick(Duration::from_millis(300));
-        }
+        let is_sortevent_searchcmd = || -> bool {
+            if !stored_static.search_flag {
+                return false;
+            }
 
+            let search_option = stored_static.search_option.as_ref().unwrap();
+            return search_option.sort_events;
+        };
+        let is_show_progress = !(stored_static.is_low_memory
+            || !is_sortevent_searchcmd()
+            || stored_static.output_path.is_some());
         self.rule_keys = self.get_all_keys(&rule_files);
         let mut detection = detection::Detection::new(rule_files);
         let mut tl = Timeline::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1869,8 +1869,7 @@ impl App {
                 return false;
             }
 
-            let search_option = stored_static.search_option.as_ref().unwrap();
-            return search_option.sort_events;
+            stored_static.search_option.as_ref().unwrap().sort_events
         };
         let is_show_progress = !(stored_static.is_low_memory
             || !is_sortevent_searchcmd()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1958,7 +1958,7 @@ impl App {
         } else if stored_static.logon_summary_flag {
             tl.tm_logon_stats_dsp_msg(stored_static);
         } else if stored_static.search_flag {
-            tl.search_dsp_msg(event_timeline_config, stored_static);
+            tl.search_dsp_msg(stored_static);
         } else if stored_static.computer_metrics_flag {
             tl.computer_metrics_dsp_msg(stored_static)
         } else if stored_static.log_metrics_flag {

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -665,8 +665,13 @@ pub fn search_result_dsp_msg(
 ) {
     let mut wtr = ResultWriter::new(search_option);
     if search_option.sort_events {
-        let hit_records = event_search.search_result.clone().into_iter().sorted_unstable_by(|a, b| Ord::cmp(&a.0, &b.0));
-        for (timestamp, hostname, channel, event_id, record_id, all_field_info, evtx_file) in hit_records
+        let hit_records = event_search
+            .search_result
+            .clone()
+            .into_iter()
+            .sorted_unstable_by(|a, b| Ord::cmp(&a.0, &b.0));
+        for (timestamp, hostname, channel, event_id, record_id, all_field_info, evtx_file) in
+            hit_records
         {
             wtr.write_record(
                 (
@@ -707,7 +712,8 @@ pub fn search_result_dsp_msg(
     write_color_buffer(
         &BufferWriter::stdout(ColorChoice::Always),
         None,
-        event_search.search_result_cnt
+        event_search
+            .search_result_cnt
             .to_formatted_string(&Locale::en)
             .as_str(),
         true,

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -221,7 +221,12 @@ impl EventSearch {
                     CompactString::from(allfieldinfo_newline_splited),
                     self.filepath.clone(),
                 );
-                wtr.write_record(hit_record, search_option, stored_static, self.search_result_cnt == 0);
+                wtr.write_record(
+                    hit_record,
+                    search_option,
+                    stored_static,
+                    self.search_result_cnt == 0,
+                );
                 self.search_result_cnt += 1;
             }
         }
@@ -292,7 +297,12 @@ impl EventSearch {
                     CompactString::from(allfieldinfo_newline_splited),
                     self.filepath.clone(),
                 );
-                wtr.write_record(hit_record, search_option, stored_static, self.search_result_cnt == 0);
+                wtr.write_record(
+                    hit_record,
+                    search_option,
+                    stored_static,
+                    self.search_result_cnt == 0,
+                );
                 self.search_result_cnt += 1;
             }
         }
@@ -310,7 +320,12 @@ impl ResultWriter {
         let mut file_wtr = Option::None;
         if let Some(path) = &search_option.output {
             // create new file if not exist and append if exist.
-            match OpenOptions::new().write(true).append(true).create(true).open(path) {
+            match OpenOptions::new()
+                .write(true)
+                .append(true)
+                .create(true)
+                .open(path)
+            {
                 Ok(file) => {
                     if search_option.json_output || search_option.jsonl_output {
                         file_wtr = Some(

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -616,10 +616,10 @@ pub fn search_result_dsp_msg(
     search_option: &SearchOption,
     stored_static: &StoredStatic,
 ) {
-    // // if sort_events option is false, search results should have been already output.
-    // if !search_option.sort_events {
-    //     return;
-    // }
+    // if sort_events option is false, search results should have been already output.
+    if !search_option.sort_events {
+        return;
+    }
 
     let mut wtr = ResultWriter::new(search_option);
 

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -356,12 +356,12 @@ impl ResultWriter {
             self.file_wtr
                 .as_mut()
                 .unwrap()
-                .write_record(&OUTPUT_HEADERS)
+                .write_record(OUTPUT_HEADERS)
                 .ok();
         } else if search_option.output.is_none() {
             // TODO hach1yon add logic, **result.isEmpty()**
             write_color_buffer(
-                &self.disp_wtr.as_mut().unwrap(),
+                self.disp_wtr.as_mut().unwrap(),
                 None,
                 &OUTPUT_HEADERS.join(" · "),
                 true,

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -709,7 +709,7 @@ pub fn search_result_dsp_msg(
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),
             Some(Color::Rgb(238, 102, 97)),
-            "\n\nNo matches found.",
+            "\nNo matches found.\n",
             true,
         )
         .ok();

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -320,12 +320,7 @@ impl ResultWriter {
         let mut file_wtr = Option::None;
         if let Some(path) = &search_option.output {
             // create new file if not exist and append if exist.
-            match OpenOptions::new()
-                .write(true)
-                .append(true)
-                .create(true)
-                .open(path)
-            {
+            match OpenOptions::new().append(true).create(true).open(path) {
                 Ok(file) => {
                     if search_option.json_output || search_option.jsonl_output {
                         file_wtr = Some(

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -492,7 +492,7 @@ impl Timeline {
         if let Action::Search(search_summary_option) =
             &stored_static.config.action.as_ref().unwrap()
         {
-            search_result_dsp_msg(&self.event_search, &search_summary_option, stored_static);
+            search_result_dsp_msg(&self.event_search, search_summary_option, stored_static);
         }
     }
 

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -488,10 +488,7 @@ impl Timeline {
     }
 
     /// Search結果出力
-    pub fn search_dsp_msg(
-        &mut self,
-        stored_static: &StoredStatic,
-    ) {
+    pub fn search_dsp_msg(&mut self, stored_static: &StoredStatic) {
         if let Action::Search(search_summary_option) =
             &stored_static.config.action.as_ref().unwrap()
         {
@@ -505,11 +502,7 @@ impl Timeline {
                 .ok();
             }
             let search_result = self.event_search.search_result.clone();
-            search_result_dsp_msg(
-                search_result,
-                &search_summary_option,
-                stored_static,
-            );
+            search_result_dsp_msg(search_result, &search_summary_option, stored_static);
             write_color_buffer(
                 &BufferWriter::stdout(ColorChoice::Always),
                 get_writable_color(

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -86,10 +86,7 @@ impl Timeline {
         } else if stored_static.log_metrics_flag {
             self.stats.logfile_stats_start(records, stored_static);
         } else if stored_static.search_flag {
-            self.event_search.search_start(
-                records,
-                stored_static,
-            );
+            self.event_search.search_start(records, stored_static);
         } else if stored_static.extract_base64_flag {
             if let Action::ExtractBase64(opt) = &stored_static.config.action.as_ref().unwrap() {
                 let records = process_evtx_record_infos(records, &opt.time_format_options);
@@ -493,7 +490,6 @@ impl Timeline {
     /// Search結果出力
     pub fn search_dsp_msg(
         &mut self,
-        event_timeline_config: &EventInfoConfig,
         stored_static: &StoredStatic,
     ) {
         if let Action::Search(search_summary_option) =
@@ -511,7 +507,6 @@ impl Timeline {
             let search_result = self.event_search.search_result.clone();
             search_result_dsp_msg(
                 search_result,
-                event_timeline_config,
                 &search_summary_option,
                 stored_static,
             );

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -492,38 +492,7 @@ impl Timeline {
         if let Action::Search(search_summary_option) =
             &stored_static.config.action.as_ref().unwrap()
         {
-            if self.event_search.search_result.is_empty() {
-                write_color_buffer(
-                    &BufferWriter::stdout(ColorChoice::Always),
-                    Some(Color::Rgb(238, 102, 97)),
-                    "\n\nNo matches found.",
-                    true,
-                )
-                .ok();
-            }
-            let search_result = self.event_search.search_result.clone();
-            search_result_dsp_msg(search_result, &search_summary_option, stored_static);
-            write_color_buffer(
-                &BufferWriter::stdout(ColorChoice::Always),
-                get_writable_color(
-                    Some(Color::Rgb(0, 255, 0)),
-                    stored_static.common_options.no_color,
-                ),
-                "Total findings: ",
-                false,
-            )
-            .ok();
-            write_color_buffer(
-                &BufferWriter::stdout(ColorChoice::Always),
-                None,
-                self.event_search
-                    .search_result
-                    .len()
-                    .to_formatted_string(&Locale::en)
-                    .as_str(),
-                true,
-            )
-            .ok();
+            search_result_dsp_msg(&self.event_search, &search_summary_option, stored_static);
         }
     }
 

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -88,16 +88,6 @@ impl Timeline {
         } else if stored_static.search_flag {
             self.event_search.search_start(
                 records,
-                stored_static
-                    .search_option
-                    .as_ref()
-                    .unwrap()
-                    .keywords
-                    .as_ref()
-                    .unwrap_or(&vec![]),
-                &stored_static.search_option.as_ref().unwrap().regex,
-                &stored_static.search_option.as_ref().unwrap().filter,
-                &stored_static.eventkey_alias,
                 stored_static,
             );
         } else if stored_static.extract_base64_flag {

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -522,12 +522,8 @@ impl Timeline {
             search_result_dsp_msg(
                 search_result,
                 event_timeline_config,
-                &search_summary_option.output,
+                &search_summary_option,
                 stored_static,
-                (
-                    search_summary_option.json_output,
-                    search_summary_option.jsonl_output,
-                ),
             );
             write_color_buffer(
                 &BufferWriter::stdout(ColorChoice::Always),


### PR DESCRIPTION
## What Changed

- add `sort-events` option to search command
- not to store all the hit records in memory and output them immediately when they are detected if `sort-events` option isn't specified.

## Evidence
@YamatoSecurity 
I checked the following patterns and confirmed that hayabusa output correct results. But I haven't tried a very big windows event file so could you try it?
Also, I'm not falimair with the `search` command so more comments are welcome.
- specify `sort-events` option
- specify no `sort-events` option


