### PR TITLE
fix: support access System32 dir without redirect, so we can run 32 bit exe on 64 bit os

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "wildmatch",
+ "winapi",
  "yaml-rust2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rust-embed={version = "8.7.2", features = ["include-exclude", "debug-embed"]}
 encoding_rs = "0.8.35"
 walkdir = "2.5.0"
 uuid = { version = "1.11.0", features = ["v4"] }
+winapi = { version = "0.3.9", features = ["wow64apiset"] }
 
 [profile.dev]
 debug-assertions = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,15 +28,6 @@ use hayabusa::detections::utils::{
     check_setting_path, get_file_size, get_writable_color, output_and_data_stack_for_html,
     output_profile_name,
 };
-#[cfg(target_os = "windows")]
-use winapi::{
-    um::wow64apiset::{
-        Wow64DisableWow64FsRedirection,
-        Wow64RevertWow64FsRedirection
-    },
-    ctypes::c_void,
-    shared::ntdef::PVOID,
-};
 use hayabusa::filter::create_channel_filter;
 use hayabusa::level::LEVEL;
 use hayabusa::options::htmlreport::{self, HTML_REPORTER};
@@ -81,6 +72,12 @@ use tokio::runtime::Runtime;
 use tokio::spawn;
 use tokio::task::JoinHandle;
 use ureq::get;
+#[cfg(target_os = "windows")]
+use winapi::{
+    ctypes::c_void,
+    shared::ntdef::PVOID,
+    um::wow64apiset::{Wow64DisableWow64FsRedirection, Wow64RevertWow64FsRedirection},
+};
 use yaml_rust2::YamlLoader;
 
 #[derive(Embed)]
@@ -120,7 +117,8 @@ impl Wow64RedirectionGuard {
         {
             let mut old_state: *mut winapi::ctypes::c_void = std::ptr::null_mut();
             unsafe {
-                if Wow64DisableWow64FsRedirection(&mut old_state as *mut *mut _ as *mut PVOID) != 0 {
+                if Wow64DisableWow64FsRedirection(&mut old_state as *mut *mut _ as *mut PVOID) != 0
+                {
                     Some(Self { old_state })
                 } else {
                     None


### PR DESCRIPTION
support access System32 dir without redirect, so we can run 32 bit exe on 64 bit os

ref:
- https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection
- https://github.com/Yamato-Security/hayabusa/issues/478
- https://github.com/Yamato-Security/hayabusa/pull/482
