### PR TITLE
fix: update regex pattern to allow for additional word `+` characters

### DIFF
--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -14,7 +14,7 @@ lazy_static! {
         Regex::new(r"^\(").unwrap(),
         Regex::new(r"^\)").unwrap(),
         Regex::new(r"^ ").unwrap(),
-        Regex::new(r"^\w+").unwrap(),
+        Regex::new(r"^[\w+]+").unwrap(),
     ];
     pub static ref RE_PIPE: Regex = Regex::new(r"\|.*").unwrap();
     // all of selection* と 1 of selection* にマッチする正規表現


### PR DESCRIPTION
## What Changed

- Closed #1706

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/18424791664
  - The integration test failure in the live-response package is caused by the following issue and is not related to this PR.
    - https://github.com/Yamato-Security/hayabusa-encoded-rules/issues/13

I’d appreciate it if you could check it when you have time🙏