### PR TITLE
fix: gate JSON/Splunk timestamp-parse errors (no un-gated stderr leak)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2473,7 +2473,10 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 Utc,
             )),
             Err(e) => {
-                AlertMessage::alert(&format!(
+                // Gate this per-record parse error like the EVTX path does, so it
+                // honors --verbose/--quiet-errors, stays out of the live progress
+                // bar, and lands in the error log instead of leaking to stderr.
+                let errmsg = format!(
                     "Timestamp parse error. Filepath: {},{} {}",
                     path,
                     &target_timestamp
@@ -2481,8 +2484,16 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                         .replace("\\\"", "")
                         .replace('"', ""),
                     e
-                ))
-                .ok();
+                );
+                if stored_static.verbose_flag {
+                    AlertMessage::alert(&errmsg).ok();
+                }
+                if !stored_static.quiet_errors_flag {
+                    ERROR_LOG_STACK
+                        .lock()
+                        .unwrap()
+                        .push(format!("[ERROR] {errmsg}"));
+                }
                 None
             }
         };
@@ -2589,7 +2600,10 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                                 .format("%Y-%m-%dT%H:%M:%S%.fZ")
                             }
                             Err(e) => {
-                                AlertMessage::warn(&format!(
+                                // Gate like the EVTX path so it honors
+                                // --verbose/--quiet-errors and is logged rather
+                                // than leaked to stderr over the progress bar.
+                                let errmsg = format!(
                                     "Timestamp parse error. Filepath: {},{} {}",
                                     path,
                                     &splunk_api_record["Event"]["System"]["SystemTime"]
@@ -2597,8 +2611,16 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                                         .replace("\\\"", "")
                                         .replace('"', ""),
                                     e
-                                ))
-                                .ok();
+                                );
+                                if stored_static.verbose_flag {
+                                    AlertMessage::warn(&errmsg).ok();
+                                }
+                                if !stored_static.quiet_errors_flag {
+                                    ERROR_LOG_STACK
+                                        .lock()
+                                        .unwrap()
+                                        .push(format!("[WARN] {errmsg}"));
+                                }
                                 DateTime::<Utc>::default().format("%Y-%m-%dT%H:%M:%S%.fZ")
                             }
                         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2476,23 +2476,26 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 // Gate this per-record parse error like the EVTX path does, so it
                 // honors --verbose/--quiet-errors, stays out of the live progress
                 // bar, and lands in the error log instead of leaking to stderr.
-                let errmsg = format!(
-                    "Timestamp parse error. Filepath: {},{} {}",
-                    path,
-                    &target_timestamp
-                        .to_string()
-                        .replace("\\\"", "")
-                        .replace('"', ""),
-                    e
-                );
-                if stored_static.verbose_flag {
-                    AlertMessage::alert(&errmsg).ok();
-                }
-                if !stored_static.quiet_errors_flag {
-                    ERROR_LOG_STACK
-                        .lock()
-                        .unwrap()
-                        .push(format!("[ERROR] {errmsg}"));
+                // Only build the message when it will actually be emitted.
+                if stored_static.verbose_flag || !stored_static.quiet_errors_flag {
+                    let errmsg = format!(
+                        "Timestamp parse error. Filepath: {},{} {}",
+                        path,
+                        &target_timestamp
+                            .to_string()
+                            .replace("\\\"", "")
+                            .replace('"', ""),
+                        e
+                    );
+                    if stored_static.verbose_flag {
+                        AlertMessage::alert(&errmsg).ok();
+                    }
+                    if !stored_static.quiet_errors_flag {
+                        ERROR_LOG_STACK
+                            .lock()
+                            .unwrap()
+                            .push(format!("[ERROR] {errmsg}"));
+                    }
                 }
                 None
             }
@@ -2603,23 +2606,26 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                                 // Gate like the EVTX path so it honors
                                 // --verbose/--quiet-errors and is logged rather
                                 // than leaked to stderr over the progress bar.
-                                let errmsg = format!(
-                                    "Timestamp parse error. Filepath: {},{} {}",
-                                    path,
-                                    &splunk_api_record["Event"]["System"]["SystemTime"]
-                                        .to_string()
-                                        .replace("\\\"", "")
-                                        .replace('"', ""),
-                                    e
-                                );
-                                if stored_static.verbose_flag {
-                                    AlertMessage::warn(&errmsg).ok();
-                                }
-                                if !stored_static.quiet_errors_flag {
-                                    ERROR_LOG_STACK
-                                        .lock()
-                                        .unwrap()
-                                        .push(format!("[WARN] {errmsg}"));
+                                // Only build the message when it will be emitted.
+                                if stored_static.verbose_flag || !stored_static.quiet_errors_flag {
+                                    let errmsg = format!(
+                                        "Timestamp parse error. Filepath: {},{} {}",
+                                        path,
+                                        &splunk_api_record["Event"]["System"]["SystemTime"]
+                                            .to_string()
+                                            .replace("\\\"", "")
+                                            .replace('"', ""),
+                                        e
+                                    );
+                                    if stored_static.verbose_flag {
+                                        AlertMessage::warn(&errmsg).ok();
+                                    }
+                                    if !stored_static.quiet_errors_flag {
+                                        ERROR_LOG_STACK
+                                            .lock()
+                                            .unwrap()
+                                            .push(format!("[WARN] {errmsg}"));
+                                    }
                                 }
                                 DateTime::<Utc>::default().format("%Y-%m-%dT%H:%M:%S%.fZ")
                             }


### PR DESCRIPTION
## Summary

Closes #1773. On JSON/JSONL/Splunk input, per-record timestamp-parse failures called `AlertMessage::alert`/`warn` **unconditionally** — printing regardless of `--verbose`/`--quiet-errors`, corrupting the live progress bar, and never reaching the error log.

## Fix
Gate both sites on `stored_static.verbose_flag` and push to `ERROR_LOG_STACK` when `!stored_static.quiet_errors_flag`, mirroring the EVTX path:
- `is_filtered_record` (main JSON/JSONL path)
- the Splunk-API branch of `analysis_json_file`

The control flow / return value is unchanged (the first still yields `None`, the second the default timestamp) — only *whether* it prints/logs changes.

## Verification
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --bins` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)