### PR TITLE
docs: remove Discord icon from the documentation footer

### DIFF
--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -737,9 +737,6 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/SecurityYamato
       name: Yamato Security on X
-    - icon: fontawesome/brands/discord
-      link: https://discord.gg/P8tkqGnNvk
-      name: Yamato Security Discord
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

The documentation site footer included a Discord social icon, but there is no Yamato Security Discord server. This removes the Discord entry from `extra.social` in `mkdocs.yml`. The GitHub and X (Twitter) icons remain.

Builds clean with `mkdocs build --strict` (0 warnings); verified no Discord icon in the rendered footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)