### PR TITLE
feat: Level adjusting depending on `config/critical_systems.txt` - "Emergency Alerts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ hayabusa*
 !contributors.txt
 !LICENSE.txt
 .~*
+config/critical_systems.txt

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,6 +5,7 @@
 **新機能:**
 
 - `eid-metrics`と`logon-summary`コマンドに`-X, --remove-duplicate-detections`オプションを追加した。 (#1552) (@fukusuket)
+- 新しい「緊急アラート 」と重要なシステムに基づく重大度レベルの調整。`config/critical_systems.txt`に重要なシステム（例: ドメインコントローラ、ファイルサーバ等々）のコンピュータ名のリストを追加すると、`low`以上のすべてのアラートが1つ高く調整される。つまり、`low`は`medium`に、`medium`は`high`に、`critical`アラートは新しい`emergency`アラートになる。(#1551) (@fukusuket)
 
 **改善:**
 
@@ -12,10 +13,15 @@
 - チャンネルフィルタリングで `logon-summary` コマンドの速度を大幅に改善した。 (#1544) (@fukusuket)
 - `extract-base64`コマンドが`PowerShell Classic EID 400`イベントも対象するようになった。 (#1549) (@fukusuket)
 - `extract-base64`コマンドがPowerShell Coreログにも対応した。 (#1558) (@fukusuket)
+- `search`コマンドは、デフォルトでは結果をソートしないので、メモリ使用量が大幅に減り、より高速になった。新しい`-s, --sort`オプションを使えば、以前と同じように結果をソートできる。(#1475) (@hach1yon)
 
 **バグ修正:**
 
 - `logon-summary`と`pivot-keywords-list`コマンドが不要なファイルを出力していた。 (#1553) (@fukusuket)
+
+**その他:**
+
+- `-s, --sort-events`オプションが`-s, --sort`に名前変更された。 (@YamatoSecurity)
 
 ## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **New Features:**
 
 - `-X, --remove-duplicate-detections` option to `eid-metrics` and `logon-summary` commands. (#1552) (@fukusuket)
+- New "Emergency Alerts" and severity level adjustment based on critical systems. Add a list of the computer names of critical systems (Ex: Domain Controllers, File Servers, etc...) to `config/critical_systems.txt` and all of the alerts above `low` will be adjusted one higher. That is, `low` will become `medium`, `medium` will become `high`, etc... `critical` alerts will become new `emergency` alerts. (#1551) (@fukusuket)
 
 **Enhancements:**
 
@@ -12,10 +13,15 @@
 - Significantly improved the speed of the `logon-summary` command with channel filtering. (#1544) (@fukusuket)
 - The `extract-base64` command now also works on `PowerShell Classic EID 400` events. (#1549) (@fukusuket)
 - The `extract-base64` command now also scans PowerShell Core logs as well. (#1558) (@fukusuket)
+- `search` command uses much less memory and is faster as it does not sort results by default now. You can sort results like before with the new `-s, --sort` option. (#1475) (@hach1yon)
 
 **Bug Fixes:**
 
 - An unneeded file was being created with `logon-summary` and `pivot-keywords-list` commands. (#1553) (@fukusuket)
+
+**Other:**
+
+- The `-s, --sort-events` options have been renamed to `-s, --sort`. (@YamatoSecurity)
 
 ## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,15 +205,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 
 [[package]]
 name = "camino"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -339,14 +339,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -373,13 +373,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -563,7 +562,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -919,7 +918,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "strum 0.27.0",
+ "strum",
  "termcolor",
  "terminal_size 0.4.1",
  "tokio",
@@ -1109,7 +1108,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1164,9 +1163,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "infer"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
 ]
@@ -1306,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
 dependencies = [
  "cc",
  "libc",
@@ -1405,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -1550,15 +1549,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1577,7 +1576,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1588,18 +1587,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -1845,7 +1844,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.96",
+ "syn 2.0.98",
  "walkdir",
 ]
 
@@ -1881,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
@@ -1973,7 +1972,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2078,30 +2077,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 dependencies = [
- "strum_macros 0.27.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.96",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2114,7 +2094,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2136,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2153,7 +2133,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2216,7 +2196,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2255,7 +2235,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2277,6 +2257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,12 +2276,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.0.2"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6a209bb4b8d5903579fc4f8cd12ce5594f1ed6b735bf290ab5e2bdb3e70013"
+checksum = "b2916852be768844b6e9cbe107358b5bc40a696bd6dc8e036c9f80c731242c9c"
 dependencies = [
  "base64",
- "cc",
  "flate2",
  "log",
  "percent-encoding",
@@ -2356,11 +2341,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -2422,7 +2407,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -2444,7 +2429,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2470,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2740,7 +2725,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -2762,7 +2747,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2782,7 +2767,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -2811,5 +2796,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,8 +378,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width",
 ]
 
@@ -919,6 +919,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "strum 0.27.0",
  "termcolor",
  "terminal_size 0.4.1",
  "tokio",
@@ -2082,10 +2083,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
+dependencies = [
+ "strum_macros 0.27.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ regex = "1"
 serde = { version = "1.*", features = ["derive"] }
 serde_derive = "1.*"
 serde_json = { version = "1.0"}
+strum = { version = "0.27.*", features = ["derive"] }
 termcolor = "*"
 terminal_size = "*"
 tokio = { version = "1", features = ["full"] }

--- a/config/html_report/hayabusa_report.css
+++ b/config/html_report/hayabusa_report.css
@@ -27,6 +27,11 @@ h3 {
   margin: 16px;
 }
 
+#computers_with_most_unique_emergency_detections {
+  color: #ff0000;
+  border-bottom: solid 3px #ff0000;
+}
+
 #computers_with_most_unique_critical_detections {
   color: #ff0000;
   border-bottom: solid 3px #ff0000;

--- a/config/level_color.txt
+++ b/config/level_color.txt
@@ -1,4 +1,5 @@
 level,colorcode
+emergency,ff0000
 critical,ff0000
 high,ffc100
 medium,ffff00

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1325,8 +1325,8 @@ pub struct SearchOption {
     #[arg(help_heading = Some("Output"), short='b', long = "disable-abbreviations", display_order = 60)]
     pub disable_abbreviations: bool,
 
-    /// Sort events before saving the file. (warning: this uses much more memory!)
-    #[arg(help_heading = Some("General Options"), short='s', long = "sort-events", display_order = 600)]
+    /// Sort results before saving the file (warning: this uses much more memory!)
+    #[arg(help_heading = Some("General Options"), short='s', long = "sort", display_order = 600)]
     pub sort_events: bool,
 }
 
@@ -1689,8 +1689,8 @@ pub struct OutputOption {
     #[arg(help_heading = Some("General Options"), short = 'w', long = "no-wizard", display_order = 400)]
     pub no_wizard: bool,
 
-    /// Sort events before saving the file. (warning: this uses much more memory!)
-    #[arg(help_heading = Some("General Options"), short='s', long = "sort-events", display_order = 451)]
+    /// Sort results before saving the file (warning: this uses much more memory!)
+    #[arg(help_heading = Some("General Options"), short='s', long = "sort", display_order = 451)]
     pub sort_events: bool,
 
     /// Enable all rules regardless of loaded evtx files (disable channel filter for rules)

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -5,6 +5,7 @@ use crate::detections::configs::CURRENT_EXE_PATH;
 use crate::detections::field_data_map::{convert_field_data, FieldDataMap, FieldDataMapKey};
 use crate::detections::rule::AggResult;
 use crate::detections::utils::{self, get_serde_number_to_string, write_color_buffer};
+use crate::level::LEVEL;
 use crate::options::profile::Profile::{
     self, AllFieldInfo, Details, ExtraFieldInfo, Literal, SrcASN, SrcCity, SrcCountry, TgtASN,
     TgtCity, TgtCountry,
@@ -26,7 +27,6 @@ use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use std::sync::Mutex;
 use termcolor::{BufferWriter, Color, ColorChoice};
-
 /*
  * This struct express log record
 */
@@ -37,7 +37,7 @@ pub struct DetectInfo {
     pub ruleid: CompactString,
     pub ruletitle: CompactString,
     pub ruleauthor: CompactString,
-    pub level: CompactString,
+    pub level: LEVEL,
     pub computername: CompactString,
     pub rec_id: CompactString,
     pub eventid: CompactString,
@@ -67,21 +67,6 @@ lazy_static! {
         false
     );
     pub static ref COMPUTER_MITRE_ATTCK_MAP : DashMap<CompactString, Vec<CompactString>> = DashMap::new();
-    pub static ref LEVEL_ABBR_MAP:HashMap<&'static str, &'static str> = HashMap::from_iter(vec![
-        ("critical", "crit"),
-        ("high", "high"),
-        ("medium", "med "),
-        ("low", "low "),
-        ("informational", "info"),
-    ]
-);
-    pub static ref LEVEL_FULL: HashMap<&'static str, &'static str> = HashMap::from([
-        ("crit", "critical"),
-        ("high", "high"),
-        ("med ", "medium"),
-        ("low ", "low"),
-        ("info", "informational")
-    ]);
 }
 
 /// ファイルパスで記載されたtagでのフル名、表示の際に置き換えられる文字列のHashMapを作成する関数。

--- a/src/level.rs
+++ b/src/level.rs
@@ -9,7 +9,7 @@ use rust_embed::Embed;
 lazy_static! {
     static ref CRITICAL_SYSTEM: HashSet<String> = {
         let current = CURRENT_EXE_PATH.to_path_buf();
-        let path = current.join("config/critical_system.txt");
+        let path = current.join("config/critical_systems.txt");
         let content = fs::read_to_string(path).unwrap_or("".to_string());
         content
             .lines()

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,215 @@
+use crate::afterfact::Colors;
+use crate::detections::configs::CURRENT_EXE_PATH;
+use crate::detections::message::AlertMessage;
+use crate::detections::utils;
+use crate::detections::utils::parse_csv;
+use hashbrown::{HashMap, HashSet};
+use lazy_static::lazy_static;
+use rust_embed::Embed;
+lazy_static! {
+    static ref CRITICAL_SYSTEM: HashSet<String> = {
+        let current = CURRENT_EXE_PATH.to_path_buf();
+        let path = current.join("config/critical_system.txt");
+        let content = fs::read_to_string(path).unwrap_or("".to_string());
+        content
+            .lines()
+            .map(|line| line.trim().to_string())
+            .collect()
+    };
+}
+use std::fs;
+use std::path::Path;
+use strum::EnumIter;
+
+use termcolor::Color;
+
+#[derive(Embed)]
+#[folder = "config"]
+#[include = "level_color.txt"]
+struct LevelColor;
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, Default, Hash)]
+pub enum LEVEL {
+    #[default]
+    UNDEFINED,
+    INFORMATIONAL,
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL,
+    EMERGENCY,
+}
+
+impl LEVEL {
+    pub fn from(s: &str) -> Self {
+        match s {
+            "informational" => LEVEL::INFORMATIONAL,
+            "low" => LEVEL::LOW,
+            "medium" => LEVEL::MEDIUM,
+            "high" => LEVEL::HIGH,
+            "critical" => LEVEL::CRITICAL,
+            "emergency" => LEVEL::EMERGENCY,
+            _ => LEVEL::UNDEFINED,
+        }
+    }
+    pub fn to_full(&self) -> &str {
+        match *self {
+            LEVEL::INFORMATIONAL => "informational",
+            LEVEL::LOW => "low",
+            LEVEL::MEDIUM => "medium",
+            LEVEL::HIGH => "high",
+            LEVEL::CRITICAL => "critical",
+            LEVEL::EMERGENCY => "emergency",
+            _ => "undefined",
+        }
+    }
+
+    pub fn to_abbrev(&self) -> &str {
+        match *self {
+            LEVEL::INFORMATIONAL => "info",
+            LEVEL::LOW => "low",
+            LEVEL::MEDIUM => "med",
+            LEVEL::HIGH => "high",
+            LEVEL::CRITICAL => "crit",
+            LEVEL::EMERGENCY => "emer",
+            _ => "undef",
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        match *self {
+            LEVEL::UNDEFINED => 0,
+            LEVEL::INFORMATIONAL => 1,
+            LEVEL::LOW => 2,
+            LEVEL::MEDIUM => 3,
+            LEVEL::HIGH => 4,
+            LEVEL::CRITICAL => 5,
+            LEVEL::EMERGENCY => 6,
+        }
+    }
+
+    pub fn convert(&self, computer: &str) -> &LEVEL {
+        // computerがCRITICAL_SYSTEMに含まれている場合は、レベルを上げる
+        let computers = computer.split(" ¦ ");
+        for c in computers {
+            if CRITICAL_SYSTEM.contains(c) {
+                return match self {
+                    LEVEL::INFORMATIONAL => &LEVEL::INFORMATIONAL,
+                    LEVEL::LOW => &LEVEL::MEDIUM,
+                    LEVEL::MEDIUM => &LEVEL::HIGH,
+                    LEVEL::HIGH => &LEVEL::CRITICAL,
+                    LEVEL::CRITICAL => &LEVEL::EMERGENCY,
+                    LEVEL::EMERGENCY => &LEVEL::EMERGENCY,
+                    _ => &LEVEL::UNDEFINED,
+                };
+            }
+        }
+        self
+    }
+}
+
+impl PartialEq<str> for LEVEL {
+    fn eq(&self, other: &str) -> bool {
+        self.to_full() == other || self.to_abbrev() == other
+    }
+}
+
+/// level_color.txtファイルを読み込み対応する文字色のマッピングを返却する関数
+pub fn create_output_color_map(no_color_flag: bool) -> HashMap<LEVEL, Colors> {
+    let path = utils::check_setting_path(Path::new("."), "config/level_color.txt", false)
+        .unwrap_or_else(|| {
+            utils::check_setting_path(
+                &CURRENT_EXE_PATH.to_path_buf(),
+                "config/level_color.txt",
+                false,
+            )
+            .unwrap_or_default()
+        });
+    let read_result = match utils::read_csv(path.to_str().unwrap()) {
+        Ok(c) => Ok(c),
+        Err(_) => {
+            let level_color = LevelColor::get("level_color.txt").unwrap();
+            let embed_level_color =
+                parse_csv(std::str::from_utf8(level_color.data.as_ref()).unwrap_or_default());
+            if embed_level_color.is_empty() {
+                Err("Not found level_color.txt in embed resource.".to_string())
+            } else {
+                Ok(embed_level_color)
+            }
+        }
+    };
+    let mut color_map: HashMap<LEVEL, Colors> = HashMap::new();
+    if no_color_flag {
+        return color_map;
+    }
+    let color_map_contents = match read_result {
+        Ok(c) => c,
+        Err(e) => {
+            // color情報がない場合は通常の白色の出力が出てくるのみで動作への影響を与えない為warnとして処理する
+            AlertMessage::warn(&e).ok();
+            return color_map;
+        }
+    };
+    color_map_contents.iter().for_each(|line| {
+        if line.len() != 2 {
+            return;
+        }
+        let empty = &"".to_string();
+        let level = LEVEL::from(line.first().unwrap_or(empty).to_lowercase().as_str());
+        let convert_color_result = hex::decode(line.get(1).unwrap_or(empty).trim());
+        if convert_color_result.is_err() {
+            AlertMessage::warn(&format!(
+                "Failed hex convert in level_color.txt. Color output is disabled. Input Line: {}",
+                line.join(",")
+            ))
+            .ok();
+            return;
+        }
+        let color_code = convert_color_result.unwrap();
+        if level == LEVEL::UNDEFINED || color_code.len() < 3 {
+            return;
+        }
+        color_map.insert(
+            level,
+            Colors {
+                output_color: Color::Rgb(color_code[0], color_code[1], color_code[2]),
+                table_color: comfy_table::Color::Rgb {
+                    r: color_code[0],
+                    g: color_code[1],
+                    b: color_code[2],
+                },
+            },
+        );
+    });
+    color_map
+}
+
+pub fn _get_output_color(color_map: &HashMap<LEVEL, Colors>, level: &LEVEL) -> Option<Color> {
+    let mut color = None;
+    if let Some(c) = color_map.get(level) {
+        color = Some(c.output_color);
+    }
+    color
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::afterfact::Colors;
+    use crate::level::LEVEL;
+    use hashbrown::HashMap;
+
+    fn check_hashmap_data(target: HashMap<LEVEL, Colors>, expected: HashMap<LEVEL, Colors>) {
+        assert_eq!(target.len(), expected.len());
+        for (k, v) in target {
+            assert!(expected.get(&k).is_some());
+            assert_eq!(format!("{v:?}"), format!("{:?}", expected.get(&k).unwrap()));
+        }
+    }
+
+    #[test]
+    /// To confirm that empty character color mapping data is returned when the no_color flag is given.
+    fn test_set_output_color_no_color_flag() {
+        let expect: HashMap<LEVEL, Colors> = HashMap::new();
+        check_hashmap_data(crate::level::create_output_color_map(true), expect);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod afterfact;
 pub mod debug;
 pub mod detections;
 pub mod filter;
+pub mod level;
 pub mod notify;
 pub mod options;
 pub mod timeline;


### PR DESCRIPTION
## What Changed
- Closed #1551 
   - added `config/critical_system.txt`  
- Refactor Level conversion logic
   -  Level string mapping process is separated in `level.rs`

## Evidence
### Integration-Test
https://github.com/Yamato-Security/hayabusa/actions/runs/13261188409

I would appreciate it if you could check it out when you have time🙏
