### PR TITLE
feat: support `neq` and `fieldref|neq` field modifiers (#1684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Enchancements:**
 
-Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fukusuket)
+- Added support for the `|neq` and `|fieldref|neq` field modifiers from the Sigma 2.1 specification. `|neq` negates a comparison and can be combined with other modifiers (`|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|fieldref|neq`, ...). (#1684) (@Shirofune-Security)
+- Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fukusuket)
 
 **Bug Fixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## x.x.x
 
-**Enchancements:**
+**Enhancements:**
 
-- Added support for the `|neq` and `|fieldref|neq` field modifiers from the Sigma 2.1 specification. `|neq` negates a comparison and can be combined with other modifiers (`|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|fieldref|neq`, ...). (#1684) (@Shirofune-Security)
+- Added support for the `|neq` and `|fieldref|neq` field modifiers from the Sigma 2.1 specification. `|neq` negates a comparison and can be combined with other modifiers (`|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|fieldref|neq`, ...). (#1684) (@YamatoSecurity)
 - Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fukusuket)
 
 **Bug Fixes:**

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -305,6 +305,17 @@ impl LeafMatcher for DefaultMatcher {
             keys_all.append(&mut rest);
         }
 
+        // `neq` has no field to negate on a keyless selection. The keyless `|all` whole-record path
+        // (in parse_selection_recursively) only fires when the key is exactly `|all`, so `|all|neq`
+        // would fall through to an empty-field match and, being negated, match every record. Reject
+        // the combination so such a rule fails to load with a clear message rather than misbehaving.
+        if self.neg_match && keys_all[0].is_empty() {
+            return Err(vec![
+                "The `neq` modifier cannot be combined with the keyless `|all` modifier."
+                    .to_string(),
+            ]);
+        }
+
         // Maps shorthand pipe names to the internal names accepted by PipeElement::new():
         // "all" -> "allOnly" (for a leading "|all" key) and the regex flags "i"/"m"/"s" ->
         // "reignorecase"/"remultiline"/"resingleline".

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -36,6 +36,13 @@ pub trait LeafMatcher: Downcast + Send + Sync {
     /// Initializes the matcher from the rule file. Returns Err with parse error messages when
     /// the rule file format is invalid.
     fn init(&mut self, key_list: &Nested<String>, select_value: &Yaml) -> Result<(), Vec<String>>;
+
+    /// Whether this matcher negates its result (i.e. the `neq` modifier is used).
+    /// Callers that aggregate multiple values (e.g. multi-valued `EventData.Data`) need this so
+    /// that the negation is applied once over the whole comparison rather than per value.
+    fn is_negated(&self) -> bool {
+        false
+    }
 }
 downcast_rs::impl_downcast!(LeafMatcher);
 
@@ -198,6 +205,9 @@ pub struct DefaultMatcher {
     fast_match: Option<Vec<FastMatch>>,
     pipes: Vec<PipeElement>,
     key_list: Nested<String>,
+    // Set to true when the `neq` modifier is used. `neq` negates the whole comparison
+    // (equivalent to Sigma's SigmaNegateModifier), so the final match result is inverted.
+    neg_match: bool,
 }
 
 impl DefaultMatcher {
@@ -207,6 +217,7 @@ impl DefaultMatcher {
             fast_match: None,
             pipes: Vec::new(),
             key_list: Nested::<String>::new(),
+            neg_match: false,
         }
     }
 
@@ -275,6 +286,24 @@ impl LeafMatcher for DefaultMatcher {
         // The first element is just the field key; the second and subsequent elements are pipes.
 
         let mut keys_all: Vec<&str> = key_list.get(0).unwrap_or(&empty_str).split('|').collect(); // key_list cannot be empty.
+
+        // `neq` (Sigma's SigmaNegateModifier) negates the whole comparison. Detect it among the
+        // pipe modifiers (never the field name at index 0), strip it from the modifier chain, and
+        // flag the matcher so the final result is inverted in `is_match`. Because it is handled as
+        // a plain negation, it composes with any other modifier (plain value, contains, startswith,
+        // endswith, re, fieldref, fieldref|contains, ...).
+        if keys_all.len() >= 2 && keys_all[1..].contains(&"neq") {
+            self.neg_match = true;
+            let field = keys_all[0];
+            let mut rest: Vec<&str> = keys_all[1..]
+                .iter()
+                .copied()
+                .filter(|k| *k != "neq")
+                .collect();
+            keys_all = Vec::with_capacity(rest.len() + 1);
+            keys_all.push(field);
+            keys_all.append(&mut rest);
+        }
 
         // Maps shorthand pipe names to the internal names accepted by PipeElement::new():
         // "all" -> "allOnly" (for a leading "|all" key) and the regex flags "i"/"m"/"s" ->
@@ -558,6 +587,20 @@ impl LeafMatcher for DefaultMatcher {
     }
 
     fn is_match(&self, event_value: Option<&String>, recinfo: &EvtxRecordInfo) -> bool {
+        let result = self.is_match_inner(event_value, recinfo);
+        // `neq` negates the whole comparison (Sigma's SigmaNegateModifier).
+        result ^ self.neg_match
+    }
+
+    fn is_negated(&self) -> bool {
+        self.neg_match
+    }
+}
+
+impl DefaultMatcher {
+    /// Performs the actual (non-negated) match. `is_match` inverts this result when the
+    /// `neq` modifier is present.
+    fn is_match_inner(&self, event_value: Option<&String>, recinfo: &EvtxRecordInfo) -> bool {
         let pipe: &PipeElement = self.pipes.first().unwrap_or(&PipeElement::Wildcard);
         // Pipes that implement their own matching (cidr, exists, field references and numeric
         // comparisons) are handled first; all other kinds fall through to fast match/regex.
@@ -2765,6 +2808,529 @@ mod tests {
             "Event": {"System": {"EventID": 4103, "Channel": "Security", "Computer": "Powershell" }},
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_detect() {
+        // `neq` matches when the field value is different from the specified value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: Security
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "PowerShell" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_neq_notdetect() {
+        // `neq` does not match when the field value equals the specified value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: Security
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_case_insensitive_notdetect() {
+        // Like the plain value match, `neq` equality is case-insensitive, so "security" == "Security"
+        // and therefore `neq` does not match.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: security
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_missing_field_detect() {
+        // A missing field is treated as different from the value (consistent with `not` in condition),
+        // so `neq` matches.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: Security
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103 }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_neq_wildcard_notdetect() {
+        // Wildcards still apply to the value being negated: "Sec*" matches "Security", so `neq` does not match.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: Sec*
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_wildcard_detect() {
+        // "Sec*" does not match "PowerShell", so `neq` matches.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|neq: Sec*
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "PowerShell" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_contains_neq_detect() {
+        // `contains|neq` matches when the field does NOT contain the value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|contains|neq: cur
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "System" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_contains_neq_notdetect() {
+        // `contains|neq` does not match when the field contains the value ("Security" contains "cur").
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|contains|neq: cur
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_startswith_neq_detect() {
+        // `startswith|neq` matches when the field does NOT start with the value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|startswith|neq: Sec
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "System" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_startswith_neq_notdetect() {
+        // `startswith|neq` does not match when the field starts with the value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|startswith|neq: Sec
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_endswith_neq_detect() {
+        // `endswith|neq` matches when the field does NOT end with the value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|endswith|neq: rity
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "System" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_endswith_neq_notdetect() {
+        // `endswith|neq` does not match when the field ends with the value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|endswith|neq: rity
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_fieldref_neq_detect() {
+        // `fieldref|neq` matches when the two field values are different.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|fieldref|neq: Computer
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security", "Computer": "PowerShell" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_fieldref_neq_notdetect() {
+        // `fieldref|neq` does not match when the two field values are the same.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|fieldref|neq: Computer
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security", "Computer": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_fieldref_neq_missing_ref_detect() {
+        // If the referenced field is missing, the values are considered different, so `fieldref|neq` matches.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|fieldref|neq: Computer
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_fieldref_contains_neq_detect() {
+        // `fieldref|contains|neq` matches when the left field does NOT contain the right field's value.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|fieldref|contains|neq: Computer
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security", "Computer": "xyz" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_fieldref_contains_neq_notdetect() {
+        // `fieldref|contains|neq` does not match when the left field contains the right field's value
+        // ("Security" contains "cur").
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|fieldref|contains|neq: Computer
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security", "Computer": "cur" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_re_neq_detect() {
+        // `re|neq` matches when the (case-sensitive) regex does NOT match.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|re|neq: ^Sec.*
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "System" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_re_neq_notdetect() {
+        // `re|neq` does not match when the regex matches.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|re|neq: ^Sec.*
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_re_i_neq_notdetect() {
+        // The `i` (case-insensitive) flag still composes with `neq`: "^sec.*" matches "Security"
+        // case-insensitively, so `re|i|neq` does not match.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|re|i|neq: ^sec.*
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_gt_neq_equal_detect() {
+        // Numeric `gt|neq`: the value equal to the bound is NOT greater than it, so the base `gt`
+        // is false and `neq` matches.
+        let rule_str = r"
+        enabled: true
+        detection:
+            selection:
+                EventID|gt|neq: 1040
+            condition: selection
+        ";
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 1040 }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_gt_neq_greater_notdetect() {
+        // A value greater than the bound satisfies the base `gt`, so `gt|neq` does not match.
+        let rule_str = r"
+        enabled: true
+        detection:
+            selection:
+                EventID|gt|neq: 1040
+            condition: selection
+        ";
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 1041 }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_gt_neq_missing_field_detect() {
+        // A missing (or non-numeric) field makes the base `gt` false, so `gt|neq` matches
+        // (consistent with the missing-field behavior of the other `neq` forms).
+        let rule_str = r"
+        enabled: true
+        detection:
+            selection:
+                EventID|gt|neq: 1040
+            condition: selection
+        ";
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_cidr_neq_detect() {
+        // `cidr|neq` matches when the IP is NOT in the range (e.g. excluding an internal subnet).
+        let rule_str = r#"
+        detection:
+            selection:
+                IpAddress|cidr|neq: 192.168.0.0/16
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4624}, "EventData": {"IpAddress": "10.0.0.1"} },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_cidr_neq_notdetect() {
+        // `cidr|neq` does not match when the IP is in the range.
+        let rule_str = r#"
+        detection:
+            selection:
+                IpAddress|cidr|neq: 192.168.0.0/16
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4624}, "EventData": {"IpAddress": "192.168.1.5"} },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_contains_cased_neq_detect() {
+        // `contains|cased|neq` is case-sensitive: "security" does not contain "Sec" (different case),
+        // so `neq` matches.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|contains|cased|neq: Sec
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_contains_cased_neq_notdetect() {
+        // "Security" contains "Sec" (same case), so `contains|cased|neq` does not match.
+        let rule_str = r#"
+        detection:
+            selection:
+                Channel|contains|cased|neq: Sec
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security" }},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
         check_select(rule_str, record_json_str, false);
     }
 

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -1052,6 +1052,36 @@ mod tests {
     }
 
     #[test]
+    fn test_neq_on_keyless_all_is_rejected() {
+        // `|all|neq` has no field to negate: the keyless `|all` whole-record path only handles an
+        // exact `|all` key, so this combination must be rejected at rule load rather than silently
+        // matching every record (regression test for the Copilot review on #1800).
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                '|all|neq':
+                    - foo
+                    - bar
+        details: 'Rule parse test'
+        "#;
+        let mut rule_yaml = YamlLoader::load_from_str(rule_str).unwrap().into_iter();
+        let mut rule_node = create_rule("testpath".to_string(), rule_yaml.next().unwrap());
+        let result = rule_node.init(&create_dummy_stored_static());
+        assert!(
+            result.is_err(),
+            "expected `|all|neq` to be rejected at init"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .iter()
+                .any(|m| m.contains("neq") && m.contains("|all")),
+            "error should explain the neq/|all conflict"
+        );
+    }
+
+    #[test]
     fn test_detect_not_defined_selection() {
         // Test that an error is returned when the detection node has no content.
         let rule_str = r#"

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -424,6 +424,34 @@ impl DetectionNode {
         } else if yaml.as_vec().is_some() && key_list.iter().any(|k: &str| k.contains("|all")) {
             // If the key carries the |all modifier (e.g. field|contains|all), the array of child
             // elements is interpreted as an AND condition.
+            // When `neq` is also present, De Morgan flips the connective:
+            // NOT(a AND b) == (NOT a) OR (NOT b), so build an OR node of the negated leaves instead.
+            let children: Vec<Box<dyn SelectionNode>> = yaml
+                .as_vec()
+                .unwrap()
+                .iter()
+                .map(|child_yaml| Self::parse_selection_recursively(key_list, child_yaml))
+                .collect();
+            if key_list
+                .iter()
+                .any(|k| k.split('|').skip(1).any(|m| m == "neq"))
+            {
+                let mut or_node = selectionnodes::OrSelectionNode::new();
+                or_node.child_nodes = children;
+                Box::new(or_node)
+            } else {
+                let mut and_node = selectionnodes::AndSelectionNode::new();
+                and_node.child_nodes = children;
+                Box::new(and_node)
+            }
+        } else if yaml.as_vec().is_some()
+            && key_list
+                .iter()
+                .any(|k| k.split('|').skip(1).any(|modifier| modifier == "neq"))
+        {
+            // `neq` negates the whole comparison, so a plain (OR-linked) list of values under a `neq`
+            // modifier means "different from ALL of them" (De Morgan: NOT(a OR b) == NOT a AND NOT b).
+            // Interpret the array as an AND condition instead of the usual OR.
             let mut and_node = selectionnodes::AndSelectionNode::new();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -438,17 +438,20 @@ impl SelectionNode for LeafSelectionNode {
                 }
                 // For arrays, the leaf matches if any element matches.
                 Value::Array(_) => {
-                    return event_data_value
-                        .as_array()
-                        .unwrap()
-                        .iter()
-                        .any(|array_element| {
-                            let event_value = utils::value_to_string(array_element);
-                            self.matcher
-                                .as_ref()
-                                .unwrap()
-                                .is_match(event_value.as_ref(), event_record)
-                        });
+                    let matcher = self.matcher.as_ref().unwrap();
+                    let per_element = |array_element: &Value| {
+                        let event_value = utils::value_to_string(array_element);
+                        matcher.is_match(event_value.as_ref(), event_record)
+                    };
+                    let array = event_data_value.as_array().unwrap();
+                    // For a negated matcher (`neq`), each element's result is already inverted, so the
+                    // negation must apply over the whole array: NOT(e1 OR e2 OR ...) == (NOT e1) AND (NOT e2) ...
+                    // Combine with `all` in that case; otherwise combine with `any` (a value matches if any element does).
+                    return if matcher.is_negated() {
+                        array.iter().all(per_element)
+                    } else {
+                        array.iter().any(per_element)
+                    };
                 }
                 _ => {
                     return self
@@ -674,6 +677,174 @@ mod tests {
         let record_json_str = r#"
         {
             "Event": {"System": {"EventID": 4103, "Channel": "not detect", "Computer":"DESKTOP-ICHIICHI"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_contains_all_detect() {
+        // `contains|all|neq` with a list negates the AND-linked comparison (De Morgan):
+        // NOT(contains "cur" AND contains "ity"). "curabc" contains "cur" but not "ity",
+        // so NOT(true AND false) = true -> MATCH.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|contains|all|neq:
+                    - cur
+                    - ity
+        details: 'command=%CommandLine%'
+        "#;
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "curabc"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_neq_contains_all_notdetect() {
+        // NOT(contains "cur" AND contains "ity"). "curity" contains both, so NOT(true AND true) = false.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|contains|all|neq:
+                    - cur
+                    - ity
+        details: 'command=%CommandLine%'
+        "#;
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "curity"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_data_array_notdetect() {
+        // Multi-valued EventData.Data with neq: Data = ["X","Y"], `neq: X`.
+        // The negation applies over the whole field: NOT(any element == X). X is present, so NO MATCH.
+        // (This must agree with condition-level `not` on the same data.)
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Data|neq: X
+        details: 'command=%CommandLine%'
+        "#;
+        let record_json_str = r#"
+        {
+            "Event": {"EventData": {"Data": ["X", "Y"]}, "System": {"EventID": 4103, "Channel": "Sec"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_data_array_detect() {
+        // Data = ["X","Y"], `neq: Z`. Z is absent, so NOT(any element == Z) = NOT(false) = MATCH.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Data|neq: Z
+        details: 'command=%CommandLine%'
+        "#;
+        let record_json_str = r#"
+        {
+            "Event": {"EventData": {"Data": ["X", "Y"]}, "System": {"EventID": 4103, "Channel": "Sec"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_neq_repeated_is_idempotent() {
+        // Repeating `neq` is idempotent (matches Sigma's SigmaNegateModifier, which sets `negated = true`
+        // rather than toggling). `Channel|neq|neq: Security` against Channel=Security stays a single
+        // negation: NOT(Channel == Security) = false.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|neq|neq: Security
+        details: 'command=%CommandLine%'
+        "#;
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_list_detect() {
+        // A list of values under `neq` means "different from ALL of them" (De Morgan).
+        // "PowerShell" differs from both "Security" and "System", so it matches.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|neq:
+                    - Security
+                    - System
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "PowerShell"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, true);
+    }
+
+    #[test]
+    fn test_neq_list_notdetect_first() {
+        // If the field equals any value in the `neq` list, it must not match.
+        // (If the list were treated as OR instead of AND, this would wrongly match.)
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|neq:
+                    - Security
+                    - System
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "Security"}},
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+
+        check_select(rule_str, record_json_str, false);
+    }
+
+    #[test]
+    fn test_neq_list_notdetect_second() {
+        // Same as above but matching the second value in the list.
+        let rule_str = r#"
+        enabled: true
+        detection:
+            selection:
+                Channel|neq:
+                    - Security
+                    - System
+        details: 'command=%CommandLine%'
+        "#;
+
+        let record_json_str = r#"
+        {
+            "Event": {"System": {"EventID": 4103, "Channel": "System"}},
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
 

--- a/website/docs/rules/detection-fields.md
+++ b/website/docs/rules/detection-fields.md
@@ -266,7 +266,7 @@ This document is dynamically updated every time there is an update to Sigma or H
 - `|lt`: Checks if a field value is less than a certain number.
 - `|lte`: Checks if a field value is less than or equal to a certain number.
 - `|neq`: Checks if a field value is different from the specified value (the negation of a plain value match). It can be combined with other modifiers (`|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|fieldref|neq`, ...) to negate them. When multiple values are specified in a list, the field must be different from **all** of them. A field that does not exist is treated as different from the value and therefore matches.
-- `|re`: Use case-sensitive regular expressions. (We are using the regex crate so please out the documentation at <https://docs.rs/regex/latest/regex/#syntax> to learn how to write supported regular expressions.)
+- `|re`: Use case-sensitive regular expressions. (We are using the regex crate so please check out the documentation at <https://docs.rs/regex/latest/regex/#syntax> to learn how to write supported regular expressions.)
     > Caution: [Regular expression syntax in Sigma rules](https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-modifiers-appendix.md#regular-expression) uses PCRE with certain metacharacters for character classes, lookbehind, atomic grouping, etc... being unsupported. The Rust regex crate should be able to use all regular expressions in Sigma rules but there is a possibility of incompatibility. 
 - `|re|i`: (Insensitive) Use case-insensitive regular expressions.
 - `|re|m`: (Multi-line) Match across multiple lines. `^` / `$` match the start/end of line.

--- a/website/docs/rules/detection-fields.md
+++ b/website/docs/rules/detection-fields.md
@@ -259,11 +259,13 @@ This document is dynamically updated every time there is an update to Sigma or H
 - `|fieldref`: Checks to see if the values in two fields are the same. You can use `not` in the `condition` if you want to check if two fields are different.
 - `|fieldref|contains`: Checks to see if the value of one field is contained in another field.
 - `|fieldref|endswith`: Check if the field on the left ends with the string of the field on the right. You can use `not` in the `condition` to check if they are different.
+- `|fieldref|neq`: Checks to see if the values in two fields are different (the negation of `|fieldref`).
 - `|fieldref|startswith`: Check if the field on the left starts with the string of the field on the right. You can use `not` in the `condition` to check if they are different.
 - `|gt`: Checks if a field value is greater than a certain number.
 - `|gte`: Checks if a field value is greater than or equal to a certain number.
 - `|lt`: Checks if a field value is less than a certain number.
 - `|lte`: Checks if a field value is less than or equal to a certain number.
+- `|neq`: Checks if a field value is different from the specified value (the negation of a plain value match). It can be combined with other modifiers (`|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|fieldref|neq`, ...) to negate them. When multiple values are specified in a list, the field must be different from **all** of them. A field that does not exist is treated as different from the value and therefore matches.
 - `|re`: Use case-sensitive regular expressions. (We are using the regex crate so please out the documentation at <https://docs.rs/regex/latest/regex/#syntax> to learn how to write supported regular expressions.)
     > Caution: [Regular expression syntax in Sigma rules](https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-modifiers-appendix.md#regular-expression) uses PCRE with certain metacharacters for character classes, lookbehind, atomic grouping, etc... being unsupported. The Rust regex crate should be able to use all regular expressions in Sigma rules but there is a possibility of incompatibility. 
 - `|re|i`: (Insensitive) Use case-insensitive regular expressions.


### PR DESCRIPTION
## What Changed

Adds support for the Sigma 2.1 [`neq`](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-appendix-modifiers.md) modifier and its combination with `fieldref`, as requested in #1684.

`neq` negates the whole comparison — mirroring pySigma's `SigmaNegateModifier` (which sets `detection_item.negated = True`) rather than being a value transform. Because of this it composes with **any** other modifier:

- `Field|neq: value` — field is different from the value
- `Field|fieldref|neq: OtherField` — the two fields have different values
- and freely with the rest: `|contains|neq`, `|startswith|neq`, `|endswith|neq`, `|re|neq`, `|re|i|neq`, `|cidr|neq`, `|gt|neq` (and `lt`/`gte`/`lte`), `|contains|cased|neq`, `|fieldref|contains|neq`, …

### Implementation

- **`matchers.rs`** — `DefaultMatcher` gains a `neg_match` flag. In `init()` the `neq` token is detected among the pipe modifiers (never the field name) and stripped from the chain, setting the flag; the rest of parsing is completely unchanged. `is_match()` now returns `is_match_inner(...) ^ neg_match`, so negation is applied once, over the fully-resolved result of every match path (fast-match, regex, fieldref, numeric, cidr, …).
- **`mod.rs`** — a value **list** under a `neq` key is combined with the De Morgan-correct connective: a normal (OR-linked) list becomes AND-of-negations (`NOT(a OR b) = ¬a AND ¬b`), and an `|all` (AND-linked) list becomes OR-of-negations (`NOT(a AND b) = ¬a OR ¬b`).
- **`selectionnodes.rs`** — for multi-valued `EventData.Data` arrays the negation is applied once over the whole field (`all` instead of `any`, via a new `LeafMatcher::is_negated()`), so a rule and its literal negation can never both match the same record.

A field that does not exist is treated as *different* from the value (so `neq` matches), consistent with how condition-level `not` already behaves in Hayabusa.

Docs (`field modifiers` page) and the CHANGELOG are updated.

## Evidence

The change adds **41 unit tests** (all passing) covering each modifier combination and the edge cases:

- core behavior: `|neq` detect / not-detect, case-insensitivity, wildcards, missing field
- composed modifiers: `contains|neq`, `startswith|neq`, `endswith|neq`, `re|neq`, `re|i|neq`, `gt|neq` (equal / greater / missing), `cidr|neq`, `contains|cased|neq`
- field references: `fieldref|neq`, `fieldref|contains|neq`, missing referenced field
- value lists (De Morgan): OR-linked `|neq` list, AND-linked `|contains|all|neq` list
- multi-valued `EventData.Data` arrays with `|neq`
- repeated `neq` is idempotent (matches Sigma semantics)

```
$ cargo test --lib
test result: ok. 458 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
$ cargo fmt -- --check      # clean
$ cargo clippy --all-targets -- -D warnings   # clean
```

Closes #1684.

> Note: field-modifier documentation was updated in English (`website/docs/rules/detection-fields.md`); the localized translations can follow.