### PR TITLE
fix thread number parameter

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,16 @@
 # 変更点
 
+## 3.7.0 [xxxx/xx/xx]
+
+**新機能:**
+
+- `csv-timeline`および`json-timeline`コマンドでチャンクヘッダーのチェックサムを確認する`-V, --validate-checksums`オプションを追加した。 (#1709) (@fukusuket)
+
+**バグ修正:**
+
+- `validate_checksum`が無効化されている場合（デフォルト）、イベントのデータサイズがゼロに設定された際の無限ループとメモリリークが修正された。 (omerbenamram/evtx#264)
+- `-t, --threads`オプションが`computer-metrics`および`search`コマンドで機能していなかった。(#1563) (@hach1yon)
+
 ## 3.6.0 [2025/09/25] - 寝覚月リリース
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 3.7.0 [xxxx/xx/xx]
+
+**New Features:**
+
+- Added a `-V, --validate-checksums` option to check chunk header checksums in the `csv-timeline` and `json-timeline` commands. (#1709) (@fukusuket)
+
+**Bug Fixes:**
+
+- When `validate_checksum` is disabled (default), an infinite loop and memory leak when the data_size of an event is set to zero was fixed. (omerbenamram/evtx#264)
+- `-t, --threads` was not working in the `computer-metrics` and `search` commands. (#1563) (@hach1yon)
+
 ## 3.6.0 [2025/09/25] - Nezamezuki Release
 
 **Enhancements:**

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -928,6 +928,7 @@ fn check_thread_number(config: &Config) -> Option<usize> {
         Action::ExtractBase64(opt) => opt.detect_common_options.thread_number,
         Action::PivotKeywordsList(opt) => opt.detect_common_options.thread_number,
         Action::LogMetrics(opt) => opt.detect_common_options.thread_number,
+        Action::Search(opt) => opt.thread_number,
         _ => None,
     }
 }

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1862,16 +1862,6 @@ pub struct ComputerMetricsOption {
     #[arg(help_heading = Some("General Options"), long = "target-file-ext", value_name = "FILE-EXT...", use_value_delimiter = true, value_delimiter = ',', display_order = 450)]
     pub evtx_file_ext: Option<Vec<String>>,
 
-    /// Number of threads (default: optimal number for performance)
-    #[arg(
-        help_heading = Some("General Options"),
-        short = 't',
-        long = "threads",
-        value_name = "NUMBER",
-        display_order = 460
-    )]
-    pub thread_number: Option<usize>,
-
     /// Quiet errors mode: do not save error logs
     #[arg(help_heading = Some("General Options"), short = 'Q', long = "quiet-errors", display_order = 430)]
     pub quiet_errors: bool,
@@ -2543,7 +2533,7 @@ fn extract_output_options(config: &Config) -> Option<OutputOption> {
             detect_common_options: DetectCommonOption {
                 json_input: option.json_input,
                 evtx_file_ext: option.evtx_file_ext.clone(),
-                thread_number: option.thread_number,
+                thread_number: None,
                 quiet_errors: option.quiet_errors,
                 config: option.config.clone(),
                 verbose: option.verbose,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2259,7 +2259,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         Vec<DetectInfo>,
     ) {
         let path = evtx_filepath.display();
-        let parser = self.evtx_to_jsons(&evtx_filepath, stored_static.enable_recover_records);
+        let parser = self.evtx_to_jsons(&evtx_filepath, stored_static);
         let mut record_cnt = 0;
         let mut recover_records_cnt = 0;
         let mut detect_infos: Vec<DetectInfo> = vec![];
@@ -2862,15 +2862,15 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
     fn evtx_to_jsons(
         &self,
         evtx_filepath: &PathBuf,
-        enable_recover_records: bool,
+        stored_static: &StoredStatic,
     ) -> Option<EvtxParser<File>> {
         match EvtxParser::from_path(evtx_filepath) {
             Ok(evtx_parser) => {
                 // parserのデフォルト設定を変更
-                let mut parse_config =
-                    ParserSettings::default().parse_empty_chunks(enable_recover_records);
+                let mut parse_config = ParserSettings::default()
+                    .parse_empty_chunks(stored_static.enable_recover_records);
                 parse_config = parse_config.separate_json_attributes(true); // XMLのattributeをJSONに変換する時のルールを設定
-                parse_config = parse_config.num_threads(0); // 設定しないと遅かったので、設定しておく。
+                parse_config = parse_config.num_threads(stored_static.thread_number.unwrap_or(0));
 
                 let evtx_parser = evtx_parser.with_configuration(parse_config);
                 Some(evtx_parser)

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -239,7 +239,6 @@ mod tests {
                 },
                 json_input: false,
                 evtx_file_ext: None,
-                thread_number: None,
                 quiet_errors: false,
                 config: Path::new("./rules/config").to_path_buf(),
                 verbose: false,


### PR DESCRIPTION
… thread number parameter to Windows Eventlog Parser Library

## What Changed

- remove thread number parameter from Computer Metrics Command
- apply thread number parameter to Windows Event Log Parser Library

## Evidence

```
C:\Users\takai\dev\hayabusa>cargo run computer-metrics
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target\debug\hayabusa.exe computer-metrics`
error: the following required arguments were not provided:
  <--directory <DIR>|--file <FILE>|--live-analysis>

Usage: hayabusa.exe computer-metrics <--directory <DIR>|--file <FILE>|--live-analysis>

For more information, try '--help'.
error: process didn't exit successfully: `target\debug\hayabusa.exe computer-metrics` (exit code: 2)
```
