### PR TITLE
ci: bump GitHub Pages deploy actions to Node 24 versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0   # needed for git-based "last updated" dates
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
           cache: pip
@@ -47,10 +47,10 @@ jobs:
         run: mkdocs build --strict --config-file website/mkdocs.yml
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/site
 
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

The docs deploy workflow (`.github/workflows/docs.yml`, added in #1783) uses action versions that run on Node.js 20, which GitHub is [deprecating on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runs currently succeed but emit a deprecation warning. This bumps each action to its Node 24 release:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`upload-pages-artifact@v5` also pulls in a Node 24 `actions/upload-artifact` transitively (the other action named in the warning).

No behavior change — only version bumps. Resolves the Node 20 deprecation warning on the Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)