### PR TITLE
chg: update actions/checkout and other actions to specific versions n workflow files

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Install stable toolchain
@@ -25,6 +25,6 @@ jobs:
           RUST_TEST_THREADS: 1
           CARGO_INCREMENTAL: "0"
         run: cargo llvm-cov --lcov --output-path /tmp/coverage.info
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           directory: /tmp/

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           path: main
 
       - name: Checkout hayabusa-sample-evtx repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
@@ -119,13 +119,13 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           path: main
 
       - name: Checkout hayabusa-sample-evtx repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
@@ -213,13 +213,13 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           path: main
 
       - name: Checkout hayabusa-sample-evtx repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch_or_tag }}
           submodules: 'true'
 
       - name: Clone hayabusa rule repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: Yamato-Security/hayabusa-rules
@@ -181,7 +181,7 @@ jobs:
           esac
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: release-binaries/*
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload Artifacts(encoded_rule)
         if: contains(matrix.info.os, 'windows') == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.set_artifact_name_encoded_rule.outputs.artifact_name }}
           path: release-binaries-encoded-rules/*
@@ -211,7 +211,7 @@ jobs:
 
       - name: Setup node
         if: matrix.info.target == 'aarch64-apple-darwin'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload Document Artifacts
         if: matrix.info.target == 'aarch64-apple-darwin'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hayabusa-documents
           path: |
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-packages
           pattern: hayabusa-*
@@ -246,7 +246,7 @@ jobs:
           rm -rf all-packages/rules_config_files.txt
 
       - name: Upload Artifacts(all-platforms)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hayabusa-${{ github.event.inputs.release_ver }}-all-platforms
           path: all-packages/*
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-packages
           pattern: hayabusa-*
@@ -270,7 +270,7 @@ jobs:
             cd ..
           done
       - name: Upload Zip Artifacts(all-packages)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: all-packages
           path: all-packages/*.zip

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
             }
     runs-on: ${{ matrix.info.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Set up Rust toolchain
@@ -62,7 +62,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Build tests
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: ClementTsang/cargo-action@v0.0.3
+        uses: ClementTsang/cargo-action@2438cc5f3ba4e971289fffca2a00dedea6911f14 # v0.0.7
         with:
           command: test
           args: --no-run --locked ${{ matrix.features }} --target=${{ matrix.info.target }}

--- a/.github/workflows/timeline-diff.yml
+++ b/.github/workflows/timeline-diff.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout dev-branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.ref }}
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout hayabusa-sample-evtx repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx


### PR DESCRIPTION
## What Changed
I have updated third-party action references to use full-length commit SHA, following the best practices.
- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

## Test
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/25242857540
### Release-Automation
- https://github.com/Yamato-Security/hayabusa/actions/runs/25243164347

I’d appreciate it if you could check it when you have time🙏