### PR TITLE
fix: exclude invalid `expand` rules

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,7 @@
 
 - `expand`ルールの数がターミナルに正しく表示されていなかった。 (#1598) (@fukusuket)
 - `status`フィールドが定義されていないルールは、スキャンウィザードで `status: test, stable` などを指定しても読み込まれた。(#1602) (@fukusuket)
+- `expand`ルールの数が正しくカウントされていなかった。 (#1606) (@fukusuket)
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - The number of `expand` rules was not being properly displayed on the terminal. (#1598) (@fukusuket)
 - Rules without the `status` field defined would be loaded even if you specified `status: test, stable`, etc... in the Scan Wizard. (#1602) (@fukusuket)
+- The number of `expand` rules were not being counted properly. (#1606) (@fukusuket)
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -332,6 +332,8 @@ impl ParseYaml {
                 self.rule_expand_cnt += 1;
                 if expand_enabled_found {
                     self.rule_expand_enabled_cnt += 1;
+                } else {
+                    return Option::None;
                 }
             };
             //除外されたルールは無視する


### PR DESCRIPTION
## What Changed
- Closed #1606 

## Evidence
### Integration-Test
https://github.com/Yamato-Security/hayabusa/actions/runs/13604232118

I would appreciate it if you could check it out when you have time🙏