### PR TITLE
test: serialize bin tests that share output filenames (overwrite-*)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3045,6 +3045,13 @@ mod tests {
         timeline::timelines::Timeline,
     };
 
+    /// Serializes the tests that exercise output-file overwrite behavior. They
+    /// share fixed output filenames (e.g. `overwrite-metric.csv`) between the
+    /// `*_exit` (no-clobber, expects the file untouched) and clobber variants,
+    /// so running them concurrently lets one test write the file the other
+    /// asserts is empty. Each such test holds this lock for its whole body.
+    static FILE_OUTPUT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn create_dummy_stored_static() -> StoredStatic {
         StoredStatic::create_static_data(Some(Config {
             action: Some(Action::CsvTimeline(CsvOutputOption {
@@ -3164,6 +3171,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_csv_exit() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -3204,6 +3215,10 @@ mod tests {
 
     #[test]
     fn test_overwrite_csv() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -3244,6 +3259,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_json_exit() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite.json").ok();
@@ -3285,6 +3304,10 @@ mod tests {
 
     #[test]
     fn test_overwrite_json() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite.csv").ok();
@@ -3325,6 +3348,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_metric_csv_exit() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-metric.csv").ok();
@@ -3359,6 +3386,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_metric_csv() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-metric.csv").ok();
@@ -3392,6 +3423,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_logon_summary_csv_exit() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-metric-successful.csv").ok();
@@ -3425,6 +3460,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_logon_summary_csv() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-metric-successful.csv").ok();
@@ -3458,6 +3497,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_computer_metrics_exit() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-computer-metrics.csv").ok();
@@ -3489,6 +3532,10 @@ mod tests {
 
     #[test]
     fn test_same_file_output_computer_metrics_csv() {
+        // Serialize against the sibling test that shares this output filename.
+        let _file_output_lock = FILE_OUTPUT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
         File::create("overwrite-computer-metrics.csv").ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3310,7 +3310,7 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         // Create an empty file first.
         let mut app = App::new(None);
-        File::create("overwrite.csv").ok();
+        File::create("overwrite.json").ok();
         let action = Action::JsonTimeline(JSONOutputOption {
             output_options: OutputOption {
                 input_args: InputOption {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3491,8 +3491,9 @@ mod tests {
         app.exec(&mut config_reader.app, &mut stored_static);
         let meta = fs::metadata("overwrite-metric-successful.csv").unwrap();
         assert_ne!(meta.len(), 0);
-        // Delete the test file.
-        remove_file("overwrite-metric-successful").ok();
+        // Delete the test files (LogonSummary writes both -successful and -failed).
+        remove_file("overwrite-metric-successful.csv").ok();
+        remove_file("overwrite-metric-failed.csv").ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes intermittent failures of the **binary** output-file tests in `src/main.rs`. An `*_exit` test and its sibling write the **same fixed output filename** with opposite expectations:

- `test_same_file_output_metric_csv_exit` — no `clobber` → refuses overwrite → asserts `meta.len() == 0`.
- `test_same_file_output_metric_csv` — `clobber: true` → overwrites → asserts `meta.len() != 0`.

Run concurrently, the clobbering sibling writes ~92 bytes to `overwrite-metric.csv` while the `*_exit` test asserts it is empty → `left: 92, right: 0` (`main.rs:3484`). Five such filename pairs across 10 tests.

## Root cause
A pure filesystem collision. The no-clobber overwrite check reads the `stored_static` **argument** and `return`s before any analysis — so the process-global `STORED_STATIC` / detection are not involved; only the shared filename is.

## Fix
Serialize the 10 output-file tests with a shared, test-only lock held for each test body:
```rust
static FILE_OUTPUT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
// ...at the start of each affected test:
let _file_output_lock = FILE_OUTPUT_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
```
**Zero new dependencies**; only these 10 tests are serialized, everything else stays parallel. Same approach as the lib-test fix in #1765.

## Verification (Rust 1.95.0)
`cargo test --bin hayabusa`, default parallelism: **6/6 runs failed pre-fix → 0/15 failed post-fix** (17 passed). `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean.

Test-only change. Completes the flaky-test cleanup started in #1765 (this was the bin family noted as out-of-scope in #1764).

Closes #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)