### PR TITLE
fix: output rule author in html report

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -18,6 +18,7 @@
 **バグ修正:**
 
 - `logon-summary`と`pivot-keywords-list`コマンドが不要なファイルを出力していた。 (#1553) (@fukusuket)
+- バージョンv3.0.x`ではルール作者情報がHTMLレポートに出力されていなかった。 (#1571) (@fukusuket)
 
 **その他:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 **Bug Fixes:**
 
 - An unneeded file was being created with `logon-summary` and `pivot-keywords-list` commands. (#1553) (@fukusuket)
+- Rule authors would not be outputted to the HTML report in version `v3.0.x`. (#1571) (@fukusuket)
 
 **Other:**
 

--- a/config/html_report/hayabusa_report.css
+++ b/config/html_report/hayabusa_report.css
@@ -37,6 +37,11 @@ h3 {
   border-bottom: solid 3px #ff0000;
 }
 
+#all_emergency_alerts {
+  color: #ff0000;
+  border-bottom: solid 3px #ff0000;
+}
+
 #all_critical_alerts {
   color: #ff0000;
   border-bottom: solid 3px #ff0000;

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -510,18 +510,19 @@ fn calc_statistic_info(
             let level_suffix = detect_info.level.index();
             let author_list = extract_author_name(&detect_info.ruleauthor);
             let author_str = author_list.iter().join(", ");
-            afterfact_info
-                .detect_rule_authors
-                .insert(detect_info.ruleid.to_owned(), author_str.to_string().into());
+            afterfact_info.detect_rule_authors.insert(
+                detect_info.rulepath.to_owned(),
+                author_str.to_string().into(),
+            );
 
             if author_str != "-"
                 && !afterfact_info
                     .detected_rule_files
-                    .contains(&detect_info.ruleid)
+                    .contains(&detect_info.rulepath)
             {
                 afterfact_info
                     .detected_rule_files
-                    .insert(detect_info.ruleid.to_owned());
+                    .insert(detect_info.rulepath.to_owned());
                 for author in author_list.iter() {
                     *afterfact_info
                         .rule_author_counter


### PR DESCRIPTION
## What Changed

- Closed #1571 
- Also, Fixed css change omission at the emer level

## Evidence
### Integration-Test
https://github.com/Yamato-Security/hayabusa/actions/runs/13283636451

I would appreciate it if you could check it out when you have time🙏