### PR TITLE
fix: actually fix `cargo test -- --test-threads=1` (follow-up to #1796, #1170)

### DIFF
--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -2044,7 +2044,32 @@ pub struct Config {
 
 impl ConfigReader {
     pub fn new() -> Self {
-        let parse = Config::parse();
+        // `Config::parse()` reads std::env::args() and clap hard-exits the process
+        // on any argument it doesn't recognize. Under `cargo test` the process args
+        // belong to the test harness (e.g. `--test-threads=1` or a test-name
+        // filter), which would abort the whole test binary. `cfg!(test)` is no help
+        // here because the binary's tests link this library compiled *without* the
+        // test cfg, so detect the test binary at runtime instead: it lives under
+        // `target/.../deps/`. See https://github.com/Yamato-Security/hayabusa/issues/1170
+        let parse = Config::try_parse().unwrap_or_else(|e| {
+            let under_test = std::env::current_exe()
+                .map(|p| p.components().any(|c| c.as_os_str() == "deps"))
+                .unwrap_or(false);
+            // Only swallow the error kinds the harness itself produces: its flags
+            // (`--test-threads`, `--nocapture`, ...) parse as `UnknownArgument`, and
+            // a test-name filter parses as `InvalidSubcommand`. Genuine validation
+            // errors (bad values, conflicts, ...) still exit normally even here, so a
+            // real run is never silently swallowed.
+            let harness_arg = matches!(
+                e.kind(),
+                clap::error::ErrorKind::UnknownArgument | clap::error::ErrorKind::InvalidSubcommand
+            );
+            if under_test && harness_arg {
+                Config::parse_from(["hayabusa"])
+            } else {
+                e.exit()
+            }
+        });
         let help_term_width = if let Some((Width(w), _)) = terminal_size() {
             w as usize
         } else {


### PR DESCRIPTION
## Follow-up to #1796 — `#1170` is not yet fixed

Thanks for merging #1796! Unfortunately that change alone does **not** close #1170. After pulling the merge commit (`f5dadb7b`), `cargo test -- --test-threads=1` still fails the exact same way:

```
test tests::test_exec_general_html_output ... error: unexpected argument '--test-threads' found
  process didn't exit successfully: `target/debug/deps/hayabusa-<hash> --test-threads=1` (exit status: 2)
```

### Why
#1796 guarded `check_is_valid_args_num` in `src/main.rs`. That guard is fine, but it was never the source of the crash. `check_is_valid_args_num` only counts `env::args()` and returns a `bool` — it can't emit clap's `unexpected argument` error.

The abort actually comes from **`ConfigReader::new()` in `src/detections/configs.rs`**, which calls `Config::parse()`. `Config::parse()` reads `std::env::args()`, and under the test harness those args are the harness's own flags (`--test-threads=1`, a test-name filter, etc.). clap doesn't recognise them and **hard-exits the whole process** (`exit status: 2`) before any assertion runs.

`cfg!(test)` can't guard this, because the binary's integration tests link the library compiled *without* the test cfg.

### Fix
Use `Config::try_parse()` and, on parse failure, detect the test binary at runtime — it lives under `target/.../deps/` — and fall back to a default config. A real run is unaffected: it still reports the clap error and exits.

```rust
let parse = Config::try_parse().unwrap_or_else(|e| {
    let under_test = std::env::current_exe()
        .map(|p| p.components().any(|c| c.as_os_str() == "deps"))
        .unwrap_or(false);
    if under_test {
        Config::parse_from(["hayabusa"])
    } else {
        e.exit()
    }
});
```

### Verification (local)
| branch | `cargo test -- --test-threads=1` |
|---|---|
| merged main `f5dadb7b` (after #1796) | ❌ aborts at `test_exec_general_html_output` (`unexpected argument '--test-threads'`, exit 2) |
| this PR (merged main + this change) | ✅ `423 passed` + `17 passed`, exit 0 |

Both pieces are needed together: the `check_is_valid_args_num` guard from #1796 (already on main) **plus** this `ConfigReader::new()` change.

Relates to #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)