### PR TITLE
docs: fix broken Hayabusa logo on non-English homepages

### DIFF
--- a/website/docs/index.ar.md
+++ b/website/docs/index.ar.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> هي أداة <strong>توليد سريع للخط الزمني للتحليل الجنائي</strong> لسجلات أحداث Windows

--- a/website/docs/index.de.md
+++ b/website/docs/index.de.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> ist ein <strong>schneller forensischer Timeline-Generator</strong> für Windows-Ereignisprotokolle

--- a/website/docs/index.es.md
+++ b/website/docs/index.es.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> es un <strong>generador rápido de líneas de tiempo forenses</strong> de registros de eventos de Windows

--- a/website/docs/index.fr.md
+++ b/website/docs/index.fr.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> est un <strong>générateur rapide de chronologies forensiques</strong>

--- a/website/docs/index.hi.md
+++ b/website/docs/index.hi.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> एक Windows इवेंट लॉग <strong>fast forensics timeline generator</strong>

--- a/website/docs/index.id.md
+++ b/website/docs/index.id.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> adalah <strong>generator linimasa forensik cepat</strong> untuk log peristiwa Windows

--- a/website/docs/index.ja.md
+++ b/website/docs/index.ja.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong>（隼）は、日本の<a href="https://yamatosecurity.connpass.com/">Yamato Security</a>

--- a/website/docs/index.ko.md
+++ b/website/docs/index.ko.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong>는 <a href="https://yamatosecurity.connpass.com/">Yamato Security</a>가 만든

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> is a Windows event log <strong>fast forensics timeline generator</strong>

--- a/website/docs/index.my.md
+++ b/website/docs/index.my.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> သည် <a href="https://yamatosecurity.connpass.com/">Yamato Security</a> မှ ဖန်တီးထားသော Windows event log

--- a/website/docs/index.pt-BR.md
+++ b/website/docs/index.pt-BR.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 O <strong>Hayabusa</strong> é um <strong>gerador rápido de linha do tempo forense</strong> de registros de eventos do Windows

--- a/website/docs/index.th.md
+++ b/website/docs/index.th.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> เป็น <strong>เครื่องมือสร้างไทม์ไลน์นิติวิทยาศาสตร์อย่างรวดเร็ว</strong>

--- a/website/docs/index.tr.md
+++ b/website/docs/index.tr.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong>, <a href="https://yamatosecurity.connpass.com/">Yamato Security</a> tarafından oluşturulmuş bir Windows olay günlüğü <strong>hızlı adli zaman çizelgesi oluşturucu</strong>

--- a/website/docs/index.uk.md
+++ b/website/docs/index.uk.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> — це <strong>швидкий генератор криміналістичних таймлайнів</strong>

--- a/website/docs/index.zh-TW.md
+++ b/website/docs/index.zh-TW.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="hb-hero" markdown>
 
-<img class="hb-logo" alt="Hayabusa" src="assets/logo.png" />
+![Hayabusa](assets/logo.png){ .hb-logo }
 
 <p class="hb-tagline">
 <strong>Hayabusa</strong> 是一款 Windows 事件記錄檔的<strong>快速鑑識時間軸產生器</strong>


### PR DESCRIPTION
## Summary

The Hayabusa logo was broken on every homepage **except English**.

**Cause:** the hero used a raw HTML tag — `<img class="hb-logo" src="assets/logo.png">`. MkDocs only rewrites relative paths inside *Markdown* image syntax, not raw HTML attributes. So on translated homepages (served from `/ja/`, `/zh-TW/`, …) the `assets/logo.png` path resolved to `/<locale>/assets/logo.png`, which doesn't exist. (The same applied to the glightbox `href` it generated.)

**Fix:** use a Markdown image instead — `![Hayabusa](assets/logo.png){ .hb-logo }`. MkDocs rewrites it per page location (e.g. `../assets/logo.png` under `/ja/`), so both the `<img src>` and the glightbox `href` resolve correctly. The `.hb-logo` class (and its styling) is preserved via `attr_list`.

Applied to all **15 homepages** (`index.md` + 14 locales). Builds clean with `mkdocs build --strict` (0 warnings); verified the logo resolves to the correct path on EN and JA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)