### PR TITLE
test: add `live-response` package result count check in Integration-Test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -200,3 +200,50 @@ jobs:
 
       - name: set-default-profile
         run: cd main && ./hayabusa set-default-profile -p verbose -q
+
+  integration-test-live-response-results:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['ubuntu-24.04', 'macos-15']
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: main
+
+      - name: Checkout hayabusa-sample-evtx repo
+        uses: actions/checkout@v4
+        with:
+          repository: Yamato-Security/hayabusa-sample-evtx
+          path: hayabusa-sample-evtx
+
+      - name: Set up Rust toolchain
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: build
+        run: cd main && cargo build --release && cp target/release/hayabusa .
+
+      - name: csv-timeline(standard package)
+        run: cd main && ./hayabusa csv-timeline -d ../hayabusa-sample-evtx -o result.csv -p super-verbose -q -w -D -n -u
+
+      - name: csv-timeline(live-response package)
+        run: |
+          cd main
+          rm -rf ./config && rm -rf ./rules/
+          curl -O https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/encoded_rules.yml
+          curl -O https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/rules_config_files.txt
+          ./hayabusa csv-timeline -d ../hayabusa-sample-evtx -o result-live-response.csv -p super-verbose -q -w -D -n -u
+
+      - name: check csv-timeline results
+        run: |
+          standard_lines=$(cat main/result.csv | wc -l)
+          live_response_lines=$(cat main/result-live-response.csv | wc -l)
+          if [ "$standard_lines" -ne "$live_response_lines" ]; then
+            echo "Line counts differ: standard ($standard_lines) vs live-response ($live_response_lines)"
+            exit 1
+          fi

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -229,7 +229,7 @@ jobs:
         run: cd main && cargo build --release && cp target/release/hayabusa .
 
       - name: csv-timeline(standard package)
-        run: cd main && ./hayabusa csv-timeline -d ../hayabusa-sample-evtx -o result.csv -p super-verbose -q -w -D -n -u
+        run: cd main && ./hayabusa update-rules &&./hayabusa csv-timeline -d ../hayabusa-sample-evtx -o result.csv -p super-verbose -q -w -D -n -u
 
       - name: csv-timeline(live-response package)
         run: |
@@ -237,6 +237,7 @@ jobs:
           rm -rf ./config && rm -rf ./rules/
           curl -O https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/encoded_rules.yml
           curl -O https://raw.githubusercontent.com/Yamato-Security/hayabusa-encoded-rules/refs/heads/main/rules_config_files.txt
+          ./hayabusa update-rules
           ./hayabusa csv-timeline -d ../hayabusa-sample-evtx -o result-live-response.csv -p super-verbose -q -w -D -n -u
 
       - name: check csv-timeline results


### PR DESCRIPTION
## What Changed
- Closed #1597

## Test Specification
On Windows, there is a difference in the number of results due to Windows Defender. 
Therefore, compare the number of  `wc -l` only on Ubuntu and macOS.

## Evidence
### Integraion-Test
https://github.com/Yamato-Security/hayabusa/actions/runs/13604064714
(Tests will fail until https://github.com/Yamato-Security/hayabusa/issues/1606  is fixed)

I would appreciate it if you could check it out when you have time🙏