### PR TITLE
feat: add unique alert count for MITRE tactics in detection logic

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,6 +2,10 @@
 
 ## x.x.x
 
+**改善:**
+
+検出されたMITRE ATT&CK戦術について、一意の件数と合計件数を追加した。 (#1753) (@fukusuket)
+
 **バグ修正:**
 
 - MITRE ATT&CK Tacticsの項目が、HTMLレポートで適切に改行されていなかった。 (#1751) (@fukusuket)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## x.x.x
 
+**Enchancements:**
+
+Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fukusuket)
+
 **Bug Fixes:**
 
 - MITRE ATT&CK Tactics were not line-breaking properly in HTML reports (#1751) (@fukusuket)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "hayabusa"
-version = "3.9.1"
+version = "3.10.0-dev"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hayabusa"
-version = "3.9.1"
+version = "3.10.0-dev"
 repository = "https://github.com/Yamato-Security/hayabusa"
 authors = ["Yamato Security @SecurityYamato"]
 edition = "2024"

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -2234,8 +2234,8 @@ fn _output_html_computer_by_mitre_attck(html_output_stock: &mut Nested<String>) 
         .iter()
         .sorted_by(|a, b| {
             Ord::cmp(
-                &format!("{}-{}", &b.value()[b.value().len() - 1], b.key()),
-                &format!("{}-{}", &a.value()[a.value().len() - 1], a.key()),
+                &format!("{}-{}", &b.value()[b.value().len() - 1].0, b.key()),
+                &format!("{}-{}", &a.value()[a.value().len() - 1].0, a.key()),
             )
         })
         .enumerate()
@@ -2247,7 +2247,12 @@ fn _output_html_computer_by_mitre_attck(html_output_stock: &mut Nested<String>) 
         html_output_stock.push(format!(
             "|{}|{}|",
             html_escape_value(sorted_output_map.key()),
-            sorted_output_map.value().join("<br>")
+            sorted_output_map
+                .value()
+                .iter()
+                .map(|(tactic, unique, total)| format!("{} ({} &#124; {})", tactic, unique, total))
+                .collect::<Vec<_>>()
+                .join("<br>")
         ));
     }
 }

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -42,7 +42,7 @@ use crate::yaml::ParseYaml;
 use super::configs::{
     EventKeyAliasConfig, GEOIP_DB_PARSER, GEOIP_DB_YAML, GEOIP_FILTER, STORED_STATIC, StoredStatic,
 };
-use super::message::{self, COMPUTER_MITRE_ATTCK_MAP};
+use super::message::{self, COMPUTER_MITRE_ATTCK_MAP, COMPUTER_MITRE_ATTCK_UNIQUE_KEYS};
 
 // Struct to hold information for one record of an event file.
 #[derive(Clone, Debug)]
@@ -516,9 +516,20 @@ impl Detection {
                             .or_default();
                         let (_, attck_tac) = v.pair_mut();
                         for html_attck_tac in html_output_tactics_str {
-                            if !attck_tac.contains(&html_attck_tac.into()) {
-                                attck_tac.push(html_attck_tac.into());
-                                attck_tac.sort_unstable();
+                            let tactic_key: CompactString = html_attck_tac.into();
+                            let unique_key = CompactString::from(format!(
+                                "{}|{}|{}",
+                                &computer_name_to_mitre_tactics, &tactic_key, &rule.rulepath
+                            ));
+                            let is_unique = COMPUTER_MITRE_ATTCK_UNIQUE_KEYS.insert(unique_key);
+                            if let Some(entry) =
+                                attck_tac.iter_mut().find(|(t, _, _)| t == tactic_key)
+                            {
+                                entry.1 += if is_unique { 1 } else { 0 };
+                                entry.2 += 1;
+                            } else {
+                                attck_tac.push((tactic_key, if is_unique { 1 } else { 0 }, 1));
+                                attck_tac.sort_unstable_by(|a, b| a.0.cmp(&b.0));
                             }
                         }
                     }

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -12,7 +12,7 @@ use crate::options::profile::Profile::{
 };
 use chrono::{DateTime, Local, Utc};
 use compact_str::CompactString;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 use itertools::Itertools;
@@ -66,7 +66,8 @@ lazy_static! {
         true,
         false
     );
-    pub static ref COMPUTER_MITRE_ATTCK_MAP : DashMap<CompactString, Vec<CompactString>> = DashMap::new();
+    pub static ref COMPUTER_MITRE_ATTCK_MAP : DashMap<CompactString, Vec<(CompactString, i64, i64)>> = DashMap::new();
+    pub static ref COMPUTER_MITRE_ATTCK_UNIQUE_KEYS : DashSet<CompactString> = DashSet::new();
 }
 
 /// Function to create a HashMap of full names for tags described by file paths and the strings to be replaced during display.


### PR DESCRIPTION
## What Changed
Closed https://github.com/Yamato-Security/hayabusa/issues/1753

## Test
### Integration-Test
- https://github.com/Yamato-Security/hayabusa/actions/runs/25407050062

I’d appreciate it if you could check it when you have time🙏
