### PR TITLE
test: serialize tests that race on global HTML_REPORTER / PIVOT_KEYWORD state

### DIFF
--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -1107,6 +1107,10 @@ mod tests {
 
     #[test]
     fn test_output_profile() {
+        // Serialize against other tests that mutate the global HTML_REPORTER.
+        let _html_reporter_lock = crate::options::htmlreport::HTML_REPORTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         HTML_REPORTER.write().unwrap().md_datas.clear();
         let stored_static = StoredStatic::create_static_data(Some(Config {
             action: Some(Action::CsvTimeline(CsvOutputOption {

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -23,6 +23,12 @@ lazy_static! {
     pub static ref HTML_REPORTER: RwLock<HtmlReporter> = RwLock::new(HtmlReporter::new());
 }
 
+/// Serializes the tests that mutate the process-global `HTML_REPORTER`
+/// (clear/populate/read) so they don't race under the parallel test harness.
+/// Each such test must hold this lock for its whole body.
+#[cfg(test)]
+pub(crate) static HTML_REPORTER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[derive(Clone)]
 pub struct HtmlReporter {
     pub section_order: Nested<String>,
@@ -202,7 +208,7 @@ mod tests {
 
     use nested::Nested;
 
-    use super::{HTML_REPORTER, img_to_base64};
+    use super::{HTML_REPORTER, HTML_REPORTER_TEST_LOCK, img_to_base64};
     use crate::{
         detections::configs::{
             Action, Config, CsvOutputOption, JSONOutputOption, OutputOption, StoredStatic,
@@ -368,6 +374,10 @@ mod tests {
 
     #[test]
     fn test_add_md_data() {
+        // Serialize against other tests that mutate the global HTML_REPORTER.
+        let _html_reporter_lock = HTML_REPORTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         HTML_REPORTER.write().unwrap().md_datas.clear();
         let mut html_reporter = HtmlReporter::default();
         let mut general_data = Nested::<String>::new();

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -22,6 +22,12 @@ lazy_static! {
         RwLock::new(IndexMap::new());
 }
 
+/// Serializes the tests that mutate the process-global `PIVOT_KEYWORD`
+/// (clear/load/insert/read) so they don't race under the parallel test harness.
+/// Each such test must hold this lock for its whole body.
+#[cfg(test)]
+pub(crate) static PIVOT_KEYWORD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 impl Default for PivotKeyword {
     fn default() -> Self {
         Self::new()
@@ -147,11 +153,16 @@ mod tests {
     use crate::detections::configs::load_pivot_keywords;
     use crate::detections::utils;
     use crate::options::pivot::PIVOT_KEYWORD;
+    use crate::options::pivot::PIVOT_KEYWORD_TEST_LOCK;
     use crate::options::pivot::insert_pivot_keyword;
     use serde_json;
 
     #[test]
     fn insert_pivot_keyword_local_ip4() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -192,6 +203,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_ip4() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -232,6 +247,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_ip_empty() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -272,6 +291,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_local_ip6() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -312,6 +335,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_infomational() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -352,6 +379,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_low() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"
@@ -392,6 +423,10 @@ mod tests {
 
     #[test]
     fn insert_pivot_keyword_level_none() {
+        // Serialize against other tests that mutate the global PIVOT_KEYWORD.
+        let _pivot_keyword_lock = PIVOT_KEYWORD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         PIVOT_KEYWORD.write().unwrap().clear();
         load_pivot_keywords("test_files/config/pivot_keywords.txt");
         let record_json_str = r#"


### PR DESCRIPTION
## Summary
Fixes intermittent failures of several **library** unit tests that share process-global `lazy_static` state and run concurrently under the default test harness.

Two independent groups:
- **`HTML_REPORTER`** — `detections::utils::tests::test_output_profile` and `options::htmlreport::tests::test_add_md_data` each `clear()` → populate → read the global `HTML_REPORTER.md_datas`. Concurrently, one test's entry/`clear()` interleaves with the other's assertion (`test_output_profile` panics at `utils.rs:1134`, seeing a foreign `"AddTest {#add_test}"` key).
- **`PIVOT_KEYWORD`** — the 7 `options::pivot::tests::insert_pivot_keyword_*` tests each `clear()` → load → insert → assert the global, racing with one another.

## Fix
Add a per-global, test-only serialization lock and have each affected test hold it for its whole body:
```rust
#[cfg(test)]
pub(crate) static HTML_REPORTER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
// ...
let _lock = HTML_REPORTER_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
```
(`unwrap_or_else(into_inner)` tolerates poisoning so a panic in one test doesn't cascade.) **Zero new dependencies**; only the tests that touch each global are serialized — everything else stays parallel.

## Verification (Rust 1.95.0, against the real deps)
- HTML_REPORTER tests forced onto 2 threads, 50 runs: **0 failures** (pre-fix: **35/40** failed).
- Full `cargo test --lib`, default parallelism, 20 runs: **0 failures** (pre-fix: **6/12** failed); **420 passed**.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check`: clean.

This is a test-only change (no runtime behavior change), so no CHANGELOG entry.

## Out of scope (separate pre-existing issue)
The **binary** tests `tests::test_same_file_output_*_exit` (`src/main.rs`) are a *different* flaky family — they race on the global `STORED_STATIC`/`STORED_EKEY_ALIAS` and shared fixed output filenames. Not touched here; noted in #1764 for awareness.

Closes #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)