### PR TITLE
fix: tests fail with `cargo test -- --test-threads=1` (#1170)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3052,6 +3052,14 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
     }
 
     fn check_is_valid_args_num(&self, action: Option<&Action>) -> bool {
+        // Under `cargo test`, `env::args()` is the test harness's argv (e.g. it
+        // contains `--test-threads=1` or a test-name filter), not hayabusa's own
+        // arguments, so this "subcommand run with no args" heuristic would misfire
+        // and make the app print help and return early. Skip it in test builds.
+        // See https://github.com/Yamato-Security/hayabusa/issues/1170
+        if cfg!(test) {
+            return true;
+        }
         match action.as_ref().unwrap() {
             Action::CsvTimeline(_)
             | Action::JsonTimeline(_)


### PR DESCRIPTION
## Summary

Fixes #1170 — tests fail with `cargo test -- --test-threads=1` but pass with `RUST_TEST_THREADS=1 cargo test`.

## Root cause

`App::check_is_valid_args_num` (`src/main.rs`) decides whether a subcommand was run with **no arguments** using the **global process arg count**:

```rust
Action::CsvTimeline(_) | ... | Action::ComputerMetrics(_) => env::args().len() != 2,
```

and the caller prints the subcommand's help and `return`s early when it's "invalid" (`src/main.rs`, ~L179).

Under `cargo test`, `env::args()` is the **test harness's** argv, not hayabusa's:

| Invocation | `env::args()` | `len() != 2` | Result |
| --- | --- | --- | --- |
| `cargo test` | `[binary]` | true → valid | ✅ pass |
| `RUST_TEST_THREADS=1 cargo test` | `[binary]` | true → valid | ✅ pass |
| `cargo test -- --test-threads=1` | `[binary, --test-threads=1]` | **false → "no args"** | ❌ app prints help & returns early → no output |

So with exactly two process args, the affected tests (all of which exercise the actions listed in `check_is_valid_args_num` — `test_same_file_output_*`, `test_overwrite_*`, `test_exec_general_html_output`, …) get no output and fail. `RUST_TEST_THREADS=1` is an env var (not argv), which is why it kept working. (The original `exclude-category` `conflicts_with` panic mentioned in the issue thread is already fixed; this is the remaining cause.)

The same heuristic also breaks running a single test by name, e.g. `cargo test test_overwrite_csv` (also two args).

## Fix

Skip the heuristic in test builds — `env::args()` is meaningless there. The shipped (non-test) binary is unaffected:

```rust
fn check_is_valid_args_num(&self, action: Option<&Action>) -> bool {
    if cfg!(test) {
        return true;
    }
    match action.as_ref().unwrap() { ... }
}
```

## Verification

`cargo test -- --test-threads=1` and `cargo test <name>` should now pass, alongside `cargo test` / `RUST_TEST_THREADS=1 cargo test`.

> Note: this was prepared in an environment without a Rust toolchain, so I relied on code analysis rather than a local `cargo test` run — please let CI (and your own run of `cargo test -- --test-threads=1`) confirm. The change is a minimal early-return guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)