### PR TITLE
Add missing level abbreviations

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -1810,11 +1810,13 @@ Message: "%RenderedMessage%"
 
 簡潔に出力するために`level`を以下のように省略し出力しています。
 
+* `emer`: `emergency`
 * `crit`: `critical`
 * `high`: `high`
 * `med `: `medium`
 * `low `: `low`
 * `info`: `informational`
+* `undef`: `undefined`
 
 ### MITRE ATT&CK戦術の省略
 

--- a/README.md
+++ b/README.md
@@ -1800,11 +1800,13 @@ You can turn off some of these abbreviations to see the original channel name, p
 
 In order to save space, we use the following abbrevations when displaying the alert `level`.
 
+* `emer`: `emergency`
 * `crit`: `critical`
 * `high`: `high`
 * `med `: `medium`
 * `low `: `low`
 * `info`: `informational`
+* `undef`: `undefined`
 
 ### MITRE ATT&CK Tactics Abbreviations
 


### PR DESCRIPTION
## Summary
This pull request adds two missing Hayabusa timeline alert level abbreviations to both README files.

## What Changed
- README.md / README-Japanese.md:
    - Added emergency level abbreviation to line 1803 / 1813
    - Added undefined level abbreviation to line 1809 / 1819

## Evidence
1. Pull the branch "docs/add-missing-level-abbreviations".
2. Recognize that both README files now contain the stated level abbreviations.

## Additional Notes
- Emergency level alerts were introduced with Hayabusa version 3.1.0 [2025/02/22] - Ninja Day Release.
- Alert level abbreviations are defined in `hayabusa/src/level.rs`.

Thanks and all the best :)