### PR TITLE
fix: don't panic on malformed JSON EventData (empty array / scalar)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2650,9 +2650,30 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 record_cnt += 1;
                 if data["Event"]["EventData"].is_object() {
                     data["Event"]["System"] = data["Event"]["EventData"].clone();
-                } else if data["Event"]["EventData"].is_array() {
-                    data["Event"]["System"] =
-                        data["Event"]["EventData"].as_array().unwrap()[0].clone();
+                } else if let Some(first) = data["Event"]["EventData"]
+                    .as_array()
+                    .and_then(|a| a.first())
+                {
+                    data["Event"]["System"] = first.clone();
+                }
+                // If EventData was an empty array, a scalar, or an array whose first
+                // element isn't an object, `System` is not a JSON object and the
+                // normalization below would panic at `as_object_mut().unwrap()`. Skip
+                // the malformed record instead of aborting the whole scan.
+                if !data["Event"]["System"].is_object() {
+                    let errmsg = format!(
+                        "Skipped a malformed JSON record (unexpected Event.EventData shape). Filepath: {path}"
+                    );
+                    if stored_static.verbose_flag {
+                        AlertMessage::warn(&errmsg).ok();
+                    }
+                    if !stored_static.quiet_errors_flag {
+                        ERROR_LOG_STACK
+                            .lock()
+                            .unwrap()
+                            .push(format!("[WARN] {errmsg}"));
+                    }
+                    continue;
                 }
                 data["Event"]["System"]
                     .as_object_mut()


### PR DESCRIPTION
## Summary

Closes #1772. While normalizing JSON-input records, `analysis_json_file` assumed `Event.EventData` was either an object or a non-empty array. Two panic vectors aborted the whole scan on a single bad record:
- an **empty** `EventData` array → `as_array().unwrap()[0]` index panic;
- a **scalar** `EventData` (or an array whose first element isn't an object) → `Event.System` left non-object → `as_object_mut().unwrap()` panic.

## Fix
Guard the array access with `.first()`, and when `System` isn't an object after normalization, **skip the record** (`continue`) with a `--verbose`/`--quiet-errors`-gated warning pushed to `ERROR_LOG_STACK` — the same graceful-skip approach as the EVTX path. Well-formed object `EventData` (incl. the Splunk-JSON branch) is unchanged.

## Verification
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --bins` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)