### PR TITLE
fix: resolve clippy warnings to unblock CI

### DIFF
--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -1488,7 +1488,7 @@ fn _print_detection_summary_by_computer(
             .filter(|a| a.0.as_str() != "-")
             .collect();
 
-        sorted_detections.sort_by(|a, b| (-a.1).cmp(&(-b.1)));
+        sorted_detections.sort_by_key(|a| -a.1);
 
         // html出力は各種すべてのコンピュータ名を表示するようにする
         if stored_static.html_report_flag {
@@ -1558,7 +1558,7 @@ fn _print_detection_summary_tables(
         let mut sorted_detections: Vec<(&CompactString, &i128)> =
             detections_by_computer.iter().collect();
 
-        sorted_detections.sort_by(|a, b| (-a.1).cmp(&(-b.1)));
+        sorted_detections.sort_by_key(|a| -a.1);
 
         // html出力の場合はすべての内容を出力するようにする
         if stored_static.html_report_flag {
@@ -2131,7 +2131,7 @@ fn output_detected_rule_authors(
 ) {
     let mut sorted_authors: Vec<(&CompactString, &i128)> = rule_author_counter.iter().collect();
 
-    sorted_authors.sort_by(|a, b| (-a.1).cmp(&(-b.1)));
+    sorted_authors.sort_by_key(|a| -a.1);
     let authors_num = sorted_authors.len();
     let div = if authors_num <= table_column_num {
         1

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -502,7 +502,7 @@ pub fn judge_timeframe(
 
     // AggRecordTimeInfoを時間順がソートされている前提で処理を進める
     let mut datas = time_datas.to_owned();
-    datas.sort_by(|a, b| a.time.cmp(&b.time));
+    datas.sort_by_key(|a| a.time);
 
     // timeframeの設定がルールにない時は最初と最後の要素の時間差をtimeframeに設定する。
     let def_frame =

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -144,18 +144,16 @@ fn extract_channel_from_rules(
         intersection_channels: &mut Vec<String>,
     ) {
         match *value {
-            Yaml::String(ref s) => {
-                if key == "Channel" {
-                    if s.contains('*') {
-                        // SigmaルールでChannelにワイルドカードが使われた場合
-                        for ch in evtx_channels {
-                            if ch.contains(s.trim_matches('*')) {
-                                intersection_channels.push(ch.to_string());
-                            }
+            Yaml::String(ref s) if key == "Channel" => {
+                if s.contains('*') {
+                    // SigmaルールでChannelにワイルドカードが使われた場合
+                    for ch in evtx_channels {
+                        if ch.contains(s.trim_matches('*')) {
+                            intersection_channels.push(ch.to_string());
                         }
-                    } else if evtx_channels.contains(s) {
-                        intersection_channels.push(s.clone());
                     }
+                } else if evtx_channels.contains(s) {
+                    intersection_channels.push(s.clone());
                 }
             }
             Yaml::Hash(ref map) => {

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -382,7 +382,7 @@ impl EventSearch {
         if pairs.is_empty() {
             return value.into();
         }
-        pairs.sort_unstable_by(|a, b| a.0.len().cmp(&b.0.len()));
+        pairs.sort_unstable_by_key(|a| a.0.len());
         let mut all_field_info = value.to_string();
         for (k, v) in pairs {
             all_field_info = all_field_info.replace(k.as_str(), v.as_str());

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -846,10 +846,8 @@ pub fn check_hayabusa_rule_fmt(yaml: &Yaml) -> Result<(), String> {
                         errors.push(format!("Invalid: {key}"));
                     }
                 }
-                "date" => {
-                    if !DATE_REGEX.is_match(yaml[key].as_str().unwrap_or("")) {
-                        errors.push(format!("Invalid: {key}"));
-                    }
+                "date" if !DATE_REGEX.is_match(yaml[key].as_str().unwrap_or("")) => {
+                    errors.push(format!("Invalid: {key}"));
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets -- -D warnings` has been failing on `main` since the clippy 1.95 bump. The Rust workflow has been red on every PR for around two weeks, including dependabot ones. This fixes the 7 lints so CI goes back to green.

Changes:

- `src/afterfact.rs`: 3x `sort_by` -> `sort_by_key`
- `src/detections/rule/count.rs`: `sort_by` -> `sort_by_key`
- `src/filter.rs`: collapse `Yaml::String` + key check into a match guard
- `src/timeline/search.rs`: `sort_unstable_by` -> `sort_unstable_by_key`
- `src/yaml.rs`: collapse the `date` arm regex check into a match guard

All seven changes are equivalent to the originals. The sort keys (`i128`, `DateTime<Utc>`, `usize`) are all `Copy + Ord`. The two collapsed matches fall through to the existing `_ => {}` arm when the guard fails, matching the original do-nothing branch.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `rustfmt --check` clean on all 5 files
- [x] `cargo test --lib` for every touched module (afterfact, detections::rule::count, filter, yaml) passes