### PR TITLE
fix: computer-metrics live-response package

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,6 +7,10 @@
 - ファイルサイズを1024ベースで出力するようにした。（例:`KiB`, `MiB`, `GiB`等） (#1648) (@fukusuket)
 - `computer-metrics`コマンドのアップタイムの計算を改善した。 (#1656) (@fukusuket)
 
+**バグ修正:**
+
+- Windowsのライブレスポンスパッケージでは、`computer-metrics`コマンドが正しく動作しなかった。 (#1654) (@fukusuket)
+
 ## 3.2.0 [2025/04/02] - Vegemite Release
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Now output file size in base 1024 (Ex: `KiB`, `MiB`, `GiB`). (#1648) (@fukusuket)
 - Improved the uptime calculation in the `computer-metrics` command. (#1656) (@fukusuket)
 
+**Bug Fixes:**
+
+- The `computer-metrics` command was not working with the Windows live response package. (#1654) (@fukusuket)
+
 ## 3.2.0 [2025/04/02] - Vegemite Release
 
 **Enhancements:**

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -55,6 +55,7 @@ lazy_static! {
         .to_str()
         .unwrap(),
     );
+    pub static ref WIN_VERSIONS: HashMap<(String, String), (String, String)> = load_win_versions();
 }
 
 fn read_one_config_file(file_path: &Path) -> io::Result<HashMap<String, String>> {
@@ -2714,6 +2715,29 @@ pub fn load_windash_characters(file_path: &str) -> Vec<char> {
             characters
         }
         Err(_) => characters,
+    }
+}
+
+pub fn load_win_versions() -> HashMap<(String, String), (String, String)> {
+    fn parse_csv<R: std::io::Read>(reader: R) -> HashMap<(String, String), (String, String)> {
+        let mut map = HashMap::new();
+        let mut rdr = csv::Reader::from_reader(reader);
+        for rec in rdr.records().flatten() {
+            let ver = rec.get(0).unwrap_or_default().to_string();
+            let build = rec.get(1).unwrap_or_default().to_string();
+            let win = rec.get(2).unwrap_or_default().to_string();
+            let date = rec.get(3).unwrap_or_default().to_string();
+            map.insert((ver, build), (win, date));
+        }
+        map
+    }
+
+    if let Ok(file) = File::open(Path::new("rules/config/windows_versions.csv")) {
+        parse_csv(file)
+    } else if let Some(contents) = ONE_CONFIG_MAP.get("windows_versions.csv") {
+        parse_csv(contents.as_bytes())
+    } else {
+        HashMap::new()
     }
 }
 

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -1,4 +1,4 @@
-use crate::detections::configs::EventKeyAliasConfig;
+use crate::detections::configs::{EventKeyAliasConfig, WIN_VERSIONS};
 use crate::detections::message::AlertMessage;
 use crate::detections::utils;
 use crate::timeline::timelines::Timeline;
@@ -9,32 +9,13 @@ use csv::{QuoteStyle, WriterBuilder};
 use downcast_rs::__std::process;
 use hashbrown::HashMap;
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use num::FromPrimitive;
 use num_format::{Locale, ToFormattedString};
 use serde_json::Value;
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::BufWriter;
-use std::path::{Path, PathBuf};
-
-lazy_static! {
-    static ref WIN_VERSIONS: HashMap<(String, String), (String, String)> = {
-        let mut map = HashMap::new();
-        if let Ok(file) = File::open(Path::new("rules/config/windows_versions.csv")) {
-            let mut rdr = csv::Reader::from_reader(file);
-            for rec in rdr.records().flatten() {
-                let ver = rec.get(0).unwrap_or_default().to_string();
-                let build = rec.get(1).unwrap_or_default().to_string();
-                let win = rec.get(2).unwrap_or_default().to_string();
-                let date = rec.get(3).unwrap_or_default().to_string();
-                map.insert((ver, build), (win, date));
-            }
-            return map;
-        }
-        HashMap::new()
-    };
-}
+use std::path::PathBuf;
 
 pub fn countup_event_by_computer(
     record: &Value,


### PR DESCRIPTION
## What Changed
- Closed #1654 

## Evidence
I have confirmed that the issue has been resolved in the rules_config.txt file in the following PR.
- https://github.com/Yamato-Security/hayabusa-encoded-rules/pull/12

<img width="1710" alt="スクリーンショット 2025-04-22 8 52 18" src="https://github.com/user-attachments/assets/0875a51e-e2c4-4039-a7d1-f978b9cc3d11" />

### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/14582730021

I’d appreciate it if you could check it when you have time🙏