### PR TITLE
docs: add a Changelog page to the Overview section

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r website/requirements.txt
 
+      - name: Sync changelog into docs
+        run: python website/scripts/sync_changelog.py
+
       - name: Build site (strict)
         run: mkdocs build --strict --config-file website/mkdocs.yml
 

--- a/website/docs/overview/changelog.ja.md
+++ b/website/docs/overview/changelog.ja.md
@@ -1,0 +1,1048 @@
+# 変更履歴
+
+!!! info "情報"
+    このページはプロジェクトの [`CHANGELOG.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG-Japanese.md) を反映したものです。ダウンロードは [リリースページ](https://github.com/Yamato-Security/hayabusa/releases) をご覧ください。
+
+## x.x.x
+
+**改善:**
+
+検出されたMITRE ATT&CK戦術について、一意の件数と合計件数を追加した。 (#1753) (@fukusuket)
+
+**バグ修正:**
+
+- MITRE ATT&CK Tacticsの項目が、HTMLレポートで適切に改行されていなかった。 (#1751) (@fukusuket)
+- 大量のファイルをスキャンする際に、スキャンのプログレスバーがその場で再描画されず、更新ごとに新しい行に表示される問題を修正した。プログレスバーのテンプレートにリテラルの改行コード（`\r\n`）が含まれていたことが原因。 (#1760) (@YamatoSecurity)
+
+## 3.9.0 [2026/04/29]
+
+**改善:**
+
+MITRE ATT&CK v19に対応した。(@fukusuket)
+
+**その他:**
+
+ユニットテストの追加。 (#1746) (@Fuzzdkk)
+
+## 3.8.1 [2026/02/24] - Spring Hayfever Release
+
+**バグ修正:**
+
+複数のプログレスバーの問題を修正した。 (#1740) (@fukusuket)
+
+## 3.8.0 [2026/01/31] - Winter Release
+
+**バグ修正:**
+
+- MaxMindのコンパイルエラーを直した。 (#1722) (@fukusuket)
+- `-GeoIP`が指定された場合、GeoIPフィールドはJSONタイムラインの`Details`と`ExtraFieldInfo`の両方に出力されていた。 (#1724) (@fukusuket)
+- 破損したログによるパニックの可能性を修正した。 (#1732) (@fukusuket)
+
+**脆弱性修正:**
+
+- HTMLレポートにおけるXSS脆弱性を修正した。ユーザが（標準の`.evtx`ファイルではなく）JSON形式でエクスポートされたログをスキャンし、攻撃者がそれらのログの`Computer`フィールドに悪意のあるJavaScriptを注入できる場合に発生する問題。 (@fukusuket)
+  - この問題を発見し報告してくれた[Mobasi](https://mobasi.ai/)チームに深く感謝します！
+
+## 3.7.0 [2025/11/15] - CODE BLUE Release
+
+**新機能:**
+
+- `csv-timeline`および`json-timeline`コマンドでチャンクヘッダーのチェックサムを確認する`-V, --validate-checksums`オプションを追加した。 (#1709) (@fukusuket)
+
+**改善:**
+
+- `log-metrics`コマンドに、4つの新しいコマンドラインオプション `--include-channel`、`--exclude-channel`、`--include-filename`、`--exclude-filename` を追加した。 (#1715) (@fukusuket)
+- Timesketchのインストール用Readmeを更新し、ARMベースのMacでのTimesketchサポートを追加した。 (#1719) (@fukusuket)
+
+**バグ修正:**
+
+- `validate_checksum`が無効（デフォルト設定）になっている場合、イベントの`data_size`がゼロに設定されていると、無限ループとメモリリークが発生する問題が修正された。 (omerbenamram/evtx#264)
+- `-t, --threads`オプションが`computer-metrics`および`search`コマンドで機能していなかった。(#1563) (@hach1yon)
+- 複数のコンピュータからのログをスキャンした際、`log-metrics`が誤った結果を返していた。 (#1713) (@fukusuket)
+
+## 3.6.0 [2025/09/25] - 寝覚月リリース
+
+**改善:**
+
+- 相関ルールにより複数の可能性を持つイベントIDおよびレコードIDは、パースしやすくするため、`-`ではなく空文字列として出力されるようになった。 (#1694) (@fukusuket)
+- `csv-timeline`および`json-timeline`コマンドの`Results Summary`に表示される最初のタイムスタンプと最後のタイムスタンプの後に、最初と最後の検出のタイムスタンプも出力するようにした。 (#1688) (@fukusuket)
+- SOF-ELK（Elastic Stack）へのHayabusa JSONL結果のインポート方法に関するガイドが更新された。 (#1091) (@yamatosecurity)
+- ルールの変更日時が定義されていない場合、SIEMへのインポートを容易にするため、`-`の代わりに空文字列を出力する。 (#1702) (@yamatosecurity)
+- ルールメタデータ内の`RuleModifiedDate`等の空フィールドは、パースを容易にしファイルサイズを削減するため、JSONに出力されない。 (#1702) (@fukusuket)
+
+**バグ修正:**
+
+- `-T, --visualize-timeline`は、`-s, --sort`が指定されていない場合、正しくない結果を出力するため、`-T`を使用する際には`-s`の指定を必須とした。 (#1690) (@yamatosecurity)
+- レコード自体のタイムスタンプではなく、レコードヘッダー内のタイムスタンプでフィルタリングしていたため、タイムレンジオプション（--timeline-start / --timeline-end）で指定した範囲外のレコードが表示されていた。 (#1689) (@fukusuket)
+- GeoIP検索が`json-timeline`で機能していなかった。 (#1693) (@fukusuket)
+- `search`コマンドにおける省略形処理は一貫していなかった。(#1697) (@fukusuket)
+
+## 3.5.0 [2025/08/16] - お盆リリース
+
+**改善*:**
+
+- `base64`フィールド修飾子に対応した。 (#1677) (@fukusuket)
+
+## 3.4.0 [2025/08/01] - Black Hat Arsenal USA 2025 Release
+
+**改善:**
+
+- `search`コマンドでフィールド名が省略されるようになった。`-b, --disable-abbreviations`で無効にできる。 (#1627) (@hitenkoku)
+- 32ビット版のHayabusaが64ビットOSでも動作するようになった。 (#1665) (@akkuman)
+- Filebeatが最後のイベントを見逃さないように、JSON/Lファイルの最終行の後にリターン文字を置くようにした。 (#1666) (@fukusuket)
+
+**バグ修正:**
+
+- レベルは、`--disable-abbreviations`オプションが有効であっても省略されていた。(#1672) (@fukusuket)
+
+## 3.3.0 [2025/03/22] - AUSCERT/SINCON Release
+
+**改善:**
+
+- ファイルサイズを1024ベースで出力するようにした。（例:`KiB`, `MiB`, `GiB`等） (#1648) (@fukusuket)
+- `computer-metrics`コマンドのアップタイムの計算を改善した。 (#1656) (@fukusuket)
+
+**バグ修正:**
+
+- Windowsのライブレスポンスパッケージでは、`computer-metrics`コマンドが正しく動作しなかった。 (#1654) (@fukusuket)
+- `ruletype`フィールドは任意フィールドに戻された。 (#1660) (@fukusuket)
+
+## 3.2.0 [2025/04/02] - Vegemite Release
+
+**改善:**
+
+- `computer-metrics`コマンドにアップタイムとタイムゾーン情報を追加した。 (#1638) (@fukusuket)
+- 無効なルールのチェックとロギングを改善した。 (#1601) (@fukusuket)
+- デフォルトの出力に最初と最後のタイムスタンプを追加した。 (#1616) (@fukusuket)
+
+**バグ修正:**
+
+- `.evtx`ファイルが開けない場合、スキャンは失敗していた。 (#1634) (@fukusuket)
+- 経過時間と保存されたファイル情報がHTMLレポートに出力されていなかった。 (#1643) (@fukusuket)
+
+## 3.1.1 [2025/03/12] - Laksa Release
+
+**改善:**
+
+- Rustエディションを2024に更新した。(@fukusuket)
+- `computer-metrics`コマンドにOS情報を追加した。 (#1629) (@fukusuket)
+
+**バグ修正:**
+
+- `expand`ルールの数がターミナルに正しく表示されていなかった。 (#1598) (@fukusuket)
+- `status`フィールドが定義されていないルールは、スキャンウィザードで `status: test, stable` などを指定しても読み込まれた。(#1602) (@fukusuket)
+- `expand`ルールが設定なしでロードされていた。 (#1606) (@fukusuket)
+- `extract-base64`コマンドでダブルBase64エンコーディングの検出が正しく動作していなかった。 (#1607) (@fukusuket)
+- エラーメッセージの後、端末の文字が赤くなることがあった。 (#1610) (@fukusuket)
+- いくつかのコマンドで`-d`オプションが使用され、`-o`オプションが使用されなかった場合、プログレスバーが表示されなかった。 (#1617) (@fukusuket)
+- `pivot-keywords-list`コマンドが壊れていた。(#1619) (@fukusuket)
+- `details`が未定義の場合、フィールドデータマッピングが正常に機能しなかった。 (#1614) (@fukusuket)
+- `details`フィールドが設定されていない場合、`Details`列と`ExtraFieldInfo`列の両方に重複したデータが出力されていた。現在は`Details`列だけに出力される。 (#1623) (@fukusuket)
+
+## 3.1.0 [2025/02/22] - Ninja Day Release
+
+**新機能:**
+
+- `eid-metrics`と`logon-summary`コマンドに`-X, --remove-duplicate-detections`オプションを追加した。 (#1552) (@fukusuket)
+- 新しい「緊急アラート 」と重要なシステムに基づく重大度レベルの調整。`config/critical_systems.txt`に重要なシステム（例: ドメインコントローラ、ファイルサーバ等々）のコンピュータ名のリストを追加すると、`low`以上のすべてのアラートが1つ高く調整される。つまり、`low`は`medium`に、`medium`は`high`に、`critical`アラートは新しい`emergency`アラートになる。 (#1551) (@fukusuket)
+- `./config/critical_systems.txt`ファイルに追加するドメインコントローラーとファイルサーバーを自動的に見つける`config-critical-systems`コマンドを追加した。 (#1570) (@fukusuket)
+- `csv-timeline`、`search`、`log-metrics`コマンドに、フィールド情報をタブで区切る`-S, --tab-separator`オプションを追加した。 (#1587) (@fukusuket)
+
+**改善:**
+
+- `search`コマンドに`--timeline-start/--timeline-end`オプションを追加した。 (#1543) (@fukuseket)
+- チャンネルフィルタリングで `logon-summary` コマンドの速度を大幅に改善した。 (#1544) (@fukusuket)
+- `extract-base64`コマンドが`PowerShell Classic EID 400`イベントも対象するようになった。 (#1549) (@fukusuket)
+- `extract-base64`コマンドがPowerShell Coreログにも対応した。 (#1558) (@fukusuket)
+- `extract-base64`コマンドが`System 7045` (サービス作成)イベントにも対応した。 (#1583) (@fukusuket)
+- `search`コマンドは、デフォルトでは結果をソートしないので、メモリ使用量が大幅に減り、より高速になった。新しい`-s, --sort`オプションを使えば、以前と同じように結果をソートできる。(#1475) (@hach1yon)
+
+**バグ修正:**
+
+- `logon-summary`と`pivot-keywords-list`コマンドが不要なファイルを出力していた。 (#1553) (@fukusuket)
+-  JSON出力では、いくつかのルールでMITRE戦術の一貫性がなかった。 (#1573) (@fukusuket)
+- バージョンv3.0.x`ではルール作者情報がHTMLレポートに出力されていなかった。 (#1571) (@fukusuket)
+- ライブ調査用のエンコードされたルールが使用されている場合、相関ルールのルールファイル名がJSONタイムラインに出力されていなかった。 (#1572) (@fukusuket)
+- `level-tuning`コマンドが正しく動いていなかった。 (#1584) (@fukusuket)
+
+**その他:**
+
+- `-s, --sort-events`オプションが`-s, --sort`に名前変更された。 (@YamatoSecurity)
+- `minimal`以外のプロファイルに`RuleID`を追加した。 (@YamatoSecurity)
+- コードのリファクタリング: StoredStaticの不要な初期化コードを減らすためにデフォルトのtraitを使用することにした。 (#1588) (@fukusuket)
+
+## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
+
+**バグ修正:**
+
+- Hayabusaはバックエンドで`expand`ルールのパースチェックに失敗していた。 (#1537) (@fukusuket)
+
+## 3.0.0 [2024/12/25] - 3rd Year Anniversary Release
+
+**新機能:**
+
+- Base64文字列を抽出して、デコードする`extract-base64`コマンドを追加した。(#1512) (@fukusuket)
+- `expand`修飾子が入っているルールで使用されるプレースホルダー名を出力する`expand-list`コマンドを追加した。(#1513) (@fukuseket)
+- `expand`フィールド修飾子に対応した。 (#1434) (@fukusuket)
+- Temporal Proximity（`temporal`）の相関ルールに対応した。 (#1446) (@fukusuket)
+- Temporal Ordered Proximity (`temporal_ordered`) の相関ルールに対応した。 (#1447) (@fukusuket)
+
+**改善:**
+
+- `log-metrics`コマンドにファイルサイズを追加した。 (#1528) (@fukusuket)
+
+**バグ修正:**
+
+- レコードIDが出力されるとき、`csv-timeline`によるソートが完璧に行われなかった。 (#1519) (@fukusuket)
+- `J, --JSON-input`は、`.json`ファイルしか対応していなかったので、`.jsonl`ファイルにも対応した。 (#1530) (@fukusuket)
+
+## 2.19.0 [2024/11/26] - "Every Day Is A Good Day" Release
+
+**新機能:**
+
+- `gt`、`gte`、`lt`、`lte`のフィールド修飾子に対応した。(#1433) (@fukusuket)
+- 新しい`log-metrics`コマンドで`.evtx`ファイルの情報を取得できるようになった。(コンピュータ名、イベント数、最初のタイムスタンプ、最後のタイムスタンプ、チャネル、プロバイダ) (#1474) (@fukusuket)
+- 以下のコマンドに`Channel`と`Provider`の略称を無効にする`-b, --disable-abbreviations`オプションを追加した。元の値を確認したい時に便利。 (#1485) (@fukusuket)
+  * `csv-timeline`
+  * `json-timeline`
+  * `eid-metrics`
+  * `log-metrics`
+  * `search`
+- `utf16/utf16be/utf16le/wide`フィールド修飾子が`base64offset|contains`フィールド修飾子と一緒に使えるようになった。 (#1432) (@fukusuket)
+  * `utf16|base64offset|contains`
+  * `utf16be|base64offset|contains`
+  * `utf16le|base64offset|contains`
+  * `wide|base64offset|contains`
+
+**改善:**
+
+- `yaml-rust`クレートを`yaml-rust2`に更新した。(#461) (@yamatosecurity)
+- `windash`文字が、`rules/config/windash_characters.txt`から動的に読み込まれるようになった。(#1440) (@fukusuket)
+- `logon-summary`コマンドがRDPイベントからのログオン情報を表示するようになった。注意: ファイルに保存する場合、Hayabusaはより詳細な情報を出力する。(#1468) (@fukusuket)
+- 見やすくなるように色を更新した。 (#1480) (@yamatosecurity)
+- 実行開始と終了のメッセージを出力するようにした。 (#1492) (@fukusuket)
+- 出力に新しい配色を追加した。 (#1491) (@fukusuket)
+- ファイルサイズがプログレスバーの下のファイル名の横に表示されるようになった。 (#1471) (@fukusuket)
+
+**バグ修正:**
+
+- logon-summary`コマンドが破損したログでクラッシュすることがあった。(#1477) (@fukusuket)
+- `csv-timeline`と`json-timeline`コマンドで、結果をターミナルに出力すると、プログレスバーの後にいくつかの結果が表示されていた。(#1459) (@fukusuket)
+- 集計ルールのアラートの詳細フィールド値の結果がソートされていないため、`csv-timeline`と`json-timeline`は、毎回完全に正確な結果を出力しなかった。 (#1466) (@fukusuket)
+- `hayabusa-evtx`クレートをバージョン`0.8.12`に更新した。(@yamatosecurity)
+  - JSONフィールドの出力順序が元のXMLに従って保持されるようになった。(omerbenamram/evtx #241)
+  - 属性と同じ名前を持つ複数のサブノードは上書きされ、最後の1つだけが出力されていた。(omerbenamram/evtx #245)
+- `logon-summary`と`eid-metrics`が複数のプログレスバーを出力することがあった。 #1479 (@fukusuket)
+- ターミナルに出力し、イベントをソートしない場合、プログレスバーは不要なため削除された。 #1508 (@fukusuket)
+
+**その他:**
+
+- `timeline-offset`オプションは、`--time-offset`に名前変更された。 (#1490) (@yamatosecurity)
+
+## 2.18.0 [2024/10/23] - SecTor Release
+
+**新機能:**
+
+- `fieldref`修飾子(`equalsfield`修飾子のエリアス)に対応した。(#1409) (@hitenkoku)
+- `fieldref|startswith`と`fieldref|contains`修飾子に対応した。 (#1439) (@fukusuket)
+- `fieldref|endswith`修飾子は、`endswithfield`をリプレースするためのエイリアスとして作成された。(#1437) (@fukusuket)
+- XORエンコードされたルールをサポートし、端末に置かれるファイルを最小限に抑えるとともに、ルールに過検知するアンチウイルス製品を回避する。(#1419) (@fukusuket)
+  - リリースページで、この機能を設定済みのパッケージを含める予定。手動で設定したい場合は、[encoded_rules.yml](https://github.com/Yamato-Security/hayabusa-encoded-rules/raw/refs/heads/main/encoded_rules.yml)をダウンロードして、Hayabusaのルートフォルダに置いてください。このファイルは、hayabusa-rulesリポジトリ内のルールから作成されており、ルールが更新されるたびに自動的にアップデートされる。configディレクトリ以外のrulesフォルダ内のファイルは、まだ単一ファイルに含まれていないので削除してください。
+  - 注意: -Hオプションで生成されるレポートは、ルールへのリンクを作成せず、ルール名だけが出力される。
+- `rules/config`の設定ファイルが単一のファイル[rules_config_files.txt](https://github.com/Yamato-Security/hayabusa-encoded-rules/raw/refs/heads/main/rules_config_files.txt)からロードされるようになり、ライブ調査のためにターゲットシステムに保存する必要があるファイル数が減った。(#1420) (@fukusuket)
+
+**バグ修正:**
+
+- `search`コマンドの`-o`オプションを使用した際に不要な改行が出力されていた。(#1425) (@fukusuket)
+- Sigma相関ルールの`group-by`フィールドは、必須だったが任意に変えた。(#1442) (@fukusuket)
+- Hayabusaは、相関ルールで参照されているルールが見つからない場合、エラーメッセージを表示するようにした。 (#1444) (@fukusuket)
+- `all-field-info`プロファイルを使用した場合、フィールド情報が出力されなかった。 (#1450) (@fukusuket)
+
+**その他:**
+
+- ライセンスをGPL-3.0からAGPL-3.0に変えた。(@yamatosecurity)
+
+## 2.17.0 [2024/08/23] "HITCON Community Release"
+
+**新機能:**
+
+- Sigma V2の`|re:`のサブ修飾子に対応した。 submodifers. (#1399) (@fukusuket)
+  - 参考: https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-modifiers-appendix.md
+    * `|re|i:`: (insensitive) 大文字小文字を区別しないマッチングを無効にする。
+    * `|re|m:`: (multi-line) 複数行にまたがってマッチする。`^` /`$` は行頭/行末にマッチする。
+    * `|re|s:`: (single-line) ドット文字 (`.`) は改行文字を含むすべての文字にマッチする。
+- Sigma V2の`|exists:`修飾子に対応した。 (#1400) (@hitenkoku)
+- Sigma V2の`|cased:`修飾子に対応した。 (#1401) (@hitenkoku)
+
+**改善:**
+
+- `cidr-utils`クレートを新バージョン0.6.xに対応した。 (#1366) (@hitenkoku)
+- Sigma相関ルールの`name`ルックアップに対応した。 (#1363) (@fukusuket)
+- デフォルトで低メモリモードを有効にした。`-s, --low-memory-mode`は、`-s, --sort-events` - 出力/保存する前に結果をソートする。(注意: より多くのメモリを消費する。）(#1361) (@hitenkoku)
+  - 注意: `-R, --remove-duplicate-data`または`-X, --remove-duplicate-detections`を使用するには、ソートを有効にする必要がある。
+- Sigma相関ルールが参照しているルールは、デフォルトで結果を出力しないようにした。ルールに`generate: true`を指定すると、出力される。 (#1367) (@fukusuket)
+- `Data`フィールドは、すべて`Data`フィールドとして、またはJSONの配列としてではなく、インデックス化された文字列として表示されるようになった。(#1371) (@fukusuket)
+  - 前: `"Data": ["17514", "Multiprocessor Free", "Service Pack 1"]`
+  - 後: `"Data[3]": "17514", "Data[4]": "Multiprocessor Free", "Data[5]": "Service Pack 1"`
+- リリースパッケージのファイル数を減らすために、`config`フォルダ内の設定ファイルもバイナリに埋め込まれるようにした。 (#1370) (@hitenkoku)
+  - 注意: `set-default-profile`コマンドは、`config/default_profile.yaml`に依存しているので、`config`ディレクトリファイルがないと実行できない。
+- 集計ルールのアラートに、複数の結果がある場合でも`Channel`と`EventID`の情報が表示されるようにした。 (#1342) (@fukusuket)
+- JSONタイムラインで`Details`フィールドに情報がない場合、JSONがパースしやすくなるように、デフォルトで出力される`"-"`を`{}`に変更した。(#1386) (@hitenkoku)
+- シグネチャーバイパスを防ぐため、`-` (エンダッシュ)、`-` (エムダッシュ)、`―` (水平バー) 文字を `windash` 修飾子でサポートするようにした。(#1392) (@hitenkoku)
+- MITRE ATT&CKタグをSigmaバージョン2の形式に対応させた。(例: `defense_evasion` => `defense-evasion`) (@fukusuket)
+- `evtx`クレートを最新のものに更新し、機能改善とバグ修正を行った。
+
+**バグ修正:**
+
+- Sigmaの相関ルールのカウントが`Events with hits`に表示されていなかった。(#1373) (@fukusuket)
+- 相関ルールのカウントが`Events with hits`に表示されていなかった。(#1374) (@fukusuket)
+- 集計ルールのカウントが`Events with hits`に表示されていなかった。(#1375) (@fukusuket)
+- まれに、ルール作成者の一覧が表示されないことがあった。 (#1383) (@fukusuket)
+
+## 2.16.0 [2024/06/11]
+
+**新機能:**
+
+- デフォルトでは、`.evtx`ファイルに適用可能なルールのみ有効になる。これは、`.evtx`ファイルと`.yml`ルールの`Channel`フィールドに基づく。例えば、`Security.evtx`がスキャンされている場合、`Channel: Security`が定義されているルールのみがこのファイルに対して使用される。ベンチマークでは、単一の`evtx`ファイルをスキャンする場合、パフォーマンスが約20％向上される。1つの`.evtx`ファイルで複数のチャネルが使用されている場合や、チャネルが定義されていないルールを使用して、チャネルに関係なくすべての`.evtx`ファイルをスキャンしたい場合は、`csv-timeline` と `json-timeline` の `-A、--enable-all-rules` オプションでこのフィルタリングをオフにすることができる。（#1317）(@fukusuket)
+  - 現在のところ、`Channel`が定義されておらず、すべての`.evtx`ファイルをスキャンすることを意図している検知ルールは以下の2つだけ:
+    - [Possible Hidden Shellcode](https://github.com/Yamato-Security/hayabusa-rules/blob/main/hayabusa/builtin/UnkwnChannEID_Med_PossibleHiddenShellcode.yml)
+    - [Mimikatz Use](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/win_alert_mimikatz_keywords.yml)
+- デフォルトでは、適用可能なルールを持つ`.evtx`ファイルのみ読み込む。たとえば、さまざまなイベントログのディレクトリをスキャンしている場合でも、 `Channel: Security` を探すルールのみを有効にした場合、Hayabusaは`Security`以外のすべてのイベントログを無視します。ベンチマークでは、通常のスキャンで約10％、単一のルールでスキャンする場合は最大60％以上のパフォーマンス向上が得られる。チャネルに関係なくすべての`.evtx`ファイルを読み込みたい場合は、`csv-timeline` と `json-timeline` の `-a、--scan-all-evtx-files` オプションでこのフィルタリングをオフにすることができる。(#1318) (@fukusuket)
+- 注意: チャンネルフィルタリングは .evtx ファイルにのみ適用され、`-J, --json-input`オプションを使用してイベントログをJSONファイルから読み込む際に`-A`または`-a`を指定するとエラーが発生する。(#1345) (@fukusuket)
+- Sigma相関ルールのEvent Countに対応した。 (#1337) (@fukusuket)
+- Sigma相関ルールのValue Countに対応した。 (#1338) (@fukusuket)
+
+**改善:**
+
+- `-d, --directory`オプションで複数のフォルダを指定できるようにした。 (#1335) (@hitenkoku)
+- REST APIからエクスポートされたSplunkログを分析できるようになった。 (#1083) (@hitenkoku)
+- `count`で複数のグループを指定できるようにした。例: `count() by IpAddress,SubStatus,LogonType >= 2`。また、出力される結果を更新した。例: `[condition] count(TargetUserName) by IpAddress > 3 in timeframe [result] count: 4 TargetUserName:tanaka/Administrator/adsyncadmin/suzuki IpAddress:- timeframe:5m` -> `Count: 4 ¦ TargetUserName: tanaka/Administrator/adsyncadmin/suzuki ¦ IpAddress: -` (#1339) (@fukusuket)
+- フィールドデータマッピングファイル(`rules/config/data_mapping/*.yaml`)で任意の`Provider_Name`フィールドを指定できるようにし、`Data[x]`表記に対応した。(#1350) (@fukusuket)
+- カウントルールのJSON出力で、フィールド情報が分離されるようになった。 (#1342) (@fukusuket)
+  - 以前: `"Details": "[condition] count() by IpAddress >= 5 in timeframe [result] count:3558 IpAddress:192.168.198.149 timeframe:5m"`
+  - 現在: `"Details": { "Count": 3558, "IpAddress": "192.168.198.149" }`
+
+## 2.15.0 [2024/04/20] "Sonic Release"
+
+**改善:**
+
+- Sigmaルールの `windash`フィールド修飾子 (例: `|contains|windash:`と`|contains|all|windash:`)に対応した。 (#1319) (@hitenkoku)
+  - https://sigmahq.io/docs/basics/modifiers.html#windash
+  - 注意: 現在、バックエンドでは、以前のバージョンのHayabusaと互換性があるようにルール内の`windash`の使用を変換しているが、5月末ごろには、`windash`の使用をそのままにする予定なので、それまでにこのバージョンにアップデートしてください。
+
+**バグ修正:**
+
+- バージョン2.14.0では、`-T`の検知頻度タイムライン出力は使用できなかった。 (#1322) (@fukusuket)
+- `windash` でワイルドカードが利用できない問題を修正した。 (#1327) (@hitenkoku)
+
+## 2.14.0 [2024/03/30] "BSides Tokyo Release"
+
+**新機能:**
+
+- 指定した`status`のルールのみを利用する`--include-status`オプションを追加した。 (#1193) (@hitenkoku)
+- メモリ使用量を最大95%削減する`-s, --low-memory-mode`(低メモリモード)オプションを追加した。ただし、そのためには結果をソートしたり、`-R, --remove-duplicate-data`または`-X, --remove-duplicate-detections`を併用したりすることはできない。(#1254) (@hach1yon @hitenkoku)
+
+**改善:**
+
+- 未使用のクレートを削除した。(@YamatoSecurity)
+- SplunkからエクスポートしたJSONファイルの入力に対応した。 (#1083) (@hitenkoku)
+- パフォーマンスの改善 (#1277, #1278) (@fukusuket)
+- `csv-timeline`コマンドの結果と同様になるようにするために、`search`コマンドの結果の表示順番を変更した。 (#1297) (@hitenkoku)
+- イースターエッグに最強のキャラクターを追加した。 (#1304) (@hitenkoku)
+- `computer-metrics`コマンドのhelpオプションの表示をほかのコマンドの形式に合わせた。 (#1314) (@hitenkoku)
+
+**バグ修正:**
+
+- `search` コマンドのJSON出力で`AllFieldInfo`フィールドの情報が出力されなくなっていたのを修正した。 (#1251) (@hitenkoku)
+- ウィザードのオプション選択の時間が処理時間の中に含まれていたため除外した。 (#1291) (@hitenkoku)
+- `-h, --help`オプションが重複して複数回表示されていた問題を修正した。 (#1309) (@hitenkoku)
+
+## 2.13.0 [2024/02/11] "Year Of The Dragon Release"
+
+**改善:**
+
+- `search` コマンドのフィルタオプションを完全一致にするようにした。加えてフィルタオプションはワイルドカード対応をするようにした。 (#1240) (@hitenkoku)
+- `update-rules`コマンドを実行したときに、検知ルールが変更された場合にルール名を出力するようにした。以前は`modified`フィールドを更新したルールだけが表示されていた。(#1243) (@hitenkoku)
+- `json-timeline`コマンドの標準出力でJSONフォーマットを出力するように修正した。 (#1197) (@hitenkoku)
+- JSON入力でデータが配列内にある場合に解析できるようにした。 (#1248) (@hitenkoku)
+- 古いターミナルでも正しく表示されるように、また読みやすくするために、`‖`区切り文字を`·`区切り文字に変更した。(#1258) (@YamatoSecurity)
+- General Optionsに`-h, --help`オプションを追加した。 (#1255) (@hitenkoku)
+- `json-timeline`コマンドの`Details`の出力で、要素がアルファベット順に並んでいたのをルールに記載されているオリジナルの順番に変更した。 (#1264) (@hitenkoku)
+- ルールをロードする必要のないコマンドを実行した場合、検出ルールのロードをスキップするようにした。 (#1263) (@hitenkoku)
+- `csv-timeline`コマンドの標準出力のカラー出力ルールを変更した。 (#1271) (@hitenkoku)
+- リファクタリングとパフォーマンスの改善。(#1268, #1260) (@hach1yon)
+
+**バグ修正:**
+
+- `search`コマンドの出力に入っている不要な改行文字を削除した。 (#1253) (@hitenkoku)
+- `no-color`オプション使用時のプログレスバーとウィザードのカラー出力を修正した。 (#1256) (@hitenkoku)
+- ローカルのタイムゾーンを特定できない場合にパニックが発生する問題を修正した。`chrono`クレートのバージョン0.4.32で修正された。(#1273)
+
+## 2.12.0 [2023/12/24] "SECCON Christmas Release"
+
+**改善:**
+
+- JSON出力において、MitreTactics、MitreTags, OtherTagsの出力を要素ごとに文字列で出力させるように修正した。 (#1230) (@hitenkoku)
+- 検知した端末に対してMITRE ATT&CKの戦術をHTMLレポートに出力できるようにした。この機能を利用するためには利用したプロファイルに`%MitreTactics%`が存在する必要がある。 (#1226) (@hitenkoku)
+- `csv-timeline`または`json-timeline`コマンドが利用されたときにissueやpull-requestの連絡先についてのメッセージを追加した。 (#1236) (@hitenkoku)
+
+**バグ修正:**
+
+- JSON出力において、同じ名前の複数のフィールド名が配列として出力されないため、`jq`でパースすると1つの結果しか返されなかった。同じフィールド名を持つ複数のフィールドデータを配列内に出力することで修正した。 (#1202) (@hitenkoku)
+- `csv-timeline`、`json-timeline`、`eid-metrics`、`logon-summary`、`pivot-keywords-list`、`search`コマンドで調査対象ファイルの指定オプション(`-l`、 `-f`、 `-d`)が存在しないときに処理が実行されないように修正した。 (#1235) (@hitenkoku)
+
+## 2.11.0 [2023/12/03] "Nasi Lemak Release"
+
+**新機能:**
+
+- PowerShell classicログのフィールドを抽出するようにした。(`--no-pwsh-field-extraction`で無効化できる) (#1220) (@fukusuket)
+
+**改善:**
+
+- スキャンウィザードにルール数を追加した. (#1206) (@hitenkoku)
+
+## 2.10.1 [2023/11/12] "Kamemushi Release"
+
+**改善:**
+
+- スキャンウィザードに質問を追加した。 (#1207) (@hitenkoku)
+
+**バグ修正:**
+
+- バージョン`2.10.0`の`update-rules`コマンドでは、新しいルールがダウンロードされても、`You currently have the latest rules`というメッセージを出力していた。 (#1209) (@fukusuket)
+- 正規表現が正しく処理されない場合があった。 (#1212) (@fukusuket)
+- JSON入力等に`Data`フィールドが存在しない場合、パニックが発生していた。(#1215) (@fukusuket)
+
+## 2.10.0 [2023/10/31] "Halloween Release"
+
+**改善:**
+
+- 初心者のユーザのために有効にしたいルールを選択するようにスキャンウィザードを追加した。`-w, --no-wizard`オプションを追加すると、従来の形式でHayabusaを実行できる。(すべてのイベントとアラートをスキャンし、オプションを手動でカスタマイズする） (#1188) (@hitenkoku)
+- `pivot-keywords-list`コマンドに`--include-tag`オプションを追加し、指定した`tags`フィールドを持つルールのみをロードするようにした。(#1195) (@hitenkoku)
+- `pivot-keywords-list`コマンドに`--exclude-tag`オプションを追加し、指定した`tags`フィールドを持つルールをロードしないようにした。(#1195) (@hitenkoku)
+
+**バグ修正:**
+
+- まれにJSONフィールドが正しくパースされない状態を修正した。(#1145) (@hitenkoku)
+- JSON出力で、`AllFieldInfo`は改行文字とタブ文字を除去していたが、出力するように修正した。 (#1189) (@hitenkoku)
+- 標準出力のいくつかのフィールドでスペースが削除されて見づらくなっていたのを修正した。 (#1192) (@hitenkoku)
+
+## 2.9.0 [2023/09/22] "Autumn Rain Release"
+
+**改善:**
+
+- ディレクトリパスの指定にバックスラッシュを使用すべきではないことを示すエラーメッセージを追加した。 (#1166) (@hitenkoku, 提案者: @joswr1ght)
+- 一度に読み込むレコード数の最適化。(#1175) (@yamatosecurity)
+- プログレスバー内にあるバックスラッシュの表示をスラッシュに変更した。 (#1172) (@hitenkoku)
+- JSON形式で出力する際に、`count`ルールの`Details`フィールドを文字列にし、パースしやすくした。(#1179) (@hitenkoku)
+- デフォルトのスレッド数をCPU数から、プログラムが使用すべきデフォルトの並列度の推定値(`std::thread::available_parallelism`)に変更した。(#1182) (@hitenkoku)
+
+**バグ修正:**
+
+- まれにJSONフィールドが正しくパースされない状態を修正した。(#1145) (@hitenkoku)
+
+**その他:**
+
+- CIを通すために`time`クレートを利用している更新されていない`hhmmss`クレートを除外した。 (#1181) (@hitenkoku)
+
+## 2.8.0 [2023/09/01] "Double X Release"
+
+**新機能:**
+
+- フィールドマッピング設定に16進数値を10進数に変換する`HexToDecimal`機能に対応した。 (元の16進数のプロセスIDを変換するのに便利。) (#1133) (@fukusuket)
+- `csv-timeline`と`json-timeline`に`-x, --recover-records`オプションを追加し、evtxのスラックスペースのファイルカービングによってevtxレコードを復元できるようにした。(#952) (@hitenkoku) (Evtxカービング機能は@forensicmattに実装された。)
+- `csv-timeline`と`json-timeline`に`-X, --remove-duplicate-detections`オプションを追加した。(`-x`を使用する場合、重複データのあるバックアップログを含める場合などに便利。) (#1157) (@fukusuket)
+- `csv-timeline`、`json-timeline`、`logon-summary`、`eid-metrics`、`pivot-keywords-list`、`search`コマンドに、直近のイベントだけをスキャンするための`--timeline-offset`オプションを追加した。 (#1159) (@hitenkoku)
+- `search`コマンドに`-a, --and-logic`オプションを追加し、複数のキーワードをAND条件で検索できるようにした。 (#1162) (@hitenkoku)
+
+**その他:**
+
+- 出力プロファイルに、回復されたかどうかを示す `%RecoveredRecord%` フィールドを追加した。 (#1170) (@hitenkoku)
+
+## 2.7.0 [2023/08/03] "SANS DFIR Summit Release"
+
+**新機能:**
+
+- `./rules/config/data_mapping`にある`.yaml`設定ファイルに基づいて、特定のコード番号が人間が読めるメッセージにマッピングされるようになった。(例:`%%2307`は、`ACCOUNT LOCKOUT`に変換される)。この動作は`-F, --no-field-data-mapping`オプションで無効にできる。(#177) (@fukusuket)
+- `csv-timeline`コマンドに`-R, --remove-duplicate-data`オプションを追加し、`%Details%`、`%AllFieldInfo%`、`%ExtraFieldInfo%`列の重複フィールドデータを`DUP`という文字列に変換し、ファイルサイズの削減を行う。(#1056) (@hitenkoku)
+- `csv-timeline`と`json-timeline`コマンドに`-P, --proven-rules`オプションを追加した。有効にすると、検知が証明されたルールしかロードされない。ロードされるルールは、`./rules/config/proven_rules.txt`の設定ファイルにルールIDで定義されている。 (#1115) (@hitenkoku)
+- `csv-timeline`と`json-timeline`コマンドに`--include-tag`オプションを追加し、指定した`tags`フィールドを持つルールのみをロードするようにした。(#1108) (@hitenkoku)
+- `csv-timeline`と`json-timeline`コマンドに`--exclude-tag`オプションを追加し、指定した`tags`フィールドを持つルールをロードしないようにした。(#1118) (@hitenkoku)
+- `csv-timeline`と`json-timeline`コマンドに`--include-category`と`--exclude-category`オプションを追加した。`include-category`は、指定された`category`フィールドのルールのみをロードする。`--exclude-category`は、指定された`category`フィールドを持つルールをロードしない。 (#1119) (@hitenkoku)
+- コンピュータ名に基づくイベント数をリストアップする`computer-metrics`コマンドを追加した。(#1116) (@hitenkoku)
+- `csv-timeline`、`json-timeline`、`metrics`、`logon-summary`、`pivot-keywords-list`コマンドに`--include-computer`と`--exclude-computer`オプションを追加した。`include-computer`は、指定された`computer`の検知のみを出力する。`--exclude-computer`は、指定された`computer`の検知を除外する。 (#1117) (@hitenkoku)
+- `csv-timeline`、`json-timeline`、`pivot-keywords-list`コマンドに`--include-eid`と`--exclude-eid`オプションを追加した。`include-eid`は、指定された`EventID`のみを検知対象とする。`--exclude-eid`は、指定された`EventID`を検知対象から除外する。 (#1130) (@hitenkoku)
+- `json-timeline`コマンドに`-R, --remove-duplicate-data`オプションを追加し、`%Details%`、`%AllFieldInfo%`、`%ExtraFieldInfo%`フィールドの重複フィールドデータを`DUP`という文字列に変換し、ファイルサイズの削減を行う。(#1134) (@hitenkoku)
+
+**改善:**
+
+- 新しいログ形式の`.evtx`を使用するWindows Vistaがリリースされた2007年1月31日以前のタイムスタンプを持つ破損されたイベントレコードを無視するようにした。(#1102) (@fukusuket)
+- `metrics`コマンドで`--output`オプションを指定した時に標準出力に結果を表示しないように変更した。 (#1099) (@hitenkoku)
+- `csv-timeline` コマンドと `json-timeline` コマンドに `--tags` オプションを追加し、指定した `tags` フィールドを持つルールのみでスキャンできるようにした。(#1108) (@hitenkoku)
+- `pivot-keywords-list`コマンドに対して、出力ファイルを上書きするための`-C, --clobber`オプションを追加した。 (#1125) (@hitenkoku)
+- `metrics`コマンドを`eid-metrics`に変更した。 (#1128) (@hitenkoku)
+- 端末の調整に余裕を持たせるため、プログレスバーの幅を減らした。 (#1135) (@hitenkoku)
+- `search`コマンドで出力時間フォーマットのオプションをサポートした。(`--European-time`, `--ISO-8601`, `--RFC-2822`, `--RFC-3339`, `--US-time`, `--US-military-time`, `-U, --UTC`) (#1040) (@hitenkoku)
+- プログレスバーのETA時間が正確でなかったため、経過時間に置き換えた。 (#1143) (@YamatoSecurity)
+- `logon-summary`コマンドで`--timeline-start`と`--timeline-end`オプションを追加した。 (#1152) (@hitenkoku)
+
+**バグ修正:**
+
+- `metrics`と`logon-summary`コマンドのレコード数の表示が`csv-timeline`のコマンドでのレコード数の表示と異なっている状態を修正した。 (#1105) (@hitenkoku)
+- パスの代わりにルールIDでルール数を数えるように変更した。 (#1113) (@hitenkoku)
+- JSON出力で`CommandLine`フィールド内で誤ったフィールドの分割が行われてしまう問題を修正した。 (#1145) (@hitenkoku)
+- `json-timeline`コマンドで`--timeline-start`と`--timeline-end`オプションが動作しなかったのを修正した。 (#1148) (@hitenkoku)
+- `pivot-keywords-list`コマンドで`--timeline-start`と`--timeline-end`オプションが動作しなかったのを修正した。 (#1150) (@hitenkoku)
+
+**その他:**
+
+- ルールのIDベースでユニークな検出数をカウントするように修正した。 (#1111) (@hitenkoku)
+- `--live_analysis`オプションを`--live-analysis`に変更した。 (#1139) (@hitenkoku)
+- `metrics`コマンドを`eid-metrics`に変更した。 (#1128) (@hitenkoku)
+
+## 2.6.0 [2023/06/16] "Ajisai Release"
+
+**新機能:**
+
+- Sigmaルールの`'|all':`キーワードに対応した。 (#1038) (@kazuminn)
+
+**改善:**
+
+- プロファイルに`%ExtraFieldInfo%`エイリアスを追加した。デフォルトの`standard`出力プロファイルに含まれるようになった。(#900) (@hitenkoku)
+- 互換性のない引数に対するエラーメッセージを追加した。 (#1054) (@YamatoSecurity)
+- 標準出力とHTML出力にプロファイル名を出力する機能を追加した。 (#1055) (@hitenkoku)
+- HTML出力のルールアラートにルール作者名を表示するように修正した。 (#1065) (@hitenkoku)
+- 端末サイズが小さくてもテーブルが壊れないように、テーブル幅を短くした。 (#1071) (@hitenkoku)
+- `csv-timeline`、`json-timeline`、`metrics`、`logon-summary`、`search`コマンドに対して、出力ファイルを上書きするための`-C, --clobber`オプションを追加した。 (#1063) (@YamatoSecurity, @hitenkoku)
+- HTML内にCSSと画像を組み込んだ。 (#1078) (@hitenkoku, 提案者: @joswr1ght)
+- 出力時の速度向上。 (#1088) (@hitenkoku, @fukusuket)
+- `metrics`コマンドは、テーブルが正しくレンダリングされるように、ワードラップを行うようになった。 (#1067) (@garigariganzy)
+- `search`コマンドでJSON/JSONLの出力できるようにした。 (#1041) (@hitenkoku)
+
+**バグ修正:**
+
+- `json-timeline`コマンドを利用した出力で、`MitreTactics`、`MitreTags`、`OtherTags`フィールドが出力されていない問題を修正した。 (#1062) (@hitenkoku)
+- `no-summary`オプションを使用した時にイベント頻度のタイムラインが出力されない問題を修正した。 (#1072) (@hitenkoku)
+- `json-timline`コマンドの出力に制御文字が含まれる問題を修正した。 (#1068) (@hitenkoku)
+- `metrics`コマンドでは、チャンネル名が小文字の場合、省略されなかった。 (#1066) (@garigariganzy)
+- JSON出力内でいくつかのフィールドがずれてしまっていた問題を修正した。 (#1086) (@hitenkoku)
+
+## 2.5.1 [2023/05/14] "Mothers Day Release"
+
+**改善:**
+
+- 新たに変換されたルールを使用する際のメモリ使用量を半分に削減した。(#1047) (@fukusuket)
+
+**バグ修正:**
+
+- `AccessMask`等のフィールド内の情報が空白で区切られていなかった状態を修正した。 (#1035) (@hitenkoku)
+- JSON形式に出力時に複数の空白が一つの空白に変換されていた。 (#1048) (@hitenkoku)
+- `pivot-keywords-list`コマンドで`--no-color`を使用した場合でも、結果がカラーで出力された。 (#1044) (@kazuminn)
+
+## 2.5.0 [2023/05/07] "Golden Week Release"
+
+**改善:**
+
+- `search`コマンドに`-M, --multiline`オプションを追加した。 (#1017) (@hitenkoku)
+- `search`コマンドの出力での不要な改行やタブを削除した。 (#1003) (@hitenkoku)
+- 正規表現の不要なエスケープを許容し、パースエラーを減らす`regex`クレートを1.8に更新した。(#1018) (@YamatoSecurity)
+- `csv-timeline`コマンドの出力で不要な空白文字の削除を行った。 (#1019) (@hitenkoku)
+- `update-rules`コマンド使用時にハヤブサのバージョン番号の詳細を確認するようにした (#1028) (@hitenkoku)
+- `search`コマンドの結果を時刻順にソートした。 (#1033) (@hitenkoku)
+- `pivot-keywords-list`のターミナル出力の改善。 (#1022) (@kazuminn)
+
+**バグ修正:**
+
+- ruleで指定された値で`\`が最後の文字のときに、検知ができない問題を修正した。 (#1025) (@fukusuket)
+- results summary内のInformationalレベルアラートの結果が同じ内容が2つ表示されている状態を修正した。 (#1031) (@hitenkoku)
+
+## 2.4.0 [2023/04/19] "SANS Secure Korea Release"
+
+**新機能:**
+
+- 指定されたキーワードに合致したレコードを検索する`search`コマンドを追加した。 (#617) (@itiB, @hitenkoku)
+- 指定された正規表現に合致したレコードを検索する`-r, --regex`オプションを`search`コマンドに追加した。 (#992) (@itiB)
+- Aho-Corasickクレートをversino1.0に更新した。 (#1013) (@hitenkoku)
+
+**改善:**
+
+- コマンドの表示順を辞書順に並べ替えた。 (#991) (@hitenkoku)
+- `csv-timeline`, `json-timeline`, `search`コマンドの `AllFieldInfo`の出力に`Event.UserData`の属性情報を追加した。 (#1006) (@hitenkoku)
+
+**バグ修正:**
+
+- v2.3.3にて`-T, --visualize-timeline`データの中に存在していないタイムスタンプがイベント頻度のタイムラインに出力するバグを修正した。 (#977) (@hitenkoku)
+
+## 2.3.3 [2023/04/07] "Sakura Release"
+
+**改善:**
+
+- ファイル(CSV, JSON, JSONL)出力の際にルールの`level`の余分なスペースを削除した。 (#979) (@hitenkoku)
+- `-M, --multiline`オプション利用時にルール作者名の出力を複数行出力対応をした。 (#980) (@hitenkoku)
+- Stringの代わりにCoWを利用することで、約5%の速度向上を実現した。 (#984) (@hitenkoku)
+- Clapの新バージョンでロゴ後のメッセージとUsageテキストの出力色が緑にならないように修正した。 (#989) (@hitenkoku)
+
+**バグ修正:**
+
+- v2.3.0にて`level-tuning`コマンド実行時にクラッシュする問題を修正した。 (#977) (@hitenkoku)
+
+## 2.3.2 [2023/03/22] "TMCIT Release-3"
+
+**改善:**
+
+- `csv-timeline`コマンドに`-M, --multiline`オプションを追加した。 (#972) (@hitenkoku)
+
+## 2.3.1 [2023/03/18] "TMCIT Release-2"
+
+**改善:**
+
+- `csv-timeline`の出力のフィールドでダブルクォートを追加した。 (#965) (@hitenkoku)
+- `logon-summary`の見出しを更新した。 (#964) (@yamatosecurity)
+- `--enable-deprecated-rules`の`-D`ショートオプションと`--enable-unsupported-rules`の`-u`ショートオプションを追加した。(@yamatosecurity)
+- Filteringセクションのオプションの表示順とヘルプの表示内容を修正した。 (#969) (@hitenkoku)
+
+**バグ修正:**
+
+- v2.3.0にて`update-rules`コマンド実行時にクラッシュする問題を修正した。 (#965) (@hitenkoku)
+- コマンドプロンプトとPowerShellプロンプトではヘルプメニューのタイトルに長いアンダーバーが表示されていた問題が修正された。 (#911) (@yamatosecurity)
+
+## 2.3.0 [2023/03/16] "TMCIT Release"
+
+**新機能:**
+
+- 新たなパイプキーワードの`|cidr`に対応した。 (#961) (@fukusuket)
+- 新たなキーワードの`1 of selection*`と`all of selection*`に対応した。 (#957) (@fukusuket)
+- 新たなパイプキーワードの`|contains|all`に対応した。 (#945) (@hitenkoku)
+- ステータスが`unsupported`となっているルールの件数を表示した。ステータス`unsupported`のルールも検知対象とするオプションとして`--enable-supported-rules`オプションを追加した。 (#949) (@hitenkoku)
+
+**改善:**
+
+- 文字列が含まれているかの確認処理を改善することで約2-3%の速度改善をした。(#947) (@hitenkoku)
+
+**バグ修正:**
+
+- 一部のイベントタイトルが定義されていても、`metrics`コマンドで`Unknown`と表示されることがあった。 (#943) (@hitenkoku)
+
+## 2.2.2 [2023/2/22] "Ninja Day Release"
+
+**新機能:**
+
+- 新たなパイプキーワード(`|base64offset|contains`)に対応した。 (#705) (@hitenkoku)
+
+**改善:**
+
+- オプションのグループ分けを再修正した。(#918)(@hitenkoku)
+- JSONL形式のログを読み込む際のメモリ使用量を約75%削減した。 (#921) (@fukusuket)
+- `rules/config/generic_abbreviations.txt`によってチャンネル名の一般的な単語名を省略する機能をmetrics、json-timeline、csv-timelineに追加した。 (#923) (@hitenkoku)
+- evtxクレートを更新することにより、パースエラーを減少させた。 (@YamatoSecurity)
+- Provider名(`%Provider%`)のフィールドに対する出力文字の省略機能を追加した。 (#932) (@hitenkoku)
+- `metrics`コマンドで`-d`オプションが指定されたときに最初と最後のイベントのタイムスタンプを表示する機能を追加した。 (#935) (@hitenkoku)
+- 結果概要に最初と最後のイベントのタイムスタンプを表示した。 (#938) (@hitenkoku)
+- `logon-summary`と`metrics`コマンドに時刻表示のオプションを追加した. (#938) (@hitenkoku)
+- `json-output`コマンドで`--output`で出力される結果に`\r`、`\n`、`\t`を出力するようにした。 (#940) (@hitenkoku)
+
+**バグ修正:**
+
+- `logon-summary`と`metrics`コマンドで、最初と最後のタイムスタンプが出力されない不具合を修正した。 (#920) (@hitenkoku)
+- `metrics`コマンドで全てのイベントのタイトルが表示されない問題を修正した。 (#933) (@hitenkoku)
+
+## 2.2.0 [2022/2/12] "SECCON Release"
+
+**新機能:**
+
+- JSON形式のイベントログファイルの入力(`-J, --JSON-input`)に対応した。 (#386) (@hitenkoku)
+- MaxMindのGeoIPデータベースに基づき、送信元および送信先IPアドレスのASN組織、都市、国を出力することによるログエンリッチメント(`-G, --GeoIP`)を実現した。 (#879) (@hitenkoku)
+- `-e, --exact-level`オプションで指定したレベルに対する結果のみを取得する機能を追加した。 (#899) (@hitenkoku)
+
+**改善:**
+
+- HTMLレポートの出力に実行したコマンドラインを追加した。 (#877) (@hitenkoku)
+- イベントIDの完全比較を行うことで、約3%の速度向上とメモリ使用量の削減を実現した。 (#882) (@fukusuket)
+- 正規表現使用前のフィルタリングにより、約14%の速度向上とメモリ使用量の削減を実現した。 (#883) (@fukusuket)
+- 正規表現ではなく大文字小文字を区別しない比較により、約8%の速度向上とメモリ使用量の削減を実現した。 (#884) (@fukusuket)
+- ワイルドカード表現における正規表現の使用量を削減することで、約5%の速度向上とメモリ使用量の削減を実現した。 (#890) (@fukusuket)
+- 正規表現の使用を避けることで、さらなる高速化とメモリ使用量の削減を実現した。 (#894) (@fukusuket)
+- 正規表現の使用量を減らすことで、約3%の速度向上と約10%のメモリ使用量削減を実現した。 (#898) (@fukuseket)
+- ライブラリの更新によって`-T, --visualize-timeline`の出力を複数行にするように変更した。 (#902) (@hitenkoku)
+- JSON/L形式のログを読み込む際のメモリ使用量を約50%削減した。 (#906) (@fukusuket)
+- Longオプションを基にしたオプションの並べ替えを行った。 (#904) (@hitenkoku)
+- `-J, --JSON-input`オプションを`logon-summary`, `metrics`, `pivot-keywords-list`コマンドに対応させた。 (#908) (@hitenkoku)
+
+**バグ修正:**
+
+- ルールの条件にバックスラッシュが4つある場合、ルールがマッチしない不具合を修正した。 (#897) (@fukuseket)
+- JSON出力では、PowerShell EID 4103をパースする際に`Payload`フィールドが複数のフィールドに分離されるバグを修正した。(#895) (@hitenkoku)
+- ファイルサイズ取得の際にpanicが発生するのを修正した。 (#914) (@hitenkoku)
+
+**脆弱性修正:**
+
+- ルールや設定ファイルを更新する際に起こりうるSSH MITM攻撃(CVE-2023-22742)を防ぐため、git2およびgitlib2クレートを更新した。 (#888) (@YamatoSecurity)
+
+## 2.1.0 [2023/01/10] "Happy Year of the Rabbit Release"
+
+**改善:**
+
+- 速度の改善。 (#847) (@hitenkoku)
+- 出力の改善を行うことによる速度の改善。 (#858) (@fukusuket)
+- 実行ごとに同じ時間の検知の出力の順番のソートを行っていないのを修正した。 (#827) (@hitenkoku)
+
+**バグ修正:**
+
+- ログオン情報の出力機能で`--output`を指定したときにログオン成功のcsv出力ができない問題を修正した。 (#849) (@hitenkoku)
+- `-J, --jsonl`を指定したときに不要な改行が含まれていたため修正した。 (#852) (@hitenkoku)
+
+## 2.0.0 [2022/12/24] "Merry Christmas Release"
+
+**新機能:**
+
+- コマンドの使用方法とヘルプメニューはサブコマンドで行うようにした。 (#656) (@hitenkoku)
+
+## 1.9.0 [2022/12/24] "Merry Christmas Release"
+
+**新機能:**
+
+- 新たなパイプキーワード(`|endswithfield`)に対応した。 (#740) (@hach1yon)
+- 実行時のメモリ利用率を表示する機能を追加した。`--debug`オプションで利用可能。 (#788) (@fukusuket)
+
+**改善:**
+
+- Clap Crateパッケージの更新。更新の関係で`--visualize-timeline` のショートオプションの`-V`を`-T`に変更した。 (#725) (@hitenkoku)
+- ログオン情報の出力でログオンタイプ、送信元の端末名とIPアドレス等を出力できるようにした。また、ログオンに失敗の一覧も出力するようにした。 (#835) (@garigariganzy @hitenkoku)
+- 速度とメモリ使用の最適化。 (#787) (@fukusuket)
+- イースターエッグのASCIIアートをカラー出力するようにした。 (#839) (@hitenkoku)
+- `--debug`オプションをオプションの一覧から非表示にした。 (#841) (@hitenkoku)
+
+**バグ修正:**
+
+- コマンドプロンプトで`-d`オプションを設定した際にダブルクォーテーションで囲んだときにevtxファイルの収集ができていないバグを修正した。 (#828) (@hitenkoku)
+- ルールのパースエラーが発生した際に不必要な改行が出力されていたのを修正した。 (#829) (@hitenkoku)
+
+## 1.8.1 [2022/11/21]
+
+**改善:**
+
+- インポートしているcrateのRustバージョンによるビルドエラーを回避するためにCargo.tomlに`rust-version`を追加した。(#802) (@hitenkoku)
+- メモリ使用の削減。 (#806) (@fukusuket)
+- WEC機能を利用したevtxファイルのレンダーされたメッセージを出力するための`%RenderedMessage%`フィールドを追加した。 (#760) (@hitenkoku)
+
+**バグ修正:**
+
+- `Data`フィールドを使ったルールが検知できていない問題を修正した。 (#775) (@hitenkoku)
+- プロファイルの出力で`%MitreTags%` と`%MitreTactics%` の出力が抜け落ちてしまう問題を修正した。 (#780) (@fukusuket)
+
+## 1.8.0 [2022/11/07]
+
+**新機能:**
+
+- 新たな時刻表示のオプションとして`--ISO-8601`を追加した。 (#574) (@hitenkoku)
+
+**改善:**
+
+- イベントIDによるフィルタリングをデフォルトでは動作しないようにした。イベントIDフィルタを利用するためのオプション`-e, --eid-filter`を追加した。 (#759) (@hitenkoku)
+- 異なるユーザアカウントで新しいルールをダウンロードしようとしたときに、分かりやすいエラーメッセージを表示する。 (#758) (@fukusuket)
+- 合計およびユニークな検知数の情報をHTMLレポートに追加した。 (#762) (@hitenkoku)
+- JSONの出力の中にある各検知内容のオブジェクトを持つ不要な配列の構造を削除した。 (#766)(@hitenkoku)
+- プロファイルで出力できる情報にルール作成者(`%RuleAuthor%`)、 ルール作成日(`%RuleCreationDate%`)、 ルール修正日(`%RuleModifiedDate%`)、ルールステータス(`%Status%`)を追加した。 (#761) (@hitenkoku)
+- JSON出力のDetailsフィールドをオブジェクト形式で出力するように変更した。 (#773) (@hitenkoku)
+- `build.rs`を削除し、メモリアロケータをmimallocに変更した。Intel系OSでは20-30%の速度向上が見込める。 (#657) (@fukusuket)
+- プロファイルの`%RecordInformation%` エイリアスを `%AllFieldInfo%` に変更した。 AllFieldInfoフィールドをJSONオブジェクト形式で出力するように変更した。 (#750) (@hitenkoku)
+- AllFieldInfoフィールドのJSONオブジェクト内で利用していたHBFI-プレフィックスを廃止した。 (#791) (@hitenkoku)
+- `--no-summary`  オプションを使用したときに、表示しないルール作者および検知回数の集計を省略した。(Velociraptorエージェントを利用するときに有用です。10%はこのオプションの付与により高速化します) (#780) (@hitenkoku)
+- メモリ使用量を少なくし、処理速度を改善した。 (#778 #790) (@hitenkoku)
+- 検知したルール作者のリストが空の時にルール作者のリストを表示しないように修正した。(#795) (@hitenkoku)
+- プロファイルで出力できる情報にルールID(`%RuleID%`)、プロバイダー名情報(`%Provider%`)を追加した。 (#794) (@hitenkoku)
+
+**バグ修正:**
+
+- ルール作者数の集計に誤りがあったのを修正した。 (#783) (@hitenkoku)
+
+## 1.7.2 [2022/10/17]
+
+**新機能:**
+
+- 利用可能な出力プロファイルの一覧を出力する`--list-profiles` オプションを追加した。 (#746) (@hitenkoku)
+
+**改善:**
+
+- 見やすくするためにファイル保存の出力をする位置とupdateオプションの出力を変更した。 (#754) (@YamatoSecurity)
+- 検知したルールの作者名の最大文字数を40文字にした。 (#751) (@hitenkoku)
+
+**バグ修正:**
+
+- フィールド内にドライブレター(ex c:)が入っていた場合JSON/JSONL出力機能のフィールドの値がずれてしまっていたバグを修正した。 (#748) (@hitenkoku)
+
+## 1.7.1 [2022/10/10]
+
+**改善:**
+
+- より正確な結果を出力するために、チャンネルとEIDの情報を`rules/config/channel_eid_info.txt`に基づいてチェックするようにした。 (#463) (@garigariganzy)
+- 検知ルールを利用しないオプション(`-M`と`-L`オプション)の時のメッセージの出力内容を修正した。 (#730) (@hitenkoku)
+- 検出したルールの作者名を標準出力に追加した。 (#724) (@hitenkoku)
+- チャンネル情報が`null`となっているレコード(ETWイベント)を検知およびmetricの対象から除外した。 (#727) (@hitenkoku)
+
+**バグ修正:**
+
+- mericオプションのEventIDのキー名の数え上げが原因となっていたイベント集計の誤りを修正した。 (#729) (@hitenkoku)
+
+## 1.7.0 [2022/09/29]
+
+**新機能:**
+
+- HTMLレポート機能 (`-H, --html-report`)の追加。 (#689) (@hitenkoku, @nishikawaakira)
+
+**改善:**
+
+- EventID解析のオプションをmetricsオプションに変更した。(旧: `-s, --statistics` -> 新: `-M, --metrics`) (#706) (@hitenkoku)
+- ルール更新オプション(`-u`)を利用したときにHayabusaの新バージョンがないかを確認し、表示するようにした。 (#710) (@hitenkoku)
+- HTMLレポート内にロゴを追加した。 (#714) (@hitenkoku)
+- メトリクスオプション(`-M --metrics`)もしくはログオン情報(`-L --logon-summary`)と`-d`オプションを利用した場合に1つのテーブルで表示されるように修正した。 (#707) (@hitenkoku)
+- メトリクスオプションの結果出力にチャンネル列を追加した。 (#707) (@hitenkoku)
+- メトリクスオプション(`-M --metrics`)もしくはログオン情報(`-L --logon-summary`)と`-d`オプションを利用した場合に「First Timestamp」と「Last Timestamp」の出力を行わないように修正した。 (#707) (@hitenkoku)
+- メトリクスオプションとログオン情報オプションに対してcsv出力機能(`-o --output`)を追加した。 (#707) (@hitenkoku)
+- メトリクスオプションの出力を検出回数と全体の割合が1つのセルで表示されていた箇所を2つの列に分けた。 (#707) (@hitenkoku)
+- メトリクスオプションとログオン情報の画面出力に利用していたprettytable-rsクレートをcomfy_tableクレートに修正した. (#707) (@hitenkoku)
+- HTMLレポート内にfavicon.pngを追加した。 (#722) (@hitenkoku)
+
+## v1.6.0 [2022/09/16]
+
+**新機能:**
+
+- 解析結果をJSONに出力する機能(`-j, --json-timeline`)を追加した。 (#654) (@hitenkoku)
+- 解析結果をJSONL形式で出力する機能 (`-J, --jsonl` )を追加した。 (#694) (@hitenkoku)
+
+**改善:**
+
+- 結果概要に各レベルで検知した上位5つのルールを表示するようにした。 (#667) (@hitenkoku)
+- 結果概要を出力しないようにするために `--no-summary` オプションを追加した。 (#672) (@hitenkoku)
+- 結果概要の表示を短縮させた。 (#675 #678) (@hitenkoku)
+- channel_abbreviations.txtによるChannelフィールドのチェックを大文字小文字の区別をなくした。 (#685) (@hitenkoku)
+- 出力結果の区切り文字を`|`から`‖`に変更した。 (#687) (@hitenkoku)
+- 結果概要の検知数と総イベント数の数に色付けを行い見やすくした。 (#690) (@hitenkoku)
+- evtxクレートを0.8.0にアップデート。(ヘッダーや日付の値が無効な場合の処理が改善された。)
+- 出力プロファイルの更新。（@YamatoSecurity)
+
+**バグ修正:**
+
+- ログオン情報の要約オプションを追加した場合に、Hayabusaがクラッシュしていたのを修正した。 (#674) (@hitenkoku)
+- configオプションで指定したルールコンフィグの読み込みができていない問題を修正した。 (#681) (@hitenkoku)
+- 結果概要のtotal eventsで読み込んだレコード数が出力されていたのを、検査対象にしているevtxファイルの実際のレコード数に修正した。 (#683) (@hitenkoku)
+
+## v1.5.1 [2022/08/20]
+
+**改善:**
+
+- TimesketchにインポートできるCSV形式を出力するプロファイルを追加して、v1.5.1を再リリースした。 (#668) (@YamatoSecurity)
+
+## v1.5.1 [2022/08/19]
+
+**バグ修正:**
+
+- Critical, medium、lowレベルのアラートはカラーで出力されていなかった。 (#663) (@fukusuket)
+- `-f`で存在しないevtxファイルが指定された場合は、Hayabusaがクラッシュしていた。 (#664) (@fukusuket)
+
+## v1.5.0 [2022/08/18]
+
+**新機能:**
+
+- `config/profiles.yaml`と`config/default_profile.yaml`の設定ファイルで、出力内容をカスタマイズできる。 (#165) (@hitenkoku)
+- 対象のフィールドがレコード内に存在しないことを確認する `null` キーワードに対応した。 (#643) (@hitenkoku)
+
+**改善:**
+
+- ルールのアップデート機能のルールパスの出力から./を削除した。 (#642) (@hitenkoku)
+- MITRE ATT&CK関連のタグとその他タグを出力するための出力用のエイリアスを追加した。 (#637) (@hitenkoku)
+- 結果概要の数値をカンマをつけて見やすくした。 (#649) (@hitenkoku)
+- `-h`オプションでメニューを使いやすいようにグループ化した。 (#651) (@YamatoSecurity and @hitenkoku)
+- 結果概要内の検知数にパーセント表示を追加した。 (#658) (@hitenkoku)
+
+**バグ修正:**
+
+- aggregation conditionのルール検知が原因で検知しなかったイベント数の集計に誤りがあったので修正した。 (#640) (@hitenkoku)
+- 一部のイベント（0.01%程度）が検出されないレースコンディションの不具合を修正した。 (#639 #660) (@fukusuket)
+
+## v1.4.3 [2022/08/03]
+
+**バグ修正:**
+
+- VC再頒布パッケージがインストールされていない環境でエラーが発生している状態を修正した。 (#635) (@fukusuket)
+
+## v1.4.2 [2022/07/24]
+
+**改善:**
+
+- `--update-rules` オプションを利用する時に、更新対象のレポジトリを`--rules`オプションで指定できるようにした。 (#615) (@hitenkoku)
+- 並列処理の改善による高速化。 (#479) (@kazuminn)
+- `--output`オプションを利用したときのRulePathをRuleFileに変更した。RuleFileは出力するファイルの容量を低減させるためにファイル名のみを出力するようにした。 (#623) (@hitenkoku)
+
+**バグ修正:**
+
+- `cargo run`コマンドでhayabusaを実行するとconfigフォルダの読み込みエラーが発生する問題を修正した。 (#618) (@hitenkoku)
+
+## v1.4.1 [2022/06/30]
+
+**改善:**
+
+- ルールや`./rules/config/default_details.txt` に対応する`details`の記載がない場合、すべてのフィールド情報を結果の``Details`列に出力するようにした (#606) (@hitenkoku)
+- `--deep-scan`オプションの追加。 このオプションがない場合、`config/target_event_ids.txt`で指定されたイベントIDのみをスキャン対象とします。 このオプションをつけることですべてのイベントIDをスキャン対象とします。(#608) (@hitenkoku)
+- `-U, --update-rules`オプションで`channel_abbreviations.txt`、`statistics_event_info.txt`、`target_event_IDs.txt`を更新できるように、`config`ディレクトリから`rules/config`ディレクトリに移動した。
+
+## v1.4.0 [2022/06/26]
+
+**新機能:**
+
+- `--target-file-ext` オプションの追加。evtx以外の拡張子を指定する事ができます。ただし、ファイルの中身の形式はevtxファイル形式である必要があります。 (#586) (@hitenkoku)
+- `--exclude-status` オプションの追加。ルール内の`status`フィールドをもとに、読み込み対象から除外するフィルタを利用することができます。 (#596) (@hitenkoku)
+
+**改善:**
+
+- ルール内に`details`フィールドがないときに、`rules/config/default_details.txt`に設定されたデフォルトの出力を行えるようにした。 (#359) (@hitenkoku)
+- Clap Crateパッケージの更新 (#413) (@hitenkoku)
+- オプションの指定がないときに、`--help`と同じ画面出力を行うように変更した。(#387) (@hitenkoku)
+- hayabusa.exeをカレントワーキングディレクトリ以外から動作できるようにした。 (#592) (@hitenkoku)
+- `output` オプションで指定されファイルのサイズを出力するようにした。 (#595) (@hitenkoku)
+
+**バグ修正:**
+
+- カラー出力で長い出力があった場合にエラーが出て終了する問題を修正した。 (#603) (@hitenkoku)
+- `Excluded rules`の合計で`rules/tools/sigmac/testfiles`配下のテストルールも入っていたので、無視するようにした。 (#602) (@hitenkoku)
+
+## v1.3.2 [2022/06/13]
+
+- evtxクレートを0.7.2から0.7.3に更新し、パッケージを全部更新した。 (@YamatoSecurity)
+
+## v1.3.1 [2022/06/13]
+
+**新機能:**
+
+- ルール内の`details`で複数の`Data`レコードから特定のデータを指定して出力できるようにした。 (#487) (@hitenkoku)
+- 読み込んだルールのステータス情報の要約を追加した。 (#583) (@hitenkoku)
+
+**改善:**
+
+- LinuxとmacOSのバイナリサイズをより小さくするために、デバッグシンボルをストリップします。(#568) (@YamatoSecurity)
+- Crateパッケージの更新 (@YamatoSecurity)
+- 新たな時刻表示のオプションとして`--US-time`、`--US-military-time`、`--European-time`の3つを追加した (#574) (@hitenkoku)
+- `--rfc-3339` オプションの時刻表示形式を変更した。 (#574) (@hitenkoku)
+- `-R/ --display-record-id`オプションを`-R/ --hide-record-id`に変更。レコードIDはデフォルトで出力するようにして`-R`オプションを付けた際に表示しないように変更した。(#579) (@hitenkoku)
+- ルール読み込み時のメッセージを追加した。 (#583) (@hitenkoku)
+- `rules/tools/sigmac/testfiles`内のテスト用のymlファイルを読み込まないようにした. (#602) (@hitenkoku)
+
+**バグ修正:**
+
+- 対応するオプションを付与していないときにもRecordIDとRecordInformationの列が出力されていたのを修正した。 (#577) (@hitenkoku)
+
+## v1.3.0 [2022/06/06]
+
+**新機能:**
+
+- `--visualize-timeline`オプションで検知されたイベントが5つ以上の時、イベント頻度のタイムラインを作成するようにした。 (#533, #566) (@hitenkoku)
+- `--all-tags`オプションでルールにある全てのtagsを、outputで指定したcsvのMitreAttackの列に出力するようにした。 (#525) (@hitenkoku)
+- `-R` / `--display-record-id` オプションの追加。evtx file内のレコードを特定するレコードID`<Event><System><EventRecordID>`が出力できるようになった。 (#548) (@hitenkoku)
+- レベルごとの検知数が最も多い日を表示するようにした。 (#550) (@hitenkoku)
+- レベルごとの検知数上位3つのコンピュータ名を表示するようにした。 (#557)(@hitenkoku)
+
+**改善:**
+
+- ルールの`details`でeventkey_alias.txtやEvent.EventData内に存在しない情報を`n/a` (not available)と表記するようにした。(#528) (@hitenkoku)
+- 読み込んだイベント数と検知しなかったイベント数を表示するようにした。 (#538) (@hitenkoku)
+- 新しいロゴに変更した。(#536) (@YamatoSecurity)
+- evtxファイルのファイルサイズの合計を出力するようにした。(#540) (@hitenkoku)
+- ロゴの色を変更した (#537) (@hitenkoku)
+- Channelの列にchannel_abbrevations.txtに記載されていないチャンネルも表示するようにした。(#553) (@hitenkoku)
+- `Ignored rules`として集計されていた`Exclude rules`、`Noisy rules`、`Deprecated rules`に分けて表示するようにした。 (#556) (@hitenkoku)
+- `output`オプションが指定されているときに、ファイル出力中のメッセージを表示するようにした。 (#561) (@hitenkoku)
+
+**バグ修正:**
+
+- `--start-timeline`、`--end-timeline`オプションが動かなかったのを修正した。 (#546) (@hitenkoku)
+- ルール内の`level`が正しくない場合に検知数が最も多い日の集計の際にcrashが起きるのを修正した。 (#560) (@hitenkoku)
+
+## v1.2.2 [2022/05/20]
+
+**新機能:**
+
+- ログオン情報の要約の機能の追加。 (`-L` / `--logon-summary`) (@garigariganzy)
+
+**改善:**
+
+- カラー出力はデフォルトで有効になって、コマンドプロンプトとPowerShellプロンプトに対応している。 (@hitenkoku)
+
+**バグ修正:**
+
+- `rules`フォルダが存在するが、レポジトリがダウンロードされていない場合は、ルール更新が失敗していたが、修正した。(#516) (@hitenkoku)
+- .gitフォルダ内にあるymlファイルが一部のWindows環境で読み込まれた際にエラーが発生していたが、修正した。(#524)(@hitenkoku)
+- 1.2.1バイナリで表示する誤ったバージョン番号の修正。
+
+## v1.2.1 [2022/04/20] Black Hat Asia Arsenal 2022 RC2
+
+**新機能:**
+
+- `./config/channel_abbreviations`の設定ファイルにより、`Channel`列も出力されるようになった。 (@hitenkoku)
+- ルールとルールの設定ファイルは強制的に上書きされる。 (@hitenkoku)
+
+**バグ修正:**
+
+- ルールがnoisyもしくはexcludedと設定された場合は、`--level-tuning`オプションで`level`が更新されなかったが、修正した。 (@hitenkoku)
+
+## v1.2.0 [2022/04/15] Black Hat Asia Arsenal 2022 RC1
+
+**新機能:**
+
+- `-C / --config` オプションの追加。検知ルールのコンフィグを指定することが可能。(Windowsでのライブ調査に便利) (@hitenkoku)
+- `|equalsfield` と記載することでルール内で二つのフィールドの値が一致するかを記載に対応。 (@hach1yon)
+- `-p / --pivot-keywords-list` オプションの追加。攻撃されたマシン名や疑わしいユーザ名などの情報をピボットキーワードリストとして出力する。 (@kazuminn)
+- `-F / --full-data`オプションの追加。ルールの`details`で指定されたフィールドだけではなく、全フィールド情報を出力する。(@hach1yon)
+- `--level-tuning` オプションの追加。ルールの検知ファイルを設定したコンフィグファイルに従って検知レベルをチューニングすることが可能(@itib、@hitenkoku)
+
+**改善:**
+
+- 検知ルールとドキュメントの更新。 (@YamatoSecurity)
+- MacとLinuxのバイナリに必要なOpenSSLライブラリを静的コンパイルした。 (@YamatoSecurity)
+- タブ等の文字が含まれたフィールドに対しての検知性能の改善。 (@hach1yon、@hitenkoku)
+- eventkey_alias.txt内に定義されていないフィールドをEvent.EventData内を自動で検索することが可能。 (@kazuminn、@hitenkoku)
+- 検知ルールの更新時、更新されたルールのファイル名が表示される。 (@hitenkoku)
+- ソースコードにあるClippyの警告を修正。 (@hitenkoku、@hach1yon)
+- イベントIDとタイトルが記載されたコンフィグファイルの名前を `timeline_event_info.txt` から `statistics_event_info.txt`に変更。 (@YamatoSecurity、 @garigariganzy)
+- 64bit Windowsで32bit版のバイナリを実行しないように修正(@hitenkoku)
+- MITRE ATT&CKのデータの出力を`output_tag.txt`で修正できるように修正(@hitenkoku)
+- 出力にChannel名のカラムを追加(@hitenkoku)
+
+**バグ修正:**
+
+- `.git` フォルダ内にある `.yml` ファイルがパースエラーを引き起こしていた問題の修正。 (@hitenkoku)
+- テスト用のルールファイルの読み込みエラーで不必要な改行が発生していた問題の修正。 (@hitenkoku)
+- Windows Terminalのバグで標準出力が途中で止まる場合がありましたが、Hayabusa側で解決しました。 (@hitenkoku)
+
+## v1.1.0 [2022/03/03]
+
+**新機能:**
+
+- `-r / --rules`オプションで一つのルール指定が可能。(ルールをテストする際に便利！) (@kazuminn)
+- ルール更新オプション (`-u / --update-rules`): [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules)レポジトリにある最新のルールに更新できる。 (@hitenkoku)
+- ライブ調査オプション (`-l / --live-analysis`): Windowsイベントログディレクトリを指定しないで、楽にWindows端末でライブ調査ができる。(@hitenkoku)
+
+**改善:**
+
+- ドキュメンテーションの更新。 (@kazuminn、@itiB、@hitenkoku、@YamatoSecurity)
+- ルールの更新。(Hayabusaルール: 20個以上、Sigmaルール: 200個以上) (@YamatoSecurity)
+- Windowsバイナリは静的でコンパイルしているので、Visual C++ 再頒布可能パッケージをインストールする必要はない。(@hitenkoku)
+- カラー出力 (`-c / --color`) True Colorに対応しているターミナル(Windows Terminal、iTerm2等々)ではカラーで出力できる。(@hitenkoku)
+- MITRE ATT&CK戦略が出力される。(@hitenkoku)
+- パフォーマンスの改善。(@hitenkoku)
+- exclude_rules.txtとnoisy_rules.txtの設定ファイルのコメント対応。(@kazuminn)
+- より速いメモリアロケータの利用。 (Windowsの場合はrpmalloc、macOS/Linuxの場合は、jemalloc) (@kazuminn)
+- Cargo crateの更新。 (@YamatoSecurity)
+
+**バグ修正:**
+
+- `cargo update`がより安定するために、clapのバージョンを固定した。(@hitenkoku)
+- フィールドのタブや改行がある場合に、ルールが検知しなかったので、修正した。(@hitenkoku)
+
+## v1.0.0-Release 2 [2022/01/27]
+
+- アンチウィルスに誤検知されたExcelの結果ファイルの削除。(@YamatoSecurity)
+- Rustのevtxライブラリを0.7.2に更新。 (@YamatoSecurity)
+
+## v1.0.0 [2021/12/25]
+
+- 最初のリリース

--- a/website/docs/overview/changelog.md
+++ b/website/docs/overview/changelog.md
@@ -1,0 +1,1051 @@
+# Changelog
+
+!!! info
+    This page mirrors the project [`CHANGELOG.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG.md). See the [Releases page](https://github.com/Yamato-Security/hayabusa/releases) for downloads.
+
+## x.x.x
+
+**Enchancements:**
+
+Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fukusuket)
+
+**Bug Fixes:**
+
+- MITRE ATT&CK Tactics were not line-breaking properly in HTML reports (#1751) (@fukusuket)
+- Fixed the scan progress bar not redrawing in place (each update was printed on a new line) during large scans, caused by literal carriage returns (`\r\n`) in the progress bar template. (#1760) (@YamatoSecurity)
+
+## 3.9.0 [2026/04/29]
+
+**Enchancements:**
+
+Support for MITRE ATT&CK v19. (@fukusuket)
+
+**Other:**
+
+Added unit tests. (#1746) (@Fuzzdkk)
+
+## 3.8.1 [2026/02/24] - Spring Hayfever Release
+
+**Bug Fixes:**
+
+Fixed multiple progress bars issue. (#1740) (@fukusuket)
+
+## 3.8.0 [2026/01/31] - Winter Release
+
+**Bug Fixes:**
+
+- Fixed MaxMind compile error. (#1722) (@fukusuket)
+- When `-GeoIP` is specified, the GeoIP fields were outputed in both the `Details` and `ExtraFieldInfo` in the JSON timelines. (#1724) (@fukusuket)
+- Fixed a possible panic with corrupted logs. (#1732) (@fukusuket)
+
+**Vulnerability Fixes:**
+
+- Fixed an XSS vulnerability in the HTML report if a user scans JSON exported logs (not the standard `.evtx` files) and an attacker has the ability to inject malicious Javascript in the `Computer` field of those logs. (@fukusuket)
+  - Many thanks to the [Mobasi](https://mobasi.ai/) team for finding and reporting this!
+
+## 3.7.0 [2025/11/15] - CODE BLUE Release
+
+**New Features:**
+
+- Added a `-V, --validate-checksums` option to check chunk header checksums in the `csv-timeline` and `json-timeline` commands. (#1709) (@fukusuket)
+
+**Enhancements:**
+
+- Added four new command-line options `--include-channel`, `--exclude-channel`, `--include-filename`, and `--exclude-filename` to the `log-metrics` command. (#1715) (@fukusuket)
+- Updated the Timesketch install readme to support Timesketch on ARM-based Macs. (#1719) (@fukusuket)
+
+**Bug Fixes:**
+
+- When `validate_checksum` is disabled (default), an infinite loop and memory leak when the data_size of an event is set to zero was fixed. (omerbenamram/evtx#264)
+- `-t, --threads` was not working in the `computer-metrics` and `search` commands. (#1563) (@hach1yon)
+- `computer-metrics` was giving incorrect results when logs from multiple comuters were scanned. (#1713) (@fukusuket)
+
+## 3.6.0 [2025/09/25] - Nezamezuki Release
+
+**Enhancements:**
+
+- Event and record IDs with multiple possibilities due to correlation rules are now outputted as empty strings instead of `-` for easier parsing. (#1694) (@fukusuket)
+- We now output first and last detection timestamps instead of just the first and last timestamps found in the `Results Summary` of the `csv-timeline` and `json-timeline` commands. (#1688) (@fukusuket)
+- The guide on how to import Hayabusa JSONL results into SOF-ELK (Elastic Stack) was updated. (#1091) (@yamatosecurity)
+- Output an empty string instead of `-` in the rule's modified date if it is not defined to make importing into a SIEM easier. (#1702) (@yamatosecurity)
+- Empty fields in rule metadata like `RuleModifiedDate`, etc... are not outputted to JSON if they are empty in order to make parsing easier and decrease file size. (#1702) (@fukusuket)
+
+**Bug Fixes:**
+
+- `-T, --visualize-timeline` would output incorrect results if `-s, --sort` was not specified so we now require `-s` when `-T` is used. (#1690) (@yamatosecurity)
+- Records outside the range specified by the time range options (`--timeline-start`/`--timeline-end`) were being displayed because we were filtering with the timestamps in the record headers instead of the timestamps in the records themselves. (#1689) (@fukusuket)
+- GeoIP lookup was not working with `json-timeline`. (#1693) (@fukusuket)
+- The `search` command would not consistently abbreviate fields. (#1697) (@fukusuket)
+
+## 3.5.0 [2025/08/16] - Obon Release
+
+**Enhancements:**
+
+- Hayabusa now supports the `base64` field modifier. (#1677) (@fukusuket)
+
+## 3.4.0 [2025/08/01] - Black Hat Arsenal USA 2025 Release
+
+**Enhancements:**
+
+- Field names are now abbreviated in the `search` command. You can disable with `-b, --disable-abbreviations`. (#1627) (@hitenkoku)
+- 32-bit version of Hayabusa will now also run on 64-bit OSes. (#1665) (@akkuman)
+- We now put a return character after the last line in JSON/L files so that filebeat will not miss the last event. (#1666) (@fukusuket)
+
+**Bug Fixes:**
+
+- Levels would be abbreviated even when `--disable-abbreviations` was enabled. (#1672) (@fukusuket)
+
+## 3.3.0 [2025/03/22] - AUSCERT/SINCON Release
+
+**Enhancements:**
+
+- Now output file size in base 1024 (Ex: `KiB`, `MiB`, `GiB`). (#1648) (@fukusuket)
+- Improved the uptime calculation in the `computer-metrics` command. (#1656) (@fukusuket)
+
+**Bug Fixes:**
+
+- The `computer-metrics` command was not working with the Windows live response package. (#1654) (@fukusuket)
+- `ruletype` field was returned to being an optional field. (#1660) (@fukusuket)
+
+## 3.2.0 [2025/04/02] - Vegemite Release
+
+**Enhancements:**
+
+- Added uptime and timezone info to the `computer-metrics` command. (#1638) (@fukusuket)
+- Improved checking and logging of invalid rules. (#1601) (@fukusuket)
+- Added first and last timestamp to the default output. (#1616) (@fukusuket)
+
+**Bug Fixes:**
+
+- Scans would fail if the `.evtx` file was not able to be opened. (#1634) (@fukusuket)
+- Elapsed time and saved file information was not being outputted in the HTML report. (#1643) (@fukusuket)
+
+## 3.1.1 [2025/03/12] - Laksa Release
+
+**Enhancements:**
+
+- Updated Rust edition to 2024. (@fukusuket)
+- Added OS information to the `computer-metrics` command. (#1629) (@fukusuket)
+
+**Bug Fixes:**
+
+- The number of `expand` rules was not being properly displayed on the terminal. (#1598) (@fukusuket)
+- Rules without the `status` field defined would be loaded even if you specified `status: test, stable`, etc... in the Scan Wizard. (#1602) (@fukusuket)
+- `expand` rules were being loaded without configuration. (#1606) (@fukusuket)
+- Detecting double Base64 encoding was not working properly with the `extract-base64` command. (#1607) (@fukusuket)
+- The terminal text would sometimes turn red after an error message. (#1610) (@fukusuket)
+- The progress bar would not display when `-d` option was used but `-o` was not used for some commands. (#1617) (@fukusuket)
+- The `pivot-keywords-list` command was broken. (#1619) (@fukusuket)
+- Field data mapping was not working when `details` was not defined. (#1614) (@fukusuket)
+- When the `details` field was not set, duplicate data was outputted to both the `Details` column and `ExtraFieldInfo` column. Now it is just outputted to the `Details` column. (#1623) (@fukusuket)
+
+## 3.1.0 [2025/02/22] - Ninja Day Release
+
+**New Features:**
+
+- `-X, --remove-duplicate-detections` option to `eid-metrics` and `logon-summary` commands. (#1552) (@fukusuket)
+- New "Emergency Alerts" and severity level adjustment based on critical systems. Add a list of the computer names of critical systems (Ex: Domain Controllers, File Servers, etc...) to `config/critical_systems.txt` and all of the alerts above `low` will be adjusted one higher. That is, `low` will become `medium`, `medium` will become `high`, etc... `critical` alerts will become new `emergency` alerts. (#1551) (@fukusuket)
+- New `config-critical-systems` command to automatically find domain controllers and file servers to add to the `./config/critical_systems.txt` file. (#1570) (@fukusuket)
+- Added a `-S, --tab-separator` option in the `csv-timeline`, `search` and `log-metrics` commands to separate field information by tabs. (#1587) (@fukusuket)
+
+**Enhancements:**
+
+- Added `--timeline-start/--timeline-end` options to the `search` command. (#1543) (@fukuseket)
+- Significantly improved the speed of the `logon-summary` command with channel filtering. (#1544) (@fukusuket)
+- The `extract-base64` command now also works on `PowerShell Classic EID 400` events. (#1549) (@fukusuket)
+- The `extract-base64` command now also scans PowerShell Core logs as well. (#1558) (@fukusuket)
+- The `extract-base64` command now also scans `System 7045` (Service Creation) events. (#1583) (@fukusuket)
+- `search` command uses much less memory and is faster as it does not sort results by default now. You can sort results like before with the new `-s, --sort` option. (#1475) (@hach1yon)
+
+**Bug Fixes:**
+
+- An unneeded file was being created with `logon-summary` and `pivot-keywords-list` commands. (#1553) (@fukusuket)
+- MITRE tactics JSON output was not consistent for a few rules. (#1573) (@fukusuket)
+- Rule authors would not be outputted to the HTML report in version `v3.0.x`. (#1571) (@fukusuket)
+- The rule file name for correlation rules would not be outputted in the JSON timeline when the live response encoded rules were used. (#1572) (@fukusuket)
+- The `level-tuning` command was not working. (#1584) (@fukusuket)
+
+**Other:**
+
+- The `-s, --sort-events` options have been renamed to `-s, --sort`. (@YamatoSecurity)
+- Added the `RuleID` to all profiles except `minimal`. (@YamatoSecurity)
+- Code refactoring: use default trait to reduce unnecessary initialization codes in StoredStatic. (#1588) (@fukusuket)
+
+## 3.0.1 [2024/12/29] - 3rd Year Anniversary Release
+
+**Bug Fixes:**
+
+- Hayabusa would fail in rule parse checking on the backend with `expand` rules. (#1537) (@fukusuket)
+
+## 3.0.0 [2024/12/25] - 3rd Year Anniversary Release
+
+**New Features:**
+
+- New `extract-base64` command to extract and decode base64 strings from events. (#1512) (@fukusuket)
+- New `expand-list` command to output placeholder names used for rules with the `expand` modifier. (#1513) (@fukuseket)
+- Support for `expand` field modifiers. (#1434) (@fukusuket)
+- Support for Temporal Proximity (`temporal`) correlation rules. (#1446) (@fukusuket)
+- Support for Temporal Ordered Proximity (`temporal_ordered`) correlation rules. (#1447) (@fukusuket)
+
+**Enhancements:**
+
+- Log file size added to `log-metrics` command. (#1528) (@fukusuket)
+
+**Bug Fixes:**
+
+- Sorting with `csv-timeline` was not done perfectly when record IDs were outputted. (#1519) (@fukusuket)
+- `-J, --JSON-input` would only accept `.json` files, not `.jsonl` files so now both are supported. (#1530) (@fukusuket)
+
+## 2.19.0 [2024/11/26] - "Every Day Is A Good Day" Release
+
+**New Features:**
+
+- Support for the `gt`, `gte`, `lt`, `lte` field modifiers. (#1433) (@fukusuket)
+- New `log-metrics` command to get information about `.evtx` files. (computer names, event count, first timestamp, last timestamp, channels, providers) (#1474) (@fukusuket)
+- New `-b, --disable-abbreviations` options for the following commands to disable `Channel` and `Provider` abbreviations for when you want to check the original values. (#1485) (@fukusuket)
+  * `csv-timeline`
+  * `json-timeline`
+  * `eid-metrics`
+  * `log-metrics`
+  * `search`
+- Support for `utf16/utf16be/utf16le/wide` field modifiers to be used with the `base64offset|contains` field modifier. (#1432) (@fukusuket)
+  * `utf16|base64offset|contains`
+  * `utf16be|base64offset|contains`
+  * `utf16le|base64offset|contains`
+  * `wide|base64offset|contains`
+
+**Enhancements:**
+
+- Updated the `yaml-rust` crate to `yaml-rust2`. (#461) (@yamatosecurity)
+- `windash` characters are now being dynamically read from `rules/config/windash_characters.txt`. (#1440) (@fukusuket)
+- `logon-summary` command now displays logon information from RDP events. Note: Hayabusa will output more detailed information when saving to a file. (#1468) (@fukusuket)
+- The colors were updated to make it easier to read. (#1480) (@yamatosecurity)
+- Added start and finish messages of the day. (#1492) (@fukusuket)
+- New color scheme added to output. (#1491) (@fukusuket)
+- File size is now displayed next to the file name under the progress bar. (#1471) (@fukusuket)
+
+**Bug Fixes:**
+
+- `logon-summary` command would sometimes crash with corrupted logs. (#1477) (@fukusuket)
+- Some results would be displayed after the progress bar when outputting results to the terminal with `csv-timeline` and `json-timeline`. (#1459) (@fukusuket)
+- The detailed field value results in aggregation rule alerts were not sorted so `csv-timeline` and `json-timeline` would not output completely exact results each time. (#1466) (@fukusuket)
+- Updated `hayabusa-evtx` crate to `0.8.12`. (@yamatosecurity)
+  - JSON field output order is now preserved according to the original XML. (omerbenamram/evtx #241)
+  - Multiple sub-nodes with attributes and the same name would be overwritten and only the last one kept. (omerbenamram/evtx #245)
+- `logon-summary` and `eid-metrics` would sometimes output multiple progress bars. #1479 (@fukusuket)
+- The progress bar has been removed when outputting to terminal and not sorting events as is unneeded. #1508 (@fukusuket)
+
+**Other:**
+
+- The `--timeline-offset` option has been renamed to `--time-offset`. (#1490) (@yamatosecurity)
+
+## 2.18.0 [2024/10/23] - SecTor Release
+
+**New Features:**
+
+- Support for the `fieldref` modifier (alias to the `equalsfield` modifier). (#1409) (@hitenkoku)
+- The `fieldref|endswith` modifier was created as an alias to `endswithfield` to replace it in the future. (#1437) (@fukusuket)
+- Support for `fieldref|startswith` and `fieldref|contains` modifiers. (#1439) (@fukusuket)
+- Support for XOR encoded rules to minimize files put on the system as well as bypass anti-virus products that give false positives on rules. (#1419) (@fukusuket)
+  - We will include packages in the Releases page that are already configured to use this. If you wanted to manually configure this though, download [encoded_rules.yml](https://github.com/Yamato-Security/hayabusa-encoded-rules/raw/refs/heads/main/encoded_rules.yml) and place it in the Hayabusa's root folder. This file is created from the rules in the hayabusa-rules repository and is automatically updated anytime there is a rule update. Delete all of the files inside the `rules` folder except for the `config` directory as those files are not yet contained in a single file.
+  - Note: The report generated by the `-H` option cannot create a link to the rule (only the rule name is outputted.) 
+  - `rules/config` config files are now loaded from a single file [rules_config_files.txt](https://github.com/Yamato-Security/hayabusa-encoded-rules/raw/refs/heads/main/rules_config_files.txt) to reduce the number of files needed to be stored on a target system for live response. (#1420) (@fukusuket)
+
+**Bug Fixes:**
+
+- Unneeded line breaks when using `-o` in the `search` command. (#1425) (@fukusuket)
+- Sigma correlation rules required the `group-by` field but now it is optional. (#1442) (@fukusuket)
+- Hayabusa will give an error message if the rules referenced by a correlation rule are not found. (#1444) (@fukusuket)
+- Field information was not being outputted when the `all-field-info` profiles were used. (#1450) (@fukusuket)
+
+**Other:**
+
+- License is changed from GPL-3.0 to AGPL-3.0. (@yamatosecurity)
+
+## 2.17.0 [2024/08/23] "HITCON Community Release"
+
+**New Features:**
+
+- Support for the Sigma V2 `|re:` submodifers. (#1399) (@fukusuket)
+  - Reference: https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-modifiers-appendix.md
+    * `|re|i:`: (insensitive) disable case-sensitive matching.
+    * `|re|m:`: (multi-line) match across multiple lines. `^` /`$` match the start/end of line.
+    * `|re|s:`: (single-line) the dot character (`.`) matches all characters, including the newline character.
+- Support for the Sigma V2 `|exists:` modifier. (#1400) (@hitenkoku)
+- Support for the Sigma V2 `|cased:` modifier. (#1401) (@hitenkoku)
+
+**Enhancements:**
+
+- Support for the newer version 0.6.x `cidr-utils` crate. (#1366) (@hitenkoku)
+- Added support for Sigma correlation rule's `name` lookup. (#1363) (@fukusuket)
+- Enabled low memory mode by default. `-s, --low-memory-mode` is now `-s, --sort-events` - Sort events before outputting results. (warning: this uses much more memory!). (#1361) (@hitenkoku)
+  - Note: you need to enable sorting in order to use  `-R, --remove-duplicate-data` and `-X, --remove-duplicate-detections`.
+- Sigma correlation reference rules now do not output alerts by default. You can enable them by adding `generate: true` to the rule. (#1367) (@fukusuket)
+- `Data` fields are now displayed as indexed strings instead of as all `Data` fields or in an array for JSON. (#1371) (@fukusuket)
+  - Before: `"Data": ["17514", "Multiprocessor Free", "Service Pack 1"]`
+  - After: `"Data[3]": "17514", "Data[4]": "Multiprocessor Free", "Data[5]": "Service Pack 1"`
+- The configuration files in the `config` folder are now also embedded in the binary to reduce the number of files in the release package. (#1370) (@hitenkoku)
+  - Note: you will not be able to run the `set-default-profile` command without the `config` directory files as it relies on `config/default_profile.yaml`.
+- Aggregation rule alerts now show `Channel` and `EventID` information even when there are multiple results. (#1342) (@fukusuket)
+- In the JSON timeline, when there is no information in the `Details` field, we changed the default output of `"-"` to `{}` in order to make parsing easier. (#1386) (@hitenkoku)
+- Added support for the `–` (en dash), `—` (em dash), and `―` (horizontal bar) characters for the `windash` modifier to prevent signature bypass. (#1392) (@hitenkoku)
+- Updated the MITRE ATT&CK tags to support Sigma version 2 format. (Ex: `defense_evasion` => `defense-evasion`) (@fukusuket)
+- Updated the `evtx` crate to the latest for enhancements and bug fixes.
+
+**Bug Fixes:**
+
+- Sigma correlation rule count was not showing up in `Events with hits`. (#1373) (@fukusuket)
+- Correlation rule count was not showing up in `Events with hits`. (#1374) (@fukusuket)
+- Aggregation condition rule count was not showing up in `Events with hits`. (#1375) (@fukusuket)
+- In rare cases, the list of rule authors would not be displayed to the terminal. (#1383) (@fukusuket)
+
+## 2.16.0 [2024/06/11] "FIRSTCON24 Release"
+
+**New Features:**
+
+- By default now, only rules that are applicable to loaded evtx files will be enabled. This is based on the `Channel` field in `.evtx` file and `.yml` rule. For example, if `Security.evtx` was being scanned, then only rules that have `Channel: Security` defined will be used against this file. In our benchmarks, this usually gives a speed benefit of around 20% when scanning single `evtx` files but can give up a 10x speed performance depending on the file. If you think there are multiple channels being used in a single `.evtx` file or you want to use rules that do not have the `Channel` field defined in order to scan all `.evtx` files regardless of the channel, then you can turn off this filtering with the `-A, --enable-all-rules` option in `csv-timeline` and `json-timeline`.  (#1317) (@fukusuket)
+  - Currently, the only two detection rules that do not have `Channel` defined and are intended to scan all `.evtx` files are the following:
+    - [Possible Hidden Shellcode](https://github.com/Yamato-Security/hayabusa-rules/blob/main/hayabusa/builtin/UnkwnChannEID_Med_PossibleHiddenShellcode.yml)
+    - [Mimikatz Use](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/win_alert_mimikatz_keywords.yml)
+- By default now, `.evtx` files that have applicable rules will be loaded. So for example, if you are scanning a directory of various event logs but only enable a rule that is looking for `Channel: Security` then Hayabusa will ignore all non-security event logs. In our benchmarks, this gives a speed benefit of around 10% with normal scans and up to 60%+ performance increase when scanning with a single rule. If you want to load all `.evtx` files regardless of channel, then you can turn off this filtering with the `-a, --scan-all-evtx-files` option in `csv-timeline` and `json-timeline`. (#1318) (@fukusuket)
+- Note: Channel filtering only works with .evtx files and you will receive an error if you try to load event logs from a JSON file with `-J, --json-input` and also specify `-A` or `-a`. (#1345) (@fukusuket)
+- Support for Sigma Correlation's Event Count. (#1337) (@fukusuket)
+- Support for Sigma Correlation's Value Count. (#1338) (@fukusuket)
+
+**Enhancements:**
+
+- You can now specify multiple directories with the `-d, --directory` option. (#1335) (@hitenkoku)
+- You can now analyze Splunk logs exported from the REST API. (#1083) (@hitenkoku)
+- You can now specify multiple groups with `count`. Ex: `count() by IpAddress,SubStatus,LogonType >= 2` Also, the output has been updated. Ex: `[condition] count(TargetUserName) by IpAddress > 3 in timeframe [result] count: 4 TargetUserName:tanaka/Administrator/adsyncadmin/suzuki IpAddress:- timeframe:5m` -> `Count: 4 ¦ TargetUserName: tanaka/Administrator/adsyncadmin/suzuki ¦ IpAddress: -` (#1339) (@fukusuket)
+- Added support for specifying an optional `Provider_Name` field in field data mapping files (`rules/config/data_mapping/*.yaml`) as well as support for `Data[x]` notation. (#1350) (@fukusuket)
+- JSON output in count rules now separates field information. (#1342) (@fukusuket)
+  - Before: `"Details": "[condition] count() by IpAddress >= 5 in timeframe [result] count:3558 IpAddress:192.168.198.149 timeframe:5m"`
+  - After: `"Details": { "Count": 3558, "IpAddress": "192.168.198.149" }`
+
+## 2.15.0 [2024/04/20] "Sonic Release"
+
+**Enhancements:**
+
+- Added support for `windash` field modifier (ex. `|contains|windash:`, `|contains|all|windash:`) in sigma rules. (#1319) (@hitenkoku)
+  - https://sigmahq.io/docs/basics/modifiers.html#windash
+  - Note: currently on the backend we convert the use of `windash` in rules so they are compatibile with previous versions of Hayabusa, however, around the end of May we will start to keep the use of `windash` as-is so please update to this version before then or else you will recieve rule parsing errors if you update rules.
+
+**Bug Fixes:**
+
+- `-T` detection frequency timeline was not usable in version 2.14.0. (#1322) (@fukusuket)
+- Fixed `windash` not working when there is a wildcard. (#1327) (@hitenkoku)
+
+## 2.14.0 [2024/03/30] "BSides Tokyo Release"
+
+**New Features:**
+
+- Added `--include-status` option: You can specify rules based on their `status`. (#1193) (@hitenkoku)
+- Added a `-s, --low-memory-mode` option that uses up to 95% less memory. However, in order to do this, Hayabusa cannot sort results nor use `-R, --remove-duplicate-data` and/or `-X, --remove-duplicate-detections` in combination.  (#1254) (@hach1yon @hitenkoku)
+
+**Enhancements:**
+
+- Removed unused crates. (@YamatoSecurity)
+- JSON input now supports the format exported from Splunk. (#1083) (@hitenkoku)
+- Performance enchancements. (#1277, #1278) (@fukusuket)
+- Reordered `search` result fields to look similar to the `csv-timeline` command results. (#1297) (@hitenkoku)
+- Added master piece character in ascii art eggs. R.I.P. lovely master hidden behind the gas mask. (#1304) (@hitenkoku)
+- Unified help option format in `computer-metrics` command with other commands. (#1314) (@hitenkoku)
+
+**Bug Fixes:**
+
+- JSON output of the `search` command was missing the `AllFieldInfo` field. (#1251) (@hitenkoku)
+- The time the user took to choose options in the scan wizard was included in elapsed time so we now exclude that. (#1291) (@hitenkoku)
+- Fixed `-h, --help` option is being displayed multiple times. (#1309) (@hitenkoku)
+
+## 2.13.0 [2024/02/11] "Year Of The Dragon Release"
+
+**Enhancements:**
+
+- Adjusted the `search` command's Filter option to be an exact match and support wildcard characters. (#1240) (@hitenkoku)
+- Any time there is a change in a detection rule, it will be displayed when running the `update-rules` command. Previously, only rules that updated their `modified` field would be displayed. (#1243) (@hitenkoku)
+- The `json-timeline` command now outputs in JSON format when outputting to the terminal. (#1197) (@hitenkoku)
+- Added support for parsing JSON input when the data is inside an array. (#1248) (@hitenkoku)
+- Changed the `‖` separator into a `·` separator to make it easier to read and render properly on older terminals. (#1258) (@YamatoSecurity)
+- Added a `-h, --help` option to General Options for all commands. (#1255) (@hitenkoku)
+- Changed the `Details` output in the `json-timeline` command from alphabetical order to the original order.
+- Loading detection rules is now skipped when running commands that do not need them. (#1263) (@hitenkoku)
+- Improved the standard output colors in the `csv-timeline` command. (#1271) (@hitenkoku)
+- Refactoring and performance enhancements. (#1268, #1260) (@hach1yon)
+
+**Bug Fixes:**
+
+- Removed newline characters in the `search` command output. (#1253) (@hitenkoku)
+- Fixed the progress bar and wizard colored output when the `--no-color` option is used. (#1256) (@hitenkoku)
+- Fixed a panic when the local timezone was not able to be identified. This was fixed in the `chrono` crate version 0.4.32. (#1273)
+
+## 2.12.0 [2023/12/23] "SECCON Christmas Release"
+
+**Enhancements:**
+
+- `%MitreTactics%`, `%MitreTags%`, `%OtherTags%` fields are now outputted as an array of strings in JSON output. (#1230) (@hitenkoku)
+- Added a summary of MITRE ATT&CK tactics that were detected for each computer in the HTML report. In order to use this feature, you need to use a profile that includes the `%MitreTactics%` field. (#1226) (@hitenkoku)
+- Output messages about reporting issues and false positives when using `csv-timeline` or `json-timeline` commands. (#1236) (@hitenkoku)
+
+**Bug Fixes:**
+
+- In JSON output, multiple field names with the same names were not outputted as an array so only one result would be returned when parsing with `jq`. We fixed this by outputting multiple field data with the same field name inside an array. (#1202) (@hitenkoku)
+- Fixed a bug in the `csv-timeline`, `json-timeline`, `eid-metrics`, `logon-summary`, `pivot-keywords-list` and `search` commands so that Hayabusa will quit whenever no input option (`-l`, `-f` or `-d`) is specified. (#1235) (@hitenkoku)
+
+## 2.11.0 [2023/12/03] "Nasi Lemak Release"
+
+**New Features:**
+
+- Extraction of fields from PowerShell classic logs. (Can disable with `--no-pwsh-field-extraction`) (#1220) (@fukusuket)
+
+**Enhancements:**
+
+- Added rule count in the scan wizard. (#1206) (@hitenkoku)
+
+## 2.10.1 [2023/11/13] "Kamemushi Release"
+
+**Enhancements:**
+
+- Added questions to the scan wizard. (#1207) (@hitenkoku)
+
+**Bug Fixes:**
+
+- `update-rules` command would output `You currently have the latest rules` even if new rules were downloaded in version `2.10.0`. (#1209) (@fukusuket)
+- Regular expressions would sometimes be incorrectly handled. (#1212) (@fukusuket)
+- In the rare case that there is no `Data` field such as for JSON input, a panic would occur. (#1215) (@fukusuket)
+
+## 2.10.0 [2023/10/31] "Halloween Release"
+
+**Enhancements:**
+
+- Added a scan wizard to help new users choose which rules they want to enable. Add the `-w, --no-wizard` option to run Hayabusa in the traditional way. (Scan for all events and alerts, and customize options manually.) (#1188) (@hitenkoku)
+- Added the `--include-tag` option to the `pivot-keywords-list` command to only load rules with the specified `tags` field. (#1195) (@hitenkoku)
+- Added the `--exclude-tag` option to the `pivot-keywords-list` command to exclude rules with specific `tags` from being loaded. (#1195) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed that field information defined in `Details` was also output to `ExtraFieldInfo` in some cases. (#1145) (@hitenkoku)
+- Fixed output of newline and tab characters in `AllFieldInfo` in JSON output. (#1189) (@hitenkoku)
+- Fixed output of space characters in some fields in standard output. (#1192) (@hitenkoku)
+
+## 2.9.0 [2023/09/22] "Autumn Rain Release"
+
+**Enhancements:**
+
+- Added an error message to indicate that when you can't load evtx files in Windows due to specifying a directory path with spaces in it, you need to remove the trailing backslash. (#1166) (@hitenkoku, thanks for the suggestion from @joswr1ght)
+- Optimized the number of records to load at a time for performance. (#1175) (@yamatosecurity)
+- Replaced double backslashes in paths under the progress bar on Windows systems with single forward slashes. (#1172) (@hitenkoku)
+- Made the `Details` field for `count` rules a string in the JSON output for easier parsing. (#1179) (@hitenkoku)
+- Changed the default number of threads from number of CPUs to the estimate of the default amount of parallelism a program should use (`std::thread::available_parallelism`). (#1182) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed JSON fields would not be correctly parsed in rare cases. (#1145) (@hitenkoku)
+
+**Other:**
+
+- Removed the unmaintained `hhmmss` crate that uses an old `time` crate in order to pass the code coverage CI checks. (#1181) (@hitenkoku)
+
+## 2.8.0 [2023/09/01] "Double X Release"
+
+**New Features:**
+
+- Added support for `HexToDecimal` in the field mapping configuration files to convert hex values to decimal. (Useful for converting the original process IDs from hex to decimal.) (#1133) (@fukusuket)
+- Added `-x, --recover-records` option to `csv-timeline` and `json-timeline` to recover evtx records through file carving in evtx slack space. (#952) (@hitenkoku) (Evtx carving feature is thanks to @forensicmatt)
+- Added `-X, --remove-duplicate-detections` option to `csv-timeline` and `json-timeline` to not output any duplicate detection entries. (Useful when you use `-x`, include backup logs or logs extracted from VSS with duplicate data, etc...)
+- Added a `--timeline-offset` option to `csv-timeline`, `json-timeline`, `logon-summary`, `eid-metrics`, `pivot-keywords-list` and `search` commands to scan just recent events based on a offset of years, months, days, hours, etc... (#1159) (@hitenkoku)
+- Added a `-a, --and-logic` option in the `search` command to search keywords with AND logic. (#1162) (@hitenkoku)
+
+**Other:**
+
+- When using `-x, --recover-records`, an additional `%RecoveredRecord%` field will be added to the output profile and will output `Y` to indicate if a record was recovered. (#1160) (@hitenkoku)
+
+## 2.7.0 [2023/08/03] "SANS DFIR Summit Release"
+
+**New Features:**
+
+- Certain code numbers are now mapped to human-readable messages based on the `.yaml` config files in `./rules/config/data_mapping`. (Example: `%%2307` will be converted to `ACCOUNT LOCKOUT`). You can turn off this behavior with the `-F, --no-field-data-mapping` option. (#177) (@fukusuket)
+- Added the `-R, --remove-duplicate-data` option in the `csv-timeline` command to replace duplicate field data with the string `DUP` in the `%Details%`, `%AllFieldInfo%`, `%ExtraFieldInfo%` columns to reduce file size. (#1056) (@hitenkoku)
+- Added the `-P, --proven-rules` option in `csv-timeline` and `json-timeline` commands. When used, Hayabusa will only load rules that have been proven to work. These are defined by rule ID in the `./rules/config/proven_rules.txt` config file. (#1115) (@hitenkoku)
+- Added the `--include-tag` option to `csv-timeline` and `json-timeline` commands to only load rules with the specified `tags` field. (#1108) (@hitenkoku)
+- Added the `--exclude-tag` option to `csv-timeline` and `json-timeline` commands to exclude rules with specific `tags` from being loaded. (#1118) (@hitenkoku)
+- Added `--include-category` and `--exclude-category` options to `csv-timeline` and `json-timeline` commands. When using `--include-category`, only rules with the specified `category` field will be loaded. `--exclude-category` will exclude rules from being loaded based on `category`. (#1119) (@hitenkoku)
+- Added the `computer-metrics` command to list up how many events there are based on computer name. (#1116) (@hitenkoku)
+- Added `--include-computer` and `--exclude-computer` options to `csv-timeline`, `json-timeline`, `metrics`, `logon-summary` and `pivot-keywords-list` commands. The `--include-computer` option only scans the specified computer(s). `--exclude-computer` excludes them. (#1117) (@hitenkoku)
+- Added `--include-eid` and `--exclude-eid` options to `csv-timeline`, `json-timeline`, and `pivot-keywords-list` commands. The `--include-eid` option only scans the specified EventID(s). `--exclude-eid` excludes them. (#1130) (@hitenkoku)
+- Added the `-R, --remove-duplicate-data` option to the `json-timeline` command to replace duplicate field data with the string `DUP` in the `%Details%`, `%AllFieldInfo%`, `%ExtraFieldInfo%` fields to reduce file size. (#1134) (@hitenkoku)
+
+**Enhancements:**
+
+- Ignore corrupted event records with timestamps before 2007/1/31 when Windows Vista was released with the new `.evtx` log format. (#1102) (@fukusuket)
+- When `--output` is set in the `metrics` command, the results will not be displayed to screen. (#1099) (@hitenkoku)
+- Added the `-C, --clobber` option to overwrite existing output files in the `pivot-keywords-list` command. (#1125) (@hitenkoku)
+- Renamed the `metrics` command to `eid-metrics`. (#1128) (@hitenkoku)
+- Reduced progress bar width to leave room for adjustment of the terminal. (#1135) (@hitenkoku)
+- Added support for outputing timestamps in the following formats in the `search` command: `--European-time`, `--ISO-8601`, `--RFC-2822`, `--RFC-3339`, `--US-time`, `--US-military-time`, `-U, --UTC`. (#1040) (@hitenkoku)
+- Replaced the ETA time in the progress bar with elapsed time as the ETA time was not accurate. (#1143) (@YamatoSecurity)
+- Added `--timeline-start` and `--timeline-end` to the `logon-summary` command. (#1152) (@hitenkoku)
+
+**Bug Fixes:**
+
+- The total number of records being displayed in the `metrics` and `logon-summary` commands differed from the `csv-timeline` command. (#1105) (@hitenkoku)
+- Changed rule count by rule ID instead of path. (#1113) (@hitenkoku)
+- Fixed a problem with incorrect field splitting in the `CommandLine` field in JSON output. (#1145) (@hitenkoku)
+- `--timeline-start` and `--timeline-end` were not working correctly with the `json-timeline` command. (#1148) (@hitenkoku)
+- `--timeline-start` and `--timeline-end` were not working correctly with the `pivot-keywords-list` command. (#1150) (@hitenkoku)
+
+**Other:**
+
+- The total count of unique detections are now based on rule IDs instead of rule file paths. (#1111) (@hitenkoku)
+- Renamed the `--live_analysis` option to `--live-analysis`. (#1139) (@hitenkoku)
+- Renamed the `metrics` command to `eid-metrics`. (#1128) (@hitenkoku)
+
+## 2.6.0 [2023/06/16] "Ajisai Release"
+
+**New Features:**
+
+- Added support for `'|all':`  keyword in sigma rules. (#1038) (@kazuminn)
+
+**Enhancements:**
+
+- Added `%ExtraFieldInfo%` alias to output profiles which will output all of the other fields that do not get outputted in `Details`. This is now included in the default `standard` output profile. (#900) (@hitenkoku)
+- Added error messages for incompatible arguments. (#1054) (@YamatoSecurity)
+- The output profile name is now outputted to standard output and in the HTML report. (#1055) (@hitenkoku)
+- Added rule author names next to rule alerts in the HTML report. (#1065) (@hitenkoku)
+- Made the table width shorter to prevent tables breaking in smaller terminal sizes. (#1071) (@hitenkoku)
+- Added the `-C, --clobber` option to overwrite existing output files in `csv-timeline`, `json-timeline`, `metrics`, `logon-summary`, and `search` commands. (#1063) (@YamatoSecurity, @hitenkoku)
+- Made the HTML report portable by embedding the images and inlining CSS. (#1078) (@hitenkoku, thanks for the suggestion from @joswr1ght)
+- Speed improvements in the output. (#1088) (@hitenkoku, @fukusuket)
+- The `metrics` command now performs word wrapping to make sure the table gets rendered correctly. (#1067) (@garigariganzy)
+- `search` command results can now be outputted to JSON/JSONL. (#1041) (@hitenkoku)
+
+**Bug Fixes:**
+
+- `MitreTactics`, `MitreTags`, `OtherTags` fields were not being outputted in the `json-timeline` command. (#1062) (@hitenkoku)
+- The detection frequency timeline (`-T`) would not output when the `no-summary` option was also enabled. (#1072) (@hitenkoku)
+- Control characters would not be escaped in the `json-timeline` command causing a JSON parsing error. (#1068) (@hitenkoku)
+- In the `metrics` command, channels would not be abbreviated if they were lowercase. (#1066) (@garigariganzy)
+- Fixed an issue where some fields were misaligned in the JSON output. (#1086) (@hitenkoku)
+
+## 2.5.1 [2023/05/14] "Mothers Day Release"
+
+**Enhancements:**
+
+- Reduced memory usage by half when using newly converted rules. (#1047) (@fukusuket)
+
+**Bug Fixes:**
+
+- Data in certain fields such as `AccessMask` would not be separated by spaces when outputted from the `details` field. (#1035) (@hitenkoku)
+- Multiple spaces would be condensed to a single space when outputting to JSON. (#1048) (@hitenkoku)
+- Output would be in color even if `--no-color` was used in the `pivot-keywords-list` command. (#1044) (@kazuminn)
+
+## 2.5.0 [2023/05/07] "Golden Week Release"
+
+**Enhancements:**
+
+- Added `-M, --multiline` option to search command. (#1017) (@hitenkoku)
+- Deleted return characters in the output of the `search` command. (#1003) (@hitenkoku)
+- `regex` crate updated to 1.8 which allows unnecessary escapes in regular expressions reducing parsing errors. (#1018) (@YamatoSecurity)
+- Deleted return characters in output of the `csv-timeline` command. (#1019) (@hitenkoku)
+- Don't show new version information with the `update-rules` command when building a newer dev build. (#1028) (@hitenkoku)
+- Sorted `search` timeline order. (#1033) (@hitenkoku)
+- Enhanced `pivot-keywords-list` terminal output. (#1022) (@kazuminn)
+
+**Bug Fixes:**
+
+- Unconverted sigma rules that search for a string that end in a backslash would not be detected. Also `|contains` conditions would not match if the string was located in the beginning. (#1025) (@fukusuket)
+- In versions 2.3.3-2.4.0, informational level alerts in the Results Summary would show the top 5 events twice instead of the top 10 events. (#1031) (@hitenkoku)
+
+## 2.4.0 [2023/04/19] "SANS Secure Korea Release"
+
+**New Features:**
+
+- Added `search` command to search for specified keywords in records. (#617) (@itiB, @hitenkoku)
+- Added `-r, --regex` option in the `search` command to search for regular expressions. (#992) (@itiB)
+
+**Enhancements:**
+
+- Alphabetically sorted commands. (#991) (@hitenkoku)
+- Added attribute information of `Event.UserData` to the output of `AllFieldInfo` in `csv-timeline`, `json-timeline` and `search` commands. (#1006) (@hitenkoku)
+- Updated Aho-Corasick crate to 1.0. (#1013) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed timestamps that did not exist from being displayed in the event frequency timeline (`-T, --visualize-timeline`) in version 2.3.3. (#977) (@hitenkoku)
+
+## 2.3.3 [2023/04/07] "Sakura Release"
+
+**Enhancements:**
+
+- Removed an extra space when outputting the rule `level` to files (CSV, JSON, JSONL). (#979) (@hitenkoku)
+- Rule authors are now outputted in multiple lines with the `-M, --multiline` option. (#980) (@hitenkoku)
+- Approximately 3-5% speed increase by replacing String with CoW. (#984) (@hitenkoku)
+- Made sure text after the logo does not turn green with recent clap versions. (#989) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a crash when the `level-tuning` command was executed on version 2.3.0. (#977) (@hitenkoku)
+
+## 2.3.2 [2023/03/22] "TMCIT Release-3"
+
+**Enhancements:**
+
+- Added `-M, --multiline` option in the `csv-timeline` command. (#972) (@hitenkoku)
+
+## 2.3.1 [2023/03/18] "TMCIT Release-2"
+
+**Enhancements:**
+
+- Added double quotes in CSV fields of `csv-timeline` output to support multiple lines in fields. (#965) (@hitenkoku)
+- Updated `logon-summary` headers. (#964) (@yamatosecurity)
+- Added short-hand option `-D` for `--enable-deprecated-rules` and `-u` for `--enable-unsupported-rules`. (@yamatosecurity)
+- Reordered option in Filtering and changed option help contents. (#969) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a crash when the `update-rules` command was executed on version 2.3.0. (#965) (@hitenkoku)
+- Fixed long underlines displayed in the help menu in Command Prompt and PowerShell prompt. (#911) (@yamatosecurity)
+
+## 2.3.0 [2023/03/16] "TMCIT Release"
+
+**New Features:**
+
+- Added support for `|cidr`. (#961) (@fukusuket)
+- Added support for `1 of selection*` and `all of selection*`. (#957) (@fukusuket)
+- Added support for the `|contains|all` pipe keyword. (#945) (@hitenkoku)
+- Added the `--enable-unsupported-rules` option to enable rules marked as `unsupported`. (#949) (@hitenkoku)
+
+**Enhancements:**
+
+- Approximately 2-3% speed increase and memory usage reduction by improving string contains check. (#947) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Some event titles would be displayed as `Unknown` in the `metrics` command even if they were defined. (#943) (@hitenkoku)
+
+## 2.2.2 [2023/2/22] "Ninja Day Release"
+
+**New Features:**
+
+- Added support for the `|base64offset|contains` pipe keyword. (#705) (@hitenkoku)
+
+**Enhancements:**
+
+- Reorganized the grouping of command line options. (#918) (@hitenkoku)
+- Reduced memory usage by approximately 75% when reading JSONL formatted logs. (#921) (@fukusuket)
+- Channel names are now further abbreviated in the metrics, json-timeline, csv-timeline commands according to `rules/config/generic_abbreviations.txt`. (#923) (@hitenkoku)
+- Reduced parsing errors by updating the evtx crate. (@YamatoSecurity)
+- Provider names (`%Provider%` field) are now abbreviated like channel names according to `rules/config/provider_abbreviations.txt` and `rules/config/generic_abbreviations.txt`. (#932) (@hitenkoku)
+- Print the first and last timestamps in the metrics command when the `-d` directory option is used. (#935) (@hitenkoku)
+- Added first and last timestamp to Results Summary. (#938) (@hitenkoku)
+- Added Time Format options for `logon-summary`, `metrics` commands. (#938) (@hitenkoku)
+- `\r`, `\n`, and `\t` characters are preserved (not converted to spaces) when saving results with the `json-output` command. (#940) (@hitenkoku)
+
+**Bug Fixes:**
+
+- The first and last timestamps in the `logon-summary` and `metrics` commands were blank. (#920) (@hitenkoku)
+- Event titles stopped being shown in the `metrics` command during development of 2.2.2. (#933) (@hitenkoku)
+
+## 2.2.0 [2023/2/12] "SECCON Release"
+
+**New Features:**
+
+- Added support for input of JSON-formatted event logs (`-J, --JSON-input`). (#386) (@hitenkoku)
+- Log enrichment by outputting the ASN organization, city and country of source and destination IP addresses based on MaxMind GeoIP databases (`-G, --GeoIP`). (#879) (@hitenkoku)
+- Added the `-e, --exact-level` option to scan for only specific rule levels. (#899) (@hitenkoku)
+
+**Enhancements:**
+
+- Added the executed command line to the HTML report. (#877) (@hitenkoku)
+- Approximately 3% speed increase and memory usage reduction by performing exact string matching on Event IDs. (#882) (@fukusuket)
+- Approximately 14% speed increase and memory usage reduction by filtering before regex usage. (#883) (@fukusuket)
+- Approximately 8% speed increase and memory usage reduction by case-insensitive comparisons instead of regex usage. (#884) (@fukusuket)
+- Approximately 5% speed increase and memory usage reduction by reducing regex usage in wildcard expressions. (#890) (@fukusuket)
+- Further speed increase and memory usage reduction by removing unnecessary regex usage. (#894) (@fukusuket)
+- Approximately 3% speed increase and 10% memory usage reduction by reducing regex usage. (#898) (@fukuseket)
+- Improved `-T, --visualize-timeline` by increasing the height of the markers to make it easier to read. (#902) (@hitenkoku)
+- Reduced memory usage by approximately 50% when reading JSON/L formatted logs. (#906) (@fukusuket)
+- Alphabetically sorted options based on their long names. (#904) (@hitenkoku)
+- Added JSON input support (`-J, --JSON-input` option) for `logon-summary`, `metrics` and `pivot-keywords-list` commands. (#908) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a bug when rules with 4 consecutive backslashes in their conditions would not be detected. (#897) (@fukusuket)
+- When parsing PowerShell EID 4103, the `Payload` field would be separated into multiple fields when outputting to JSON. (#895) (@hitenkoku)
+- Fixed a crash when looking up event log file size. (#914) (@hitenkoku)
+
+**Vulnerability Fixes:**
+
+- Updated the git2 and gitlib2 crates to prevent a possible SSH MITM attack (CVE-2023-22742) when updating rules and config files. (#888) (@YamatoSecurity)
+
+## 2.1.0 [2023/01/10] "Happy Year of the Rabbit Release"
+
+**Enhancements:**
+
+- Speed improvements. (#847) (@hitenkoku)
+- Improved speed by up to 20% by improving I/O processesing. (#858) (@fukusuket)
+- The timeline order of detections are now sorted to a fixed order even when the timestamp is identical. (#827) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Successful login CSV results were not correctly being outputted when using the logon timeline function. (#849) (@hitenkoku)
+- Removed unnecessary line breaks that would occur when using the `-J, --jsonl` option. (#852) (@hitenkoku)
+
+## 2.0.0 [2022/12/24] "Merry Christmas Release"
+
+**New Features:**
+
+- Command usage and help menu are now done by subcommands. (#656) (@hitenkoku)
+
+## 1.9.0 [2022/12/24] "Merry Christmas Release"
+
+**New Features:**
+
+- Added a new pipe keyword. (`|endswithfield`) (#740) (@hach1yon)
+- Added `--debug` option to display memory utilization at runtime. (#788) (@fukusuket)
+
+**Enhancements:**
+
+- Updated clap crate package to version 4 and changed the `--visualize-timeline` short option `-V` to `-T`. (#725) (@hitenkoku)
+- Added output of logon types, source computer and source IP address in Logon Summary as well as failed logons. (#835) (@garigariganzy @hitenkoku)
+- Optimized speed and memory usage. (#787) (@fukusuket)
+- Changed output color in eggs ascii art.(#839) (@hitenkoku)
+- Made the `--debug` option hidden by default. (#841) (@hitenkoku)
+- Added color to the ascii art eggs. (#839) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a bug where evtx files would not be loaded if run from a command prompt and the directory path was enclosed in double quotes. (#828) (@hitenkoku)
+- Fixed unneeded spaces outputted when there were rule parsing errors. (#829) (@hitenkoku)
+
+## 1.8.1 [2022/11/21]
+
+**Enhancements:**
+
+- Specified the minimum Rust version `rust-version` field in `Cargo.toml` to avoid build dependency errors. (#802) (@hitenkoku)
+- Reduced memory usage. (#806) (@fukusuket)
+- Added the support for the `%RenderedMessage%` field in output profiles which is the rendered message in logs forwarded by WEC. (#760) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a problem where rules using the `Data` field were not being detected. (#775) (@hitenkoku)
+- Fixed a problem where the `%MitreTags%` and `%MitreTactics%` fields would randomly miss values. (#807) (@fukusuket)
+
+## 1.8.0 [2022/11/07]
+
+**New Features:**
+
+- Added the `--ISO-8601` output time format option. This good to use when importing to Elastic Stack. It is exactly the same as what is in the original log.  (#767) (@hitenkoku)
+
+**Enhancements:**
+
+- Event ID filtering is now turned off by default. Use the `-e, --eid-filter` option to filter by Event ID. (Will usually be 10%+ faster but with a small chance of false negatives.) (#759) (@hitenkoku)
+- Print an easy to understand error message when a user tries to download new rules with a different user account. (#758) (@fukusuket)
+- Added total and unique detecion count information in the HTML Report. (#762) (@hitenkoku)
+- Removed unnecessary array structure in the JSON output. (#766)(@hitenkoku)
+- Added rule authors (`%RuleAuthor%`), rule creation date (`%RuleCreationDate%`), rule modified date (`%RuleModifiedDate%`), and rule status (`%Status%`) fields to output profiles. (#761) (@hitenkoku)
+- Changed Details field in JSON output to an object. (#773) (@hitenkoku)
+- Removed `build.rs` and changed the memory allocator to mimalloc for a speed increase of 20-30% on Intel-based OSes. (#657) (@fukusuket)
+- Replaced `%RecordInformation%` alias in output profiles to `%AllFieldInfo%`, and changed the `AllFieldInfo` field in JSON output to an object. (#750) (@hitenkoku)
+- Removed `HBFI-` prefix in `AllFieldInfo` field of json output. (#791) (@hitenkoku)
+- Don't display result summary, etc... when `--no-summary` option is used. (This is good to use when using as a Velociraptor agent, etc... It will usually be 10% faster.) (#780) (@hitenkoku)
+- Reduced memory usage and improved speed performance. (#778 #790) (@hitenkoku)
+- Don't display Rule Authors list when authors list is empty. (#795) (@hitenkoku)
+- Added rule ID (`%RuleID%`) and Provider Name (`%Provider%`) fields to output profiles. (#794) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed rule author unique rule count. (It was displaying one extra.) (#783) (@hitenkoku)
+
+## 1.7.2 [2022/10/17]
+
+**New Features:**
+
+- Added `--list-profiles` option to print a list of output profiles. (#746) (@hitenkoku)
+
+**Enhancements:**
+
+- Moved the saved file line and shortened the update option output. (#754) (@YamatoSecurity)
+- Limited rule author names of detected alerts to 40 characters. (#751) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a bug where field information would get moved over in JSON/JSONL output when a drive letter (ex: `c:`) was in the field. (#748) (@hitenkoku)
+
+## 1.7.1 [2022/10/10]
+
+**Enhancements:**
+
+- Hayabusa now checks Channel and EID information based on `rules/config/channel_eid_info.txt` to provide more accurate results. (#463) (@garigariganzy)
+- Do not display a message about loading detection rules when using the `-M` or `-L` options. (#730) (@hitenkoku)
+- Added a table of rule authors to standard output. (#724) (@hitenkoku)
+- Ignore event records when the channel name is `null` (ETW events) when scanning and showing EID metrics. (#727) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a bug where the same Channel and EID would be counted separately with the `-M` option. (#729) (@hitenkoku)
+
+## 1.7.0 [2022/09/29]
+
+**New Features:**
+
+- Added a HTML summary report output option (`-H, --html-report`). (#689) (@hitenkoku, @nishikawaakira)
+
+**Enhancements:**
+
+- Changed Event ID Statistics option to Event ID Metrics option. (`-s, --statistics`  -> `-M, --metrics`) (#706) (@hitenkoku)
+  (Note: `statistics_event_info.txt` was changed to `event_id_info.txt`.)
+- Display new version of Hayabusa link when updating rules if there is a newer version. (#710) (@hitenkoku)
+- Added logo in HTML summary output. (#714) (@hitenkoku)
+- Unified output to one table when using `-M` or `-L` with the `-d` option. (#707) (@hitenkoku)
+- Added Channel column to metrics output. (#707) (@hitenkoku)
+- Removed First Timestamp and Last Timestamp of `-M` and `-L` option with the `-d` option. (#707) (@hitenkoku)
+- Added csv output option(`-o --output`) when `-M` or `-L` option is used. (#707) (@hitenkoku)
+- Separated Count and Percent columns in metric output. (#707) (@hitenkoku)
+- Changed output table format of the metric option and logon information crate from prettytable-rs to comfy_table. (#707) (@hitenkoku)
+- Added favicon.png in HTML summary output. (#722) (@hitenkoku)
+
+## v1.6.0 [2022/09/16]
+
+**New Features:**
+
+- You can now save the timeline to JSON files with the `-j, --json` option.  (#654) (@hitenkoku)
+- You can now save the timeline to JSONL files with the `-J, --jsonl` option.  (#694) (@hitenkoku)
+
+**Enhancements:**
+
+- Added top alerts to results summary. (#667) (@hitenkoku)
+- Added `--no-summary` option to not display the results summary. (#672) (@hitenkoku)
+- Made the results summary more compact. (#675 #678) (@hitenkoku)
+- Made Channel field in channel_abbreviations.txt case-insensitive. (#685) (@hitenkoku)
+- Changed pipe separator character in output from `|` to `‖`. (#687) (@hitenkoku)
+- Added color to Saved alerts and events / Total events analyzed. (#690) (@hitenkoku)
+- Updated evtx crate to 0.8.0. (better handling when headers or date values are invalid.)
+- Updated output profiles. (@YamatoSecurity)
+
+**Bug Fixes:**
+
+- Hayabusa would crash with `-L` option (logon summary option). (#674) (@hitenkoku)
+- Hayabusa would continue to scan without the correct config files but now will print and error and gracefully terminate. (#681) (@hitenkoku)
+- Fixed total events from the number of scanned events to actual events in evtx. (#683) (@hitenkoku)
+
+## v1.5.1 [2022/08/20]
+
+**Enhancements:**
+
+- Re-released v1.5.1 with an updated output profile that is compatible with Timesketch. (#668) (@YamatoSecurity)
+
+## v1.5.1 [2022/08/19]
+
+**Bug Fixes:**
+
+- Critical, medium and low level alerts were not being displayed in color. (#663) (@fukusuket)
+- Hayabusa would crash when an evtx file specified with `-f` did not exist. (#664) (@fukusuket)
+
+## v1.5.0 [2022/08/18]
+
+**New Features:**
+
+- Customizable output of fields defined at `config/profiles.yaml` and `config/default_profile.yaml`. (#165) (@hitenkoku)
+- Implemented the `null` keyword for rule detection. It is used to check if a target field exists or not. (#643) (@hitenkoku)
+- Added output to JSON option (`-j` and `--json-timeline` )  (#654) (@hitenkoku)
+
+**Enhancements:**
+
+- Trimmed `./` from the rule path when updating. (#642) (@hitenkoku)
+- Added new output aliases for MITRE ATT&CK tags and other tags. (#637) (@hitenkoku)
+- Organized the menu output when `-h` is used. (#651) (@YamatoSecurity and @hitenkoku)
+- Added commas to summary numbers to make them easier to read. (#649) (@hitenkoku)
+- Added output percentage of detections in Result Summary. (#658) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed miscalculation of Data Reduction due to aggregation condition rule detection. (#640) (@hitenkoku)
+- Fixed a race condition bug where a few events (around 0.01%) would not be detected. (#639 #660) (@fukusuket)
+
+## v1.4.3 [2022/08/03]
+
+**Bug Fixes:**
+
+- Hayabusa would not run on Windows 11 when the VC redistribute package was not installed but now everything is compiled statically. (#635) (@fukusuket)
+
+## v1.4.2 [2022/07/24]
+
+**Enhancements:**
+
+- You can now update rules to a custom directory by combining the `--update-rules` and `--rules` options. (#615) (@hitenkoku)
+- Improved speed with parallel processing by up to 20% with large files. (#479) (@kazuminn)
+- When saving files with `-o`, the `.yml` detection rule path column changed from `RulePath` to `RuleFile` and only the rule file name will be saved in order to decrease file size. (#623) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a runtime error when hayabusa is run from a different path than the current directory. (#618) (@hitenkoku)
+
+## v1.4.1 [2022/06/30]
+
+**Enhancements:**
+
+- When no `details` field is defined in a rule nor in `./rules/config/default_details.txt`, all fields will be outputted to the `details` column. (#606) (@hitenkoku)
+- Added the `-D, --deep-scan` option. Now by default, events are filtered by Event IDs that there are detection rules for defined in `./rules/config/target_event_IDs.txt`. This should improve performance by 25~55% while still detecting almost everything. If you want to do a thorough scan on all events, you can disable the event ID filter with `-D, --deep-scan`. (#608) (@hitenkoku)
+- `channel_abbreviations.txt`, `statistics_event_info.txt` and `target_event_IDs.txt` have been moved from the `config` directory to the `rules/config` directory in order to provide updates with `-U, --update-rules`.
+
+## v1.4.0 [2022/06/26]
+
+**New Features:**
+
+- Added `--target-file-ext` option. You can specify additional file extensions to scan in addtition to the default `.evtx` files. For example, `--target-file-ext evtx_data` or multiple extensions with `--target-file-ext evtx1 evtx2`. (#586) (@hitenkoku)
+- Added `--exclude-status` option: You can ignore rules based on their `status`. (#596) (@hitenkoku)
+
+**Enhancements:**
+
+- Added default details output based on `rules/config/default_details.txt` when no `details` field in a rule is specified. (i.e. Sigma rules) (#359) (@hitenkoku)
+- Updated clap crate package to version 3. (#413) (@hitnekoku)
+- Updated the default usage and help menu. (#387) (@hitenkoku)
+- Hayabusa can be run from any directory, not just from the current directory. (#592) (@hitenkoku)
+- Added saved file size output when `output` is specified. (#595) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed output error and program termination when long output is displayed with color. (#603) (@hitenkoku)
+- Ignore loading yml files in `rules/tools/sigmac/testfiles` to fix `Excluded rules` count. (#602) (@hitenkoku)
+
+## v1.3.2 [2022/06/13]
+
+**Enhancements:**
+
+- Changed the evtx Rust crate from 0.7.2 to 0.7.3 with updated packages. (@YamatoSecurity)
+
+## v1.3.1 [2022/06/13]
+
+**New Features:**
+
+- You can now specify specific fields when there are multiple fields with the same name (Ex: `Data`). In the `details` line in a rule, specify a placeholder like `%Data[1]%` to display the first `Data` field. (#487) (@hitenkoku)
+- Added loaded rules status summary. (#583) (@hitenkoku)
+
+**Enhancements:**
+
+- Debug symbols are stripped by default for smaller Linux and macOS binaries. (#568) (@YamatoSecurity)
+- Updated crate packages (@YamatoSecurity)
+- Added new output time format options. (`--US-time`, `--US-military-time`, `--European-time`) (#574) (@hitenkoku)
+- Changed the output time format when `--rfc-3339` option is enabled. (#574) (@hitenkoku)
+- Changed the `-R / --display-record-id` option to `-R / --hide-record-id` and now by default the event record ID is displayed. You can hide the record ID with `-R / --hide-record-id`. (#579) (@hitenkoku)
+- Added rule loading message. (#583) (@hitenkoku)
+
+**Bug Fixes:**
+
+- The RecordID and RecordInformation column headers would be shown even if those options were not enabled. (#577) (@hitenkoku)
+
+## v1.3.0 [2022/06/06]
+
+**New Features:**
+
+- Added `-V / --visualize-timeline` option: Event Frequency Timeline feature to visualize the number of events. (Note: There needs to be more than 5 events and you need to use a terminal like Windows Terminal, iTerm2, etc... for it to properly render.) (#533, #566) (@hitenkoku)
+- Display all the `tags` defined in a rule to the `MitreAttack` column when saving to CSV file with the `--all-tags` option. (#525) (@hitenkoku)
+- Added the `-R / --display-record-id` option: Display the event record ID (`<Event><System><EventRecordID>`). (#548) (@hitenkoku)
+- Display dates with most detections. (#550) (@hitenkoku)
+- Display the top 5 computers with the most unique detections. (#557) (@hitenkoku)
+
+**Enhancements:**
+
+- In the `details` line in a rule, when a placeholder points to a field that does not exist or there is an incorrect alias mapping, it will be outputted as `n/a` (not available). (#528) (@hitenkoku)
+- Display total event and data reduction count. (How many and what percent of events were ignored.) (#538) (@hitenkoku)
+- New logo. (#536) (@YamatoSecurity)
+- Display total evtx file size. (#540) (@hitenkoku)
+- Changed logo color. (#537) (@hitenkoku)
+- Display the original `Channel` name when not specified in `channel_abbrevations.txt`. (#553) (@hitenkoku)
+- Display separately `Ignored rules` to `Exclude rules`, `Noisy rules`, and `Deprecated rules`. (#556) (@hitenkoku)
+- Display results messge when `output` option is set. (#561) (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed the `--start-timeline` and `--end-timeline` options as they were not working. (#546) (@hitenkoku)
+- Fixed crash bug when level in rule is not valid. (#560) (@hitenkoku)
+
+## v1.2.2 [2022/05/20]
+
+**New Features:**
+
+- Added a logon summary feature. (`-L` / `--logon-summary`) (@garigariganzy)
+
+**Enhancements:**
+
+- Colored output is now on by default and supports Command and Powershell prompts. (@hitenkoku)
+
+**Bug Fixes:**
+
+- Fixed a bug in the update feature when the rules repository does not exist but the rules folder exists. (#516) (@hitenkoku)
+- Fixed a rule parsing error bug when there were .yml files in a .git folder. (#524) (@hitenkoku)
+- Fixed wrong version number in the 1.2.1 binary.
+
+## v1.2.1 [2022/04/20] Black Hat Asia Arsenal 2022 RC2
+
+**New Features:**
+
+- Added a `Channel` column to the output based on the `./config/channel_abbreviations.txt` config file. (@hitenkoku)
+- Rule and rule config files are now forcefully updated. (@hitenkoku)
+
+**Bug Fixes:**
+
+- Rules marked as noisy or excluded would not have their `level` changed with `--level-tuning` but now all rules will be checked. (@hitenkoku)
+
+## v1.2.0 [2022/04/15] Black Hat Asia Arsenal 2022 RC1
+
+**New Features:**
+
+- Specify config directory (`-C / --config`): When specifying a different rules directory, the rules config directory will still be the default `rules/config`, so this option is useful when you want to test rules and their config files in a different directory. (@hitenkoku)
+- `|equalsfield` aggregator: In order to write rules that compare if two fields are equal or not. (@hach1yon)
+- Pivot keyword list generator feature (`-p / --pivot-keywords-list`): Will generate a list of keywords to grep for to quickly identify compromised machines, suspicious usernames, files, etc... (@kazuminn)
+- `-F / --full-data` option: Will output all field information in addition to the fields defined in the rule’s `details`. (@hach1yon)
+- `--level-tuning` option: You can tune the risk `level` in hayabusa and sigma rules to your environment. (@itib and @hitenkoku)
+
+**Enhancements:**
+
+- Updated detection rules and documentation. (@YamatoSecurity)
+- Mac and Linux binaries now statically compile the OpenSSL libraries. (@YamatoSecurity)
+- Performance and accuracy improvement for fields with tabs, etc... in them. (@hach1yon and @hitenkoku)
+- Fields that are not defined in eventkey_alias.txt will automatically be searched in Event.EventData. (@kazuminn and @hitenkoku)
+- When updating rules, the names of new rules as well as the count will be displayed. (@hitenkoku)
+- Removed all Clippy warnings from the source code. (@hitenkoku and @hach1yon)
+- Updated the event ID and title config file (`timeline_event_info.txt`) and changed the name to `statistics_event_info.txt`. (@YamatoSecurity and @garigariganzy)
+- 32-bit Hayabusa Windows binaries are now prevented from running on 64-bit Windows as it would cause unexpected results. (@hitenkoku)
+- MITRE ATT&CK tag output can be customized in `output_tag.txt`. (@hitenkoku)
+- Added Channel column output. (@hitenkoku)
+
+**Bug Fixes:**
+
+- `.yml` files in the `.git` folder would cause parse errors so they are now ignored. (@hitenkoku)
+- Removed unnecessary newline due to loading test file rules. (@hitenkoku)
+- Fixed output stopping in Windows Terminal due a bug in Terminal itself. (@hitenkoku)
+
+## v1.1.0 [2022/03/03]
+
+**New Features:**
+
+- Can specify a single rule with the `-r / --rules` option. (Great for testing rules!) (@kazuminn)
+- Rule update option (`-u / --update-rules`): Update to the latest rules in the [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) repository. (@hitenkoku)
+- Live analysis option (`-l / --live-analysis`): Can easily perform live analysis on Windows machines without specifying the Windows event log directory. (@hitenkoku)
+
+**Enhancements:**
+
+- Updated documentation. (@kazuminn , @hitenkoku , @YamatoSecurity)
+- Updated rules. (20+ Hayabusa rules, 200+ Sigma rules) (@YamatoSecurity)
+- Windows binaries are now statically compiled so installing Visual C++ Redistributable is not required. (@hitenkoku)
+- Color output (`-c / --color`) for terminals that support True Color (Windows Terminal, iTerm2, etc...). (@hitenkoku)
+- MITRE ATT&CK tactics are included in the saved CSV output. (@hitenkoku)
+- Performance improvement. (@hitenkoku)
+- Comments added to exclusion and noisy config files. (@kazuminn)
+- Using faster memory allocators (rpmalloc for Windows, jemalloc for macOS and Linux.) (@kazuminn)
+- Updated cargo crates. (@YamatoSecurity)
+
+**Bug Fixes:**
+
+- Made the clap library version static to make `cargo update` more stable. (@hitenkoku)
+- Some rules were not alerting if there were tabs or carriage returns in the fields. (@hitenkoku)
+
+## v1.0.0-Release 2 [2022/01/27]
+
+- Removed Excel result sample files as they were being flagged by anti-virus. (@YamatoSecurity)
+- Updated the Rust evtx library to 0.7.2 (@YamatoSecurity)
+
+## v1.0.0 [2021/12/25]
+
+- Initial release.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -137,6 +137,7 @@ plugins:
             Features: 特徴・機能
             Screenshots: スクリーンショット
             Licenses: ライセンス
+            Changelog: 変更履歴
             Getting Started: はじめに
             Downloads: ダウンロード
             Git Cloning: Gitクローン
@@ -180,6 +181,7 @@ plugins:
             "Features": "功能特色"
             "Screenshots": "螢幕擷圖"
             "Licenses": "授權條款"
+            "Changelog": "變更日誌"
             "Getting Started": "開始使用"
             "Downloads": "下載"
             "Git Cloning": "Git 複製"
@@ -223,6 +225,7 @@ plugins:
             "Features": "기능"
             "Screenshots": "스크린샷"
             "Licenses": "라이선스"
+            "Changelog": "변경 이력"
             "Getting Started": "시작하기"
             "Downloads": "다운로드"
             "Git Cloning": "Git 클론"
@@ -266,6 +269,7 @@ plugins:
             "Features": "Funktionen"
             "Screenshots": "Screenshots"
             "Licenses": "Lizenzen"
+            "Changelog": "Änderungsprotokoll"
             "Getting Started": "Erste Schritte"
             "Downloads": "Downloads"
             "Git Cloning": "Git-Klonen"
@@ -309,6 +313,7 @@ plugins:
             "Features": "Özellikler"
             "Screenshots": "Ekran Görüntüleri"
             "Licenses": "Lisanslar"
+            "Changelog": "Değişiklik Günlüğü"
             "Getting Started": "Başlarken"
             "Downloads": "İndirmeler"
             "Git Cloning": "Git ile Klonlama"
@@ -352,6 +357,7 @@ plugins:
             "Features": "Fonctionnalités"
             "Screenshots": "Captures d'écran"
             "Licenses": "Licences"
+            "Changelog": "Journal des modifications"
             "Getting Started": "Premiers pas"
             "Downloads": "Téléchargements"
             "Git Cloning": "Clonage Git"
@@ -395,6 +401,7 @@ plugins:
             "Features": "Características"
             "Screenshots": "Capturas de pantalla"
             "Licenses": "Licencias"
+            "Changelog": "Registro de cambios"
             "Getting Started": "Primeros pasos"
             "Downloads": "Descargas"
             "Git Cloning": "Clonación con Git"
@@ -438,6 +445,7 @@ plugins:
             "Features": "Funcionalidades"
             "Screenshots": "Capturas de tela"
             "Licenses": "Licenças"
+            "Changelog": "Registro de alterações"
             "Getting Started": "Primeiros passos"
             "Downloads": "Downloads"
             "Git Cloning": "Clonagem com Git"
@@ -481,6 +489,7 @@ plugins:
             "Features": "Можливості"
             "Screenshots": "Знімки екрана"
             "Licenses": "Ліцензії"
+            "Changelog": "Журнал змін"
             "Getting Started": "Початок роботи"
             "Downloads": "Завантаження"
             "Git Cloning": "Клонування Git"
@@ -524,6 +533,7 @@ plugins:
             "Features": "विशेषताएँ"
             "Screenshots": "स्क्रीनशॉट"
             "Licenses": "लाइसेंस"
+            "Changelog": "चेंजलॉग"
             "Getting Started": "शुरुआत करना"
             "Downloads": "डाउनलोड"
             "Git Cloning": "Git क्लोनिंग"
@@ -567,6 +577,7 @@ plugins:
             "Features": "Fitur"
             "Screenshots": "Tangkapan Layar"
             "Licenses": "Lisensi"
+            "Changelog": "Catatan Perubahan"
             "Getting Started": "Memulai"
             "Downloads": "Unduhan"
             "Git Cloning": "Kloning Git"
@@ -610,6 +621,7 @@ plugins:
             "Features": "အင်္ဂါရပ်များ"
             "Screenshots": "ဖန်သားပြင်ဓာတ်ပုံများ"
             "Licenses": "လိုင်စင်များ"
+            "Changelog": "ပြောင်းလဲမှုမှတ်တမ်း"
             "Getting Started": "စတင်အသုံးပြုခြင်း"
             "Downloads": "ဒေါင်းလုဒ်များ"
             "Git Cloning": "Git Cloning ပြုလုပ်ခြင်း"
@@ -653,6 +665,7 @@ plugins:
             "Features": "คุณสมบัติ"
             "Screenshots": "ภาพหน้าจอ"
             "Licenses": "สัญญาอนุญาต"
+            "Changelog": "บันทึกการเปลี่ยนแปลง"
             "Getting Started": "เริ่มต้นใช้งาน"
             "Downloads": "ดาวน์โหลด"
             "Git Cloning": "การโคลนด้วย Git"
@@ -696,6 +709,7 @@ plugins:
             "Features": "الميزات"
             "Screenshots": "لقطات الشاشة"
             "Licenses": "التراخيص"
+            "Changelog": "سجل التغييرات"
             "Getting Started": "البدء"
             "Downloads": "التنزيلات"
             "Git Cloning": "الاستنساخ عبر Git"
@@ -746,6 +760,7 @@ nav:
       - Features: overview/features.md
       - Screenshots: overview/screenshots.md
       - Licenses: overview/licenses.md
+      - Changelog: overview/changelog.md
   - Getting Started:
       - Downloads: getting-started/index.md
       - Git Cloning: getting-started/git-cloning.md

--- a/website/scripts/sync_changelog.py
+++ b/website/scripts/sync_changelog.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regenerate the docs Changelog pages from the repo's CHANGELOG files.
+
+The Overview > Changelog pages mirror the root CHANGELOG.md /
+CHANGELOG-Japanese.md. This script regenerates them so the published site is
+always current. The docs deploy workflow runs it before `mkdocs build`; the
+committed pages are a snapshot for local previews.
+
+Run from anywhere:  python website/scripts/sync_changelog.py
+"""
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DOCS = os.path.join(ROOT, "website", "docs", "overview")
+
+NOTE_EN = (
+    "!!! info\n"
+    "    This page mirrors the project "
+    "[`CHANGELOG.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG.md). "
+    "See the [Releases page](https://github.com/Yamato-Security/hayabusa/releases) for downloads."
+)
+NOTE_JA = (
+    '!!! info "情報"\n'
+    "    このページはプロジェクトの "
+    "[`CHANGELOG.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG-Japanese.md) "
+    "を反映したものです。ダウンロードは "
+    "[リリースページ](https://github.com/Yamato-Security/hayabusa/releases) をご覧ください。"
+)
+
+_LIST = re.compile(r'^([-*+]|\d{1,9}[.)])\s+\S')
+_FENCE = re.compile(r'^\s*(```|~~~)')
+_HEADING = re.compile(r'^#{1,6}\s')
+
+
+def fix_tight_lists(text):
+    """Insert a blank line before a top-level list that directly follows a
+    top-level paragraph (Python-Markdown needs it; GitHub doesn't)."""
+    out, in_fence = [], False
+    for ln in text.split("\n"):
+        if _FENCE.match(ln):
+            in_fence = not in_fence
+        if not in_fence and _LIST.match(ln) and out:
+            p = out[-1]
+            if (p.strip() and not _LIST.match(p) and not _HEADING.match(p)
+                    and not p.lstrip().startswith(">") and not p.lstrip().startswith("|")
+                    and not re.match(r'^\s', p)):
+                out.append("")
+        out.append(ln)
+    return "\n".join(out)
+
+
+def build(src, title, note, dest):
+    lines = open(src, encoding="utf-8").read().split("\n")
+    body = lines[1:]                      # drop the source's own top-level heading
+    while body and body[0].strip() == "":
+        body.pop(0)
+    content = f"# {title}\n\n{note}\n\n" + "\n".join(body)
+    content = fix_tight_lists(content).rstrip() + "\n"
+    with open(dest, "w", encoding="utf-8") as f:
+        f.write(content)
+    print("wrote", os.path.relpath(dest, ROOT))
+
+
+def main():
+    build(os.path.join(ROOT, "CHANGELOG.md"), "Changelog", NOTE_EN,
+          os.path.join(DOCS, "changelog.md"))
+    build(os.path.join(ROOT, "CHANGELOG-Japanese.md"), "変更履歴", NOTE_JA,
+          os.path.join(DOCS, "changelog.ja.md"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a **Changelog** page under the Overview section with the full release history, kept in sync automatically.

- `overview/changelog.md` — from the project [`CHANGELOG.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG.md)
- `overview/changelog.ja.md` — from [`CHANGELOG-Japanese.md`](https://github.com/Yamato-Security/hayabusa/blob/main/CHANGELOG-Japanese.md)
- A short info admonition at the top links to the source changelog and the Releases page.
- Adds the Overview nav entry and a localized **"Changelog"** sidebar label for all 15 languages. The other 13 languages fall back to the English changelog (canonical source) rather than machine-translating a long, frequently-updated file.

## Kept in sync at build time

- `website/scripts/sync_changelog.py` regenerates the two changelog pages from the root `CHANGELOG.md` / `CHANGELOG-Japanese.md` (applying the page title, the info note, and a blank-line-before-list normalization so Python-Markdown renders the lists).
- The docs deploy workflow (`.github/workflows/docs.yml`) runs it **before `mkdocs build`**, so the published changelog is always current — no manual updates needed. The committed pages are just a snapshot for local previews, and the script is idempotent against them.

Builds clean with `mkdocs build --strict` (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)