### PR TITLE
fix: field outputted twice when `Details` does not set

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,7 @@
 - いくつかのコマンドで`-d`オプションが使用され、`-o`オプションが使用されなかった場合、プログレスバーが表示されなかった。 (#1617) (@fukusuket)
 - `pivot-keywords-list`コマンドが壊れていた。(#1619) (@fukusuket)
 - `details`が未定義の場合、フィールドデータマッピングが正常に機能しなかった。 (#1614) (@fukusuket)
+- `details`フィールドが設定されていない場合、`Details`列と`ExtraFieldInfo`列の両方に重複したデータが出力されていた。現在は`Details`列だけに出力される。 (#1623) (@fukusuket)
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The progress bar would not display when `-d` option was used but `-o` was not used for some commands. (#1617) (@fukusuket)
 - The `pivot-keywords-list` command was broken. (#1619) (@fukusuket)
 - Field data mapping was not working when `details` was not defined. (#1614) (@fukusuket)
+- When the `details` field was not set, duplicate data was outputted to both the `Details` column and `ExtraFieldInfo` column. Now it is just outputted to the `Details` column. (#1623) (@fukusuket)
 
 ## 3.1.0 [2025/02/22] - Ninja Day Release
 

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -376,6 +376,13 @@ pub fn parse_message(
             }
         }
     }
+    if hash_map.is_empty() {
+        for detail_contents in details_key.iter() {
+            let key = detail_contents.split_once(": ").unwrap_or_default().0;
+            let val = detail_contents.split_once(": ").unwrap_or_default().1;
+            details_key_and_value.push(format!("{}: {}", key, val).into());
+        }
+    }
     (return_message, details_key_and_value)
 }
 


### PR DESCRIPTION
## What Changed
- Closed #1623 

## Specification
Based on the following specification, modified to output fields in `Details` when `Details` is undefined.
(instead of empty column)
- https://github.com/Yamato-Security/hayabusa/issues/900

## Evidence
### Integrartion-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/13678246350

I would appreciate it if you could check it out when you have time🙏