### PR TITLE
fix: enable git2 TLS backend so update-rules works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,12 @@ dashmap = "*"
 dialoguer = "*"
 downcast-rs = "2.*"
 evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"] , rev = "5c2bc81" } # 0.9.7 2026/04/29 update
-git2 = "0.*"
+# Enable the vendored-OpenSSL HTTPS/TLS backend for libgit2. The wildcard
+# `0.*` resolved to a build of libgit2 with no TLS transport, so `update-rules`
+# failed with `class=Ssl (16) - there is no TLS stream available`. The project
+# already vendors OpenSSL (see `openssl` below), so this just links libgit2's
+# TLS transport against it.
+git2 = { version = "0.20", features = ["https", "vendored-openssl"] }
 hashbrown = "0.17.*"
 hex = "0.4.*"
 horrorshow = "0.8.*"


### PR DESCRIPTION
Closes #1777

`update-rules` (and any HTTPS git fetch) fails with `class=Ssl (16) - there is no TLS stream available` because `git2 = "0.*"` resolves to a libgit2 build with **no TLS transport** — `libgit2-sys` isn't compiled with an OpenSSL backend.

### Fix
The project already vendors OpenSSL (`openssl = { features = ["vendored"] }`), so enabling git2's `https` + `vendored-openssl` features links libgit2's TLS transport against it:

```toml
git2 = { version = "0.20", features = ["https", "vendored-openssl"] }
```

**`Cargo.lock` is unchanged** — `openssl-sys`/`openssl-src` were already in the dependency graph via the standalone `openssl` dep; this only flips the `libgit2-sys` feature so it actually builds with them. After the change, `libgit2-sys` is compiled with `openssl-sys`.

### Verification
- `cargo build` recompiles `libgit2-sys`+`git2` with the TLS backend; `libgit2-sys` deps now include `openssl-sys`.
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, **423 lib tests pass**.
- Functional confirmation (`update-rules` over HTTPS) should be done in your environment, as with the equivalent hayabusa-pro fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)