### PR TITLE
docs: add a Licenses page to the Overview section

### DIFF
--- a/website/docs/overview/licenses.ar.md
+++ b/website/docs/overview/licenses.ar.md
@@ -1,0 +1,31 @@
+# التراخيص
+
+يُصدر Hayabusa وقواعد الكشف الخاصة به بموجب ترخيصين مختلفين.
+
+## Hayabusa (الأداة)
+
+يُصدر Hayabusa بموجب **[رخصة جنو أفيرو العمومية العامة الإصدار 3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+يوجد النص القانوني الكامل في ملف [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) داخل المستودع.
+
+## قواعد الكشف
+
+تُصدر قواعد [Sigma](https://github.com/SigmaHQ/sigma) وقواعد الكشف الخاصة بـ Hayabusa
+(المستضافة في مستودع [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+بموجب **[رخصة قاعدة الكشف (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## ماذا يعني ترخيص AGPL بالنسبة لك
+
+باختصار، **أنت حر في استخدام Hayabusa بالطريقة التي تريدها — بما في ذلك للأغراض التجارية**:
+داخليًا ضمن مؤسستك، في حلول SaaS، لأعمال الاستشارات، وعمليات الاستجابة للحوادث،
+وما إلى ذلك.
+
+يضيف ترخيص AGPL شرطًا واحدًا مهمًا: **إذا قمت بتعديل أو تحسين شيفرة Hayabusa وقدمتها
+للآخرين كخدمة** (على سبيل المثال، كجزء من عرض SaaS)، **فإننا نطلب منك أن تجعل تلك التحسينات
+مفتوحة المصدر** وأن تتيحها بموجب الترخيص نفسه.
+
+عندما تقوم بإجراء تحسينات، سنكون ممتنين جدًا لو أنك **تردّ الجميل للمشروع**
+عبر [تقديم طلب سحب (pull request)](https://github.com/Yamato-Security/hayabusa/pulls) إلى المستودع
+الأصلي (upstream) — بهذه الطريقة يستفيد المجتمع بأكمله من عملك.
+
+!!! note "بيانات أخرى"
+    يستخدم Hayabusa أيضًا بيانات GeoLite2 التي أنشأتها [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.bn.md
+++ b/website/docs/overview/licenses.bn.md
@@ -1,0 +1,30 @@
+# লাইসেন্স
+
+Hayabusa এবং এর ডিটেকশন রুলগুলো দুটি ভিন্ন লাইসেন্সের অধীনে প্রকাশ করা হয়েছে।
+
+## Hayabusa (টুলটি)
+
+Hayabusa **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** এর অধীনে প্রকাশ করা হয়েছে।
+সম্পূর্ণ আইনি পাঠ্য রিপোজিটরির [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) ফাইলে রয়েছে।
+
+## ডিটেকশন রুল
+
+[Sigma](https://github.com/SigmaHQ/sigma) রুল এবং Hayabusa ডিটেকশন রুলগুলো
+([hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) রিপোজিটরিতে হোস্ট করা)
+**[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** এর অধীনে প্রকাশ করা হয়েছে।
+
+## AGPL আপনার জন্য কী বোঝায়
+
+সংক্ষেপে, **আপনি Hayabusa যেভাবে খুশি ব্যবহার করতে স্বাধীন — বাণিজ্যিক উদ্দেশ্যেও সহ**:
+আপনার প্রতিষ্ঠানের অভ্যন্তরে, SaaS সমাধানে, পরামর্শদান কাজে, ইনসিডেন্ট রেসপন্স
+এনগেজমেন্টে, ইত্যাদি।
+
+AGPL একটি গুরুত্বপূর্ণ শর্ত যোগ করে: **যদি আপনি Hayabusa-এর কোড পরিবর্তন বা উন্নত করেন এবং তা
+অন্যদের একটি সেবা হিসেবে প্রদান করেন** (উদাহরণস্বরূপ, একটি SaaS অফারিংয়ের অংশ হিসেবে), **আমরা আপনাকে সেই উন্নতিগুলো
+ওপেন-সোর্স করতে অনুরোধ করি** এবং একই লাইসেন্সের অধীনে সেগুলো উপলব্ধ করতে।
+
+যখন আপনি উন্নতি করেন, আমরা অত্যন্ত কৃতজ্ঞ হব যদি আপনি আপস্ট্রিম
+রিপোজিটরিতে [একটি পুল রিকোয়েস্ট জমা দিয়ে](https://github.com/Yamato-Security/hayabusa/pulls) **প্রকল্পে অবদান ফিরিয়ে দেন** — সেভাবে গোটা কমিউনিটি আপনার কাজ থেকে উপকৃত হয়।
+
+!!! note "অন্যান্য ডেটা"
+    Hayabusa [MaxMind](https://www.maxmind.com) দ্বারা তৈরি GeoLite2 ডেটাও ব্যবহার করে।

--- a/website/docs/overview/licenses.de.md
+++ b/website/docs/overview/licenses.de.md
@@ -1,0 +1,31 @@
+# Lizenzen
+
+Hayabusa und seine Erkennungsregeln werden unter zwei verschiedenen Lizenzen veröffentlicht.
+
+## Hayabusa (das Werkzeug)
+
+Hayabusa wird unter der **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** veröffentlicht.
+Der vollständige Rechtstext befindet sich in der Datei [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) des Repositorys.
+
+## Erkennungsregeln
+
+Die [Sigma](https://github.com/SigmaHQ/sigma)-Regeln und die Hayabusa-Erkennungsregeln
+(gehostet im Repository [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+werden unter der **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** veröffentlicht.
+
+## Was die AGPL für Sie bedeutet
+
+Kurz gesagt: **Es steht Ihnen frei, Hayabusa nach Belieben zu verwenden — auch für kommerzielle Zwecke**:
+intern innerhalb Ihrer Organisation, in SaaS-Lösungen, für Beratungstätigkeiten, Einsätze zur
+Reaktion auf Sicherheitsvorfälle und so weiter.
+
+Die AGPL fügt eine wichtige Bedingung hinzu: **Wenn Sie den Code von Hayabusa verändern oder verbessern und ihn
+anderen als Dienst bereitstellen** (zum Beispiel als Teil eines SaaS-Angebots), **bitten wir Sie, diese
+Verbesserungen als Open Source zu veröffentlichen** und unter derselben Lizenz verfügbar zu machen.
+
+Wenn Sie Verbesserungen vornehmen, würden wir uns sehr freuen, wenn Sie **etwas an das Projekt zurückgeben**
+würden, indem Sie [einen Pull Request einreichen](https://github.com/Yamato-Security/hayabusa/pulls) an das
+Upstream-Repository — auf diese Weise profitiert die gesamte Community von Ihrer Arbeit.
+
+!!! note "Weitere Daten"
+    Hayabusa verwendet außerdem GeoLite2-Daten, die von [MaxMind](https://www.maxmind.com) erstellt wurden.

--- a/website/docs/overview/licenses.es.md
+++ b/website/docs/overview/licenses.es.md
@@ -1,0 +1,31 @@
+# Licencias
+
+Hayabusa y sus reglas de detección se publican bajo dos licencias diferentes.
+
+## Hayabusa (la herramienta)
+
+Hayabusa se publica bajo la **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+El texto legal completo se encuentra en el archivo [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) del repositorio.
+
+## Reglas de detección
+
+Las reglas de [Sigma](https://github.com/SigmaHQ/sigma) y las reglas de detección de Hayabusa
+(alojadas en el repositorio [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+se publican bajo la **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## Lo que la AGPL significa para ti
+
+En resumen, **eres libre de usar Hayabusa como quieras, incluso con fines comerciales**:
+de forma interna dentro de tu organización, en soluciones SaaS, para trabajos de consultoría, tareas de
+respuesta a incidentes, etc.
+
+La AGPL añade una condición importante: **si modificas o mejoras el código de Hayabusa y lo proporcionas
+a otros como un servicio** (por ejemplo, como parte de una oferta SaaS), **te pedimos que liberes como código abierto
+esas mejoras** y las pongas a disposición bajo la misma licencia.
+
+Cuando realices mejoras, te agradeceríamos enormemente que **contribuyeras de vuelta al proyecto**
+[enviando una pull request](https://github.com/Yamato-Security/hayabusa/pulls) al repositorio
+original (upstream), de modo que toda la comunidad se beneficie de tu trabajo.
+
+!!! note "Otros datos"
+    Hayabusa también utiliza datos de GeoLite2 creados por [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.fr.md
+++ b/website/docs/overview/licenses.fr.md
@@ -1,0 +1,31 @@
+# Licences
+
+Hayabusa et ses règles de détection sont publiés sous deux licences différentes.
+
+## Hayabusa (l'outil)
+
+Hayabusa est publié sous la **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+Le texte juridique complet se trouve dans le fichier [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) du dépôt.
+
+## Règles de détection
+
+Les règles [Sigma](https://github.com/SigmaHQ/sigma) et les règles de détection Hayabusa
+(hébergées dans le dépôt [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+sont publiées sous la **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## Ce que l'AGPL signifie pour vous
+
+En résumé, **vous êtes libre d'utiliser Hayabusa comme bon vous semble — y compris à des fins commerciales** :
+en interne au sein de votre organisation, dans des solutions SaaS, pour des missions de conseil, des
+interventions de réponse aux incidents, et ainsi de suite.
+
+L'AGPL ajoute une condition importante : **si vous modifiez ou améliorez le code de Hayabusa et que vous le fournissez
+à autrui sous forme de service** (par exemple, dans le cadre d'une offre SaaS), **nous vous demandons d'ouvrir le code source
+de ces améliorations** et de les rendre disponibles sous la même licence.
+
+Lorsque vous apportez des améliorations, nous vous serions très reconnaissants de **redonner au projet**
+en [soumettant une pull request](https://github.com/Yamato-Security/hayabusa/pulls) au dépôt
+amont — de cette manière, toute la communauté bénéficie de votre travail.
+
+!!! note "Autres données"
+    Hayabusa utilise également les données GeoLite2 créées par [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.hi.md
+++ b/website/docs/overview/licenses.hi.md
@@ -1,0 +1,31 @@
+# लाइसेंस
+
+Hayabusa और इसके डिटेक्शन नियम दो अलग-अलग लाइसेंस के अंतर्गत जारी किए जाते हैं।
+
+## Hayabusa (टूल)
+
+Hayabusa को **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** के अंतर्गत जारी किया गया है।
+पूरा कानूनी पाठ रिपॉज़िटरी की [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) फ़ाइल में है।
+
+## डिटेक्शन नियम
+
+[Sigma](https://github.com/SigmaHQ/sigma) नियम और Hayabusa डिटेक्शन नियम
+([hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) रिपॉज़िटरी में होस्ट किए गए)
+**[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** के अंतर्गत जारी किए जाते हैं।
+
+## AGPL का आपके लिए क्या अर्थ है
+
+संक्षेप में, **आप Hayabusa का उपयोग जैसे चाहें वैसे करने के लिए स्वतंत्र हैं — व्यावसायिक उद्देश्यों सहित**:
+अपने संगठन के भीतर आंतरिक रूप से, SaaS समाधानों में, परामर्श कार्य के लिए, घटना प्रतिक्रिया
+कार्यों के लिए, इत्यादि।
+
+AGPL एक महत्वपूर्ण शर्त जोड़ता है: **यदि आप Hayabusa के कोड को संशोधित या बेहतर बनाते हैं और उसे
+किसी सेवा के रूप में दूसरों को प्रदान करते हैं** (उदाहरण के लिए, किसी SaaS पेशकश के भाग के रूप में), **तो हम आपसे
+उन सुधारों को ओपन-सोर्स करने** और उन्हें उसी लाइसेंस के अंतर्गत उपलब्ध कराने का अनुरोध करते हैं।
+
+जब आप सुधार करते हैं, तो हम बहुत आभारी होंगे यदि आप अपस्ट्रीम रिपॉज़िटरी में
+[एक पुल रिक्वेस्ट सबमिट करके](https://github.com/Yamato-Security/hayabusa/pulls) **परियोजना को वापस योगदान दें**
+— इस तरह पूरे समुदाय को आपके काम से लाभ होता है।
+
+!!! note "अन्य डेटा"
+    Hayabusa [MaxMind](https://www.maxmind.com) द्वारा बनाए गए GeoLite2 डेटा का भी उपयोग करता है।

--- a/website/docs/overview/licenses.ja.md
+++ b/website/docs/overview/licenses.ja.md
@@ -1,0 +1,31 @@
+# ライセンス
+
+Hayabusa とその検知ルールは、それぞれ異なるライセンスで公開されています。
+
+## Hayabusa（ツール本体）
+
+Hayabusa は **[GNU Affero 一般公衆利用許諾書 v3.0（AGPLv3）](https://www.gnu.org/licenses/agpl-3.0.en.html)** の下で公開されています。
+完全な法的条文は、レポジトリの [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) ファイルをご覧ください。
+
+## 検知ルール
+
+[Sigma](https://github.com/SigmaHQ/sigma) ルール、および Hayabusa の検知ルール
+（[hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) レポジトリで管理）は、
+**[Detection Rule License（DRL）1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** の下で公開されています。
+
+## AGPL が意味すること
+
+簡単に言えば、**Hayabusa は商用利用を含め、自由にご利用いただけます**。
+組織内での利用、SaaS ソリューションへの組み込み、コンサルティング業務、インシデントレスポンス
+対応など、用途を問いません。
+
+ただし、AGPL には一つ重要な条件があります。**Hayabusa のコードを改変・改良し、それをサービスとして
+他者に提供する場合**（例えば SaaS の一部として提供する場合）、**その改良点をオープンソースとして公開**し、
+同じライセンスの下で利用できるようにすることをお願いしています。
+
+改良を行った際は、ぜひ [プルリクエストを送信](https://github.com/Yamato-Security/hayabusa/pulls) して
+アップストリームのレポジトリに **還元** していただけると大変ありがたく思います。そうすることで、
+コミュニティ全体があなたの成果から恩恵を受けられます。
+
+!!! note "その他のデータ"
+    Hayabusa は [MaxMind](https://www.maxmind.com) が作成した GeoLite2 データも利用しています。

--- a/website/docs/overview/licenses.ko.md
+++ b/website/docs/overview/licenses.ko.md
@@ -1,0 +1,31 @@
+# 라이선스
+
+Hayabusa와 그 탐지 규칙은 서로 다른 두 가지 라이선스로 배포됩니다.
+
+## Hayabusa (도구)
+
+Hayabusa는 **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**로 배포됩니다.
+전체 법률 원문은 저장소의 [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) 파일에 있습니다.
+
+## 탐지 규칙
+
+[Sigma](https://github.com/SigmaHQ/sigma) 규칙과 Hayabusa 탐지 규칙
+([hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) 저장소에서 호스팅됨)은
+**[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**로 배포됩니다.
+
+## AGPL이 여러분에게 의미하는 것
+
+간단히 말해, **여러분은 상업적 목적을 포함하여 원하는 방식으로 자유롭게 Hayabusa를 사용할 수 있습니다**:
+조직 내부에서, SaaS 솔루션에서, 컨설팅 업무에서, 사고 대응
+업무 등에서 사용할 수 있습니다.
+
+AGPL은 한 가지 중요한 조건을 추가합니다: **여러분이 Hayabusa의 코드를 수정하거나 개선하여 이를
+다른 사람에게 서비스로 제공하는 경우**(예: SaaS 제공의 일부로), **그러한 개선 사항을 오픈소스로 공개하고**
+동일한 라이선스로 제공해 주실 것을 요청드립니다.
+
+개선 사항을 만드실 때, 업스트림 저장소에 [풀 리퀘스트를 제출](https://github.com/Yamato-Security/hayabusa/pulls)하여
+**프로젝트에 기여**해 주신다면 대단히 감사하겠습니다 — 그렇게 하면 커뮤니티 전체가 여러분의
+작업으로부터 혜택을 받게 됩니다.
+
+!!! note "기타 데이터"
+    Hayabusa는 [MaxMind](https://www.maxmind.com)가 만든 GeoLite2 데이터도 사용합니다.

--- a/website/docs/overview/licenses.md
+++ b/website/docs/overview/licenses.md
@@ -1,0 +1,31 @@
+# Licenses
+
+Hayabusa and its detection rules are released under two different licenses.
+
+## Hayabusa (the tool)
+
+Hayabusa is released under the **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+The full legal text is in the [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) file of the repository.
+
+## Detection rules
+
+The [Sigma](https://github.com/SigmaHQ/sigma) rules and the Hayabusa detection rules
+(hosted in the [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) repository)
+are released under the **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## What the AGPL means for you
+
+In short, **you are free to use Hayabusa however you like — including for commercial purposes**:
+internally within your organization, in SaaS solutions, for consulting work, incident response
+engagements, and so on.
+
+The AGPL adds one important condition: **if you modify or improve Hayabusa's code and provide it
+to others as a service** (for example, as part of a SaaS offering), **we ask you to open-source
+those improvements** and make them available under the same license.
+
+When you do make improvements, we'd greatly appreciate it if you would **give back to the project**
+by [submitting a pull request](https://github.com/Yamato-Security/hayabusa/pulls) to the upstream
+repository — that way the whole community benefits from your work.
+
+!!! note "Other data"
+    Hayabusa also uses GeoLite2 data created by [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.my.md
+++ b/website/docs/overview/licenses.my.md
@@ -1,0 +1,30 @@
+# လိုင်စင်များ
+
+Hayabusa နှင့် ၎င်း၏ detection rule များကို မတူညီသော လိုင်စင်နှစ်မျိုးအောက်တွင် ထုတ်ဝေထားသည်။
+
+## Hayabusa (tool)
+
+Hayabusa ကို **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** အောက်တွင် ထုတ်ဝေထားသည်။
+ဥပဒေဆိုင်ရာ စာသားအပြည့်အစုံကို repository ၏ [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) ဖိုင်တွင် တွေ့ရှိနိုင်သည်။
+
+## Detection rule များ
+
+[Sigma](https://github.com/SigmaHQ/sigma) rule များနှင့် Hayabusa detection rule များ
+([hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) repository တွင် သိမ်းဆည်းထားသည်) ကို
+**[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** အောက်တွင် ထုတ်ဝေထားသည်။
+
+## AGPL သည် သင့်အတွက် ဘာကိုဆိုလိုသနည်း
+
+အတိုချုပ်အားဖြင့်၊ **သင်သည် Hayabusa ကို သင်နှစ်သက်သလို — စီးပွားရေးရည်ရွယ်ချက်များအပါအဝင် — အသုံးပြုနိုင်ပါသည်**။
+သင့်အဖွဲ့အစည်းအတွင်း၌ ဖြစ်စေ၊ SaaS solution များတွင်ဖြစ်စေ၊ အကြံပေးလုပ်ငန်းများအတွက်ဖြစ်စေ၊ incident response
+ဆောင်ရွက်မှုများအတွက်ဖြစ်စေ၊ စသည်ဖြင့် အသုံးပြုနိုင်ပါသည်။
+
+AGPL သည် အရေးကြီးသော အခြေအနေတစ်ခုကို ထပ်ဆောင်းထားသည်။ **အကယ်၍ သင်သည် Hayabusa ၏ code ကို ပြုပြင်မွမ်းမံ သို့မဟုတ် တိုးတက်အောင်ပြုလုပ်ပြီး
+အခြားသူများအား ဝန်ဆောင်မှုအဖြစ် ပေးအပ်ပါက** (ဥပမာ၊ SaaS ဝန်ဆောင်မှုတစ်ခု၏ အစိတ်အပိုင်းအဖြစ်)၊ **ထိုတိုးတက်မှုများကို
+open-source ပြုလုပ်ရန်** နှင့် တူညီသော လိုင်စင်အောက်တွင် ရရှိနိုင်အောင် ပြုလုပ်ပေးရန် ကျွန်ုပ်တို့ တောင်းဆိုပါသည်။
+
+သင်တိုးတက်မှုများ ပြုလုပ်သောအခါ၊ upstream repository သို့ [pull request တင်သွင်း](https://github.com/Yamato-Security/hayabusa/pulls)ခြင်းဖြင့်
+**ဤ project သို့ ပြန်လည်ပံ့ပိုးပေး**ပါက ကျွန်ုပ်တို့ အလွန်ကျေးဇူးတင်ပါမည် — ထိုသို့ဖြင့် community တစ်ခုလုံးသည် သင်၏လုပ်ဆောင်ချက်မှ အကျိုးကျေးဇူး ရရှိမည်ဖြစ်သည်။
+
+!!! note "အခြားဒေတာ"
+    Hayabusa သည် [MaxMind](https://www.maxmind.com) မှ ဖန်တီးထားသော GeoLite2 ဒေတာကိုလည်း အသုံးပြုပါသည်။

--- a/website/docs/overview/licenses.pt-BR.md
+++ b/website/docs/overview/licenses.pt-BR.md
@@ -1,0 +1,31 @@
+# Licenças
+
+O Hayabusa e suas regras de detecção são distribuídos sob duas licenças diferentes.
+
+## Hayabusa (a ferramenta)
+
+O Hayabusa é distribuído sob a **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+O texto legal completo está no arquivo [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) do repositório.
+
+## Regras de detecção
+
+As regras do [Sigma](https://github.com/SigmaHQ/sigma) e as regras de detecção do Hayabusa
+(hospedadas no repositório [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+são distribuídas sob a **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## O que a AGPL significa para você
+
+Em resumo, **você é livre para usar o Hayabusa como quiser — inclusive para fins comerciais**:
+internamente na sua organização, em soluções SaaS, em trabalhos de consultoria, em atividades
+de resposta a incidentes e assim por diante.
+
+A AGPL acrescenta uma condição importante: **se você modificar ou melhorar o código do Hayabusa e o fornecer
+a terceiros como um serviço** (por exemplo, como parte de uma oferta SaaS), **pedimos que você disponibilize
+essas melhorias em código aberto** e as torne disponíveis sob a mesma licença.
+
+Quando você fizer melhorias, ficaríamos muito gratos se você **retribuísse ao projeto**
+[enviando um pull request](https://github.com/Yamato-Security/hayabusa/pulls) para o
+repositório upstream — assim toda a comunidade se beneficia do seu trabalho.
+
+!!! note "Outros dados"
+    O Hayabusa também usa dados do GeoLite2 criados pela [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.th.md
+++ b/website/docs/overview/licenses.th.md
@@ -1,0 +1,31 @@
+# สัญญาอนุญาต
+
+Hayabusa และกฎการตรวจจับของมันถูกเผยแพร่ภายใต้สัญญาอนุญาตที่แตกต่างกันสองแบบ
+
+## Hayabusa (ตัวเครื่องมือ)
+
+Hayabusa ถูกเผยแพร่ภายใต้ **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**
+ข้อความทางกฎหมายฉบับเต็มอยู่ในไฟล์ [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) ของที่เก็บข้อมูล (repository)
+
+## กฎการตรวจจับ
+
+กฎ [Sigma](https://github.com/SigmaHQ/sigma) และกฎการตรวจจับของ Hayabusa
+(ซึ่งโฮสต์อยู่ในที่เก็บข้อมูล [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+ถูกเผยแพร่ภายใต้ **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**
+
+## AGPL มีความหมายอย่างไรต่อคุณ
+
+โดยสรุปแล้ว **คุณมีอิสระที่จะใช้ Hayabusa ได้ตามที่คุณต้องการ — รวมถึงเพื่อวัตถุประสงค์ทางการค้าด้วย**:
+ภายในองค์กรของคุณ ในโซลูชัน SaaS สำหรับงานที่ปรึกษา การปฏิบัติงานตอบสนองต่อเหตุการณ์ (incident response)
+และอื่น ๆ
+
+AGPL เพิ่มเงื่อนไขสำคัญหนึ่งข้อ: **หากคุณแก้ไขหรือปรับปรุงโค้ดของ Hayabusa และมอบให้
+ผู้อื่นในรูปแบบบริการ** (ตัวอย่างเช่น เป็นส่วนหนึ่งของบริการแบบ SaaS) **เราขอให้คุณเปิดเผยซอร์สโค้ด
+ของการปรับปรุงเหล่านั้น** และทำให้สามารถใช้งานได้ภายใต้สัญญาอนุญาตเดียวกัน
+
+เมื่อคุณทำการปรับปรุง เราจะรู้สึกซาบซึ้งเป็นอย่างยิ่งหากคุณจะ **ตอบแทนโครงการ**
+ด้วยการ [ส่ง pull request](https://github.com/Yamato-Security/hayabusa/pulls) ไปยังที่เก็บข้อมูลต้นทาง (upstream)
+— ด้วยวิธีนี้ ชุมชนทั้งหมดจะได้รับประโยชน์จากงานของคุณ
+
+!!! note "ข้อมูลอื่น ๆ"
+    Hayabusa ยังใช้ข้อมูล GeoLite2 ที่สร้างขึ้นโดย [MaxMind](https://www.maxmind.com) ด้วย

--- a/website/docs/overview/licenses.tr.md
+++ b/website/docs/overview/licenses.tr.md
@@ -1,0 +1,31 @@
+# Lisanslar
+
+Hayabusa ve tespit kuralları iki farklı lisans altında yayımlanmıştır.
+
+## Hayabusa (araç)
+
+Hayabusa, **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** altında yayımlanmıştır.
+Tam yasal metin, deponun [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) dosyasında bulunur.
+
+## Tespit kuralları
+
+[Sigma](https://github.com/SigmaHQ/sigma) kuralları ve Hayabusa tespit kuralları
+([hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) deposunda barındırılır)
+**[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** altında yayımlanmıştır.
+
+## AGPL'nin sizin için anlamı
+
+Kısacası, **Hayabusa'yı istediğiniz gibi kullanmakta özgürsünüz — ticari amaçlar dahil**:
+kuruluşunuz içinde dahili olarak, SaaS çözümlerinde, danışmanlık işlerinde, olay müdahalesi
+çalışmalarında ve benzeri durumlarda.
+
+AGPL önemli bir koşul ekler: **Hayabusa'nın kodunu değiştirir veya geliştirir ve bunu
+başkalarına bir hizmet olarak sunarsanız** (örneğin, bir SaaS teklifinin parçası olarak), **bu
+geliştirmeleri açık kaynaklı hale getirmenizi** ve aynı lisans altında kullanılabilir kılmanızı rica ederiz.
+
+Geliştirmeler yaptığınızda, üst akış deposuna [bir çekme isteği (pull request) göndererek](https://github.com/Yamato-Security/hayabusa/pulls)
+**projeye katkıda bulunursanız** çok memnun oluruz — bu sayede tüm topluluk çalışmanızdan
+yararlanır.
+
+!!! note "Diğer veriler"
+    Hayabusa ayrıca [MaxMind](https://www.maxmind.com) tarafından oluşturulan GeoLite2 verilerini kullanır.

--- a/website/docs/overview/licenses.uk.md
+++ b/website/docs/overview/licenses.uk.md
@@ -1,0 +1,31 @@
+# Ліцензії
+
+Hayabusa та її правила виявлення випускаються за двома різними ліцензіями.
+
+## Hayabusa (інструмент)
+
+Hayabusa випускається за ліцензією **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)**.
+Повний юридичний текст міститься у файлі [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) репозиторію.
+
+## Правила виявлення
+
+Правила [Sigma](https://github.com/SigmaHQ/sigma) та правила виявлення Hayabusa
+(розміщені в репозиторії [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules))
+випускаються за ліцензією **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
+
+## Що AGPL означає для вас
+
+Коротко кажучи, **ви вільні використовувати Hayabusa як завгодно — зокрема й у комерційних цілях**:
+всередині вашої організації, у SaaS-рішеннях, для консалтингової роботи, заходів з реагування на інциденти
+тощо.
+
+AGPL додає одну важливу умову: **якщо ви змінюєте чи покращуєте код Hayabusa та надаєте його
+іншим як послугу** (наприклад, у складі SaaS-пропозиції), **ми просимо вас опублікувати з відкритим кодом
+ці покращення** та зробити їх доступними за тією самою ліцензією.
+
+Коли ви робите покращення, ми були б дуже вдячні, якби ви **зробили внесок у проєкт**,
+[надіславши pull request](https://github.com/Yamato-Security/hayabusa/pulls) до основного
+репозиторію — таким чином уся спільнота отримає користь від вашої роботи.
+
+!!! note "Інші дані"
+    Hayabusa також використовує дані GeoLite2, створені [MaxMind](https://www.maxmind.com).

--- a/website/docs/overview/licenses.zh-TW.md
+++ b/website/docs/overview/licenses.zh-TW.md
@@ -1,0 +1,30 @@
+# 授權條款
+
+Hayabusa 及其偵測規則以兩種不同的授權條款發布。
+
+## Hayabusa（工具本體）
+
+Hayabusa 以 **[GNU Affero General Public License v3.0 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.en.html)** 發布。
+完整的法律條文位於儲存庫中的 [`LICENSE.txt`](https://github.com/Yamato-Security/hayabusa/blob/main/LICENSE.txt) 檔案。
+
+## 偵測規則
+
+[Sigma](https://github.com/SigmaHQ/sigma) 規則以及 Hayabusa 偵測規則
+（存放於 [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) 儲存庫）
+以 **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)** 發布。
+
+## AGPL 對您的意義
+
+簡而言之，**您可以自由地以任何方式使用 Hayabusa——包括用於商業目的**：
+在您的組織內部使用、用於 SaaS 解決方案、用於顧問工作、事件回應
+專案等等。
+
+AGPL 增加了一項重要的條件：**如果您修改或改進了 Hayabusa 的程式碼，並以服務的形式提供
+給他人**（例如，作為 SaaS 服務的一部分），**我們請您將這些改進開放原始碼**，
+並以相同的授權條款提供。
+
+當您進行改進時，如果您願意透過[提交 pull request](https://github.com/Yamato-Security/hayabusa/pulls) 到上游
+儲存庫來**回饋這個專案**，我們將會非常感激——這樣一來整個社群都能從您的成果中受益。
+
+!!! note "其他資料"
+    Hayabusa 也使用了由 [MaxMind](https://www.maxmind.com) 所建立的 GeoLite2 資料。

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -136,6 +136,7 @@ plugins:
             Main Goals: 主な目的
             Features: 特徴・機能
             Screenshots: スクリーンショット
+            Licenses: ライセンス
             Getting Started: はじめに
             Downloads: ダウンロード
             Git Cloning: Gitクローン
@@ -178,6 +179,7 @@ plugins:
             "Main Goals": "主要目標"
             "Features": "功能特色"
             "Screenshots": "螢幕擷圖"
+            "Licenses": "授權條款"
             "Getting Started": "開始使用"
             "Downloads": "下載"
             "Git Cloning": "Git 複製"
@@ -220,6 +222,7 @@ plugins:
             "Main Goals": "주요 목표"
             "Features": "기능"
             "Screenshots": "스크린샷"
+            "Licenses": "라이선스"
             "Getting Started": "시작하기"
             "Downloads": "다운로드"
             "Git Cloning": "Git 클론"
@@ -262,6 +265,7 @@ plugins:
             "Main Goals": "Hauptziele"
             "Features": "Funktionen"
             "Screenshots": "Screenshots"
+            "Licenses": "Lizenzen"
             "Getting Started": "Erste Schritte"
             "Downloads": "Downloads"
             "Git Cloning": "Git-Klonen"
@@ -304,6 +308,7 @@ plugins:
             "Main Goals": "Ana Hedefler"
             "Features": "Özellikler"
             "Screenshots": "Ekran Görüntüleri"
+            "Licenses": "Lisanslar"
             "Getting Started": "Başlarken"
             "Downloads": "İndirmeler"
             "Git Cloning": "Git ile Klonlama"
@@ -346,6 +351,7 @@ plugins:
             "Main Goals": "Objectifs principaux"
             "Features": "Fonctionnalités"
             "Screenshots": "Captures d'écran"
+            "Licenses": "Licences"
             "Getting Started": "Premiers pas"
             "Downloads": "Téléchargements"
             "Git Cloning": "Clonage Git"
@@ -388,6 +394,7 @@ plugins:
             "Main Goals": "Objetivos principales"
             "Features": "Características"
             "Screenshots": "Capturas de pantalla"
+            "Licenses": "Licencias"
             "Getting Started": "Primeros pasos"
             "Downloads": "Descargas"
             "Git Cloning": "Clonación con Git"
@@ -430,6 +437,7 @@ plugins:
             "Main Goals": "Principais objetivos"
             "Features": "Funcionalidades"
             "Screenshots": "Capturas de tela"
+            "Licenses": "Licenças"
             "Getting Started": "Primeiros passos"
             "Downloads": "Downloads"
             "Git Cloning": "Clonagem com Git"
@@ -472,6 +480,7 @@ plugins:
             "Main Goals": "Основні цілі"
             "Features": "Можливості"
             "Screenshots": "Знімки екрана"
+            "Licenses": "Ліцензії"
             "Getting Started": "Початок роботи"
             "Downloads": "Завантаження"
             "Git Cloning": "Клонування Git"
@@ -514,6 +523,7 @@ plugins:
             "Main Goals": "मुख्य लक्ष्य"
             "Features": "विशेषताएँ"
             "Screenshots": "स्क्रीनशॉट"
+            "Licenses": "लाइसेंस"
             "Getting Started": "शुरुआत करना"
             "Downloads": "डाउनलोड"
             "Git Cloning": "Git क्लोनिंग"
@@ -556,6 +566,7 @@ plugins:
             "Main Goals": "মূল লক্ষ্যসমূহ"
             "Features": "বৈশিষ্ট্যসমূহ"
             "Screenshots": "স্ক্রিনশট"
+            "Licenses": "লাইসেন্স"
             "Getting Started": "শুরু করা"
             "Downloads": "ডাউনলোড"
             "Git Cloning": "Git ক্লোনিং"
@@ -598,6 +609,7 @@ plugins:
             "Main Goals": "အဓိကရည်မှန်းချက်များ"
             "Features": "အင်္ဂါရပ်များ"
             "Screenshots": "ဖန်သားပြင်ဓာတ်ပုံများ"
+            "Licenses": "လိုင်စင်များ"
             "Getting Started": "စတင်အသုံးပြုခြင်း"
             "Downloads": "ဒေါင်းလုဒ်များ"
             "Git Cloning": "Git Cloning ပြုလုပ်ခြင်း"
@@ -640,6 +652,7 @@ plugins:
             "Main Goals": "เป้าหมายหลัก"
             "Features": "คุณสมบัติ"
             "Screenshots": "ภาพหน้าจอ"
+            "Licenses": "สัญญาอนุญาต"
             "Getting Started": "เริ่มต้นใช้งาน"
             "Downloads": "ดาวน์โหลด"
             "Git Cloning": "การโคลนด้วย Git"
@@ -682,6 +695,7 @@ plugins:
             "Main Goals": "الأهداف الرئيسية"
             "Features": "الميزات"
             "Screenshots": "لقطات الشاشة"
+            "Licenses": "التراخيص"
             "Getting Started": "البدء"
             "Downloads": "التنزيلات"
             "Git Cloning": "الاستنساخ عبر Git"
@@ -734,6 +748,7 @@ nav:
       - Main Goals: overview/main-goals.md
       - Features: overview/features.md
       - Screenshots: overview/screenshots.md
+      - Licenses: overview/licenses.md
   - Getting Started:
       - Downloads: getting-started/index.md
       - Git Cloning: getting-started/git-cloning.md


### PR DESCRIPTION
## Summary

Adds a dedicated **Licenses** page under the Overview section of the docs site.

It explains:

- **Hayabusa (the tool)** is released under the **[GNU AGPLv3](https://www.gnu.org/licenses/agpl-3.0.en.html)** (with a link to `LICENSE.txt`).
- The **[Sigma](https://github.com/SigmaHQ/sigma) rules and the Hayabusa detection rules** are released under the **[Detection Rule License (DRL) 1.1](https://github.com/SigmaHQ/sigma/blob/master/LICENSE.Detection.Rules.md)**.
- **What the AGPL means in practice:** you're free to use Hayabusa for any purpose including commercial use, but if you modify the code and provide it to others as a service, you're asked to open-source those improvements — and preferably contribute them back via a [pull request](https://github.com/Yamato-Security/hayabusa/pulls) to the upstream repo.
- A small note that Hayabusa uses GeoLite2 data from MaxMind.

## Details

- Page authored in **English** and **Japanese**; machine-translated into the other 13 languages (license/proper-noun names and all canonical links preserved, so the authoritative license text is always one click away).
- Adds the Overview nav entry and a localized **"Licenses"** sidebar label for every language.
- Builds clean with `mkdocs build --strict` (0 warnings); verified the AGPL/DRL links and the admonition render, and the nav label is localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)