### PR TITLE
fix: timeline::metrics nextest test failure (#1281)

### DIFF
--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -505,7 +505,7 @@ mod tests {
         detections::{
             configs::{
                 Action, CommonOptions, Config, DetectCommonOption, EidMetricsOption, InputOption,
-                StoredStatic,
+                STORED_EKEY_ALIAS, StoredStatic,
             },
             utils::create_rec_info,
         },
@@ -560,6 +560,13 @@ mod tests {
                 clobber: false,
                 remove_duplicate_detections: false,
             }));
+
+        // `create_rec_info` reads the global `STORED_EKEY_ALIAS`, which starts as
+        // `None`. Initialize it here so the test passes in isolation (e.g. under
+        // `cargo nextest run`, which runs each test in its own process and so cannot
+        // rely on another test having populated it). See
+        // https://github.com/Yamato-Security/hayabusa/issues/1281
+        *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
 
         let mut timeline = Timeline::new();
         // Test 1: When the channel of the record is included in the alias.


### PR DESCRIPTION
## Fixes #1281

`cargo nextest run` fails on `timeline::metrics::tests::test_evt_logon_stats`:

```
thread 'timeline::metrics::tests::test_evt_logon_stats' panicked at src/detections/utils.rs:336:43:
called `Option::unwrap()` on a `None` value
```

### Root cause
The test calls `create_rec_info`, which reads the process-global `STORED_EKEY_ALIAS` — a `RwLock<Option<EventKeyAliasConfig>>` that starts as `None`:

```rust
let binding = STORED_EKEY_ALIAS.read().unwrap();
let eventkey_alias = binding.as_ref().unwrap();   // <- panics when None
```

Every *other* `create_rec_info` test initializes that global first (e.g. `timeline::timelines::tests::test_evt_logon_stats`, `rule::count`, `rule::mod` all do `*STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());`). This one never did. Under the normal `cargo test` runner all tests share a single process, so some earlier test populates the global first and `test_evt_logon_stats` passes *by luck of ordering*. Under **nextest's process-per-test isolation** nothing sets it, so the `unwrap()` hits `None`.

### Fix
Initialize `STORED_EKEY_ALIAS` from the test's own dummy config before calling `create_rec_info`, exactly like the sibling tests:

```rust
*STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
```

The alias is loaded from the same `rules/config/eventkey_alias.txt` that every other test uses (`create_static_data` loads it unconditionally for all actions), so the written value is identical to what the other tests write — no new data race in the multi-threaded `cargo test` runner.

### Verification
nextest's prebuilt binary wouldn't run in my sandbox, so I reproduced its process-per-test isolation by running the single test in its own process (`<test-binary> --exact <name>`):

| check | before | after |
|---|---|---|
| `test_evt_logon_stats` in isolation (nextest-equivalent) | ❌ panics at `utils.rs:336` (`Option::unwrap()` on `None`) | ✅ passes |
| every `timeline::` test, one-per-process | metrics fails | ✅ all pass |
| full multi-threaded `cargo test --lib` (regression) | 423 pass | ✅ 423 pass, **25/25 runs** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)