### PR TITLE
docs: translate remaining Japanese code comments to English and fix misspelled identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fuku
 - Fixed a typo (`infomational` → `informational`) in the pivot keyword list level exclusion that prevented `informational`-level records from being excluded, so their field values polluted the pivot keyword lists. (#1804) (@YamatoSecurity)
 - Fixed a Markdown-injection issue in the HTML report: user-supplied values (e.g. computer names) were HTML-escaped but not Markdown-escaped, so a value like `[x](javascript:alert(1))` could render as a clickable `javascript:` link. Markdown metacharacters in user values are now escaped as well. (#1806) (@YamatoSecurity)
 
+**Other:**
+
+- Translated all remaining Japanese code comments to English, cleaned up and added many code comments for readability, and fixed misspelled internal identifiers. Comments and identifiers only; no behavior changes. (#1808) (@Shirofune-Security)
+
 ## 3.9.0 [2026/04/29]
 
 **Enchancements:**

--- a/src/afterfact.rs
+++ b/src/afterfact.rs
@@ -24,7 +24,7 @@ use terminal_size::Width;
 use terminal_size::terminal_size;
 
 use crate::detections::configs::{
-    Action, CONTROL_CHAT_REPLACE_MAP, CURRENT_EXE_PATH, GEOIP_DB_PARSER, StoredStatic,
+    Action, CONTROL_CHAR_REPLACE_MAP, CURRENT_EXE_PATH, GEOIP_DB_PARSER, StoredStatic,
     TimeFormatOptions,
 };
 use crate::detections::message::{AlertMessage, COMPUTER_MITRE_ATTCK_MAP, DetectInfo};
@@ -75,12 +75,17 @@ use crate::level::{_get_output_color, LEVEL, create_output_color_map};
 use crate::options::htmlreport;
 use crate::options::profile::Profile;
 
+/// The same display color expressed once for the termcolor crate (plain terminal output) and
+/// once for the comfy_table crate (table output).
 #[derive(Debug)]
 pub struct Colors {
     pub output_color: termcolor::Color,
     pub table_color: comfy_table::Color,
 }
 
+/// State accumulated while emitting detection results, used afterwards to build the results
+/// summary: detection counts broken down by level/date/computer/rule, timestamps for the
+/// detection frequency timeline, and the previous-record data needed for duplicate suppression.
 pub struct AfterfactInfo {
     pub tl_starttime: Option<DateTime<Utc>>,
     pub tl_endtime: Option<DateTime<Utc>>,
@@ -106,6 +111,8 @@ pub struct AfterfactInfo {
     pub prev_details_convert_map: HashMap<CompactString, Vec<CompactString>>,
 }
 
+/// The three per-level count maps (by date, by computer, by rule) created together in
+/// `AfterfactInfo::default`.
 struct InitLevelMapResult(
     HashMap<LEVEL, HashMap<CompactString, i128>>,
     HashMap<LEVEL, HashMap<CompactString, i128>>,
@@ -127,7 +134,8 @@ impl Default for AfterfactInfo {
             > = HashMap::new();
             let mut detect_counts_by_rule_and_level: HashMap<LEVEL, HashMap<CompactString, i128>> =
                 HashMap::new();
-            // Initialize aggregation variables by level and day.
+            // Pre-insert an empty inner map for every level so later per-level lookups always
+            // find an entry (several output functions rely on this and unwrap the result).
             for level_init in LEVEL::iter() {
                 detect_counts_by_date_and_level.insert(level_init.clone(), HashMap::new());
                 detect_counts_by_computer_and_level.insert(level_init.clone(), HashMap::new());
@@ -167,6 +175,9 @@ impl Default for AfterfactInfo {
     }
 }
 
+/// The writers used for result output: a termcolor writer for colored terminal display and a
+/// csv crate writer for the CSV/JSON output itself. `display_flag` is true when no output file
+/// was specified, i.e. results are displayed on the terminal.
 pub struct AfterfactWriter {
     disp_wtr: BufferWriter,
     disp_wtr_buf: Buffer,
@@ -174,6 +185,11 @@ pub struct AfterfactWriter {
     pub display_flag: bool,
 }
 
+/// Creates the result writer, targeting the file given with the output option if one was
+/// specified, otherwise stdout (the pivot-keywords-list and logon-summary commands write their
+/// own files elsewhere, so their writer stays on stdout). The csv writer is also (ab)used for
+/// JSON output by configuring
+/// it to perform no quoting and use newline as the delimiter.
 pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
     let disp_wtr = BufferWriter::stdout(ColorChoice::Always);
     let mut disp_wtr_buf = disp_wtr.buffer();
@@ -188,7 +204,7 @@ pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
         ) {
             Box::new(BufWriter::new(io::stdout()))
         } else {
-            // output to file
+            // Write the results to the specified output file.
             match File::create(path) {
                 Ok(file) => Box::new(BufWriter::new(file)),
                 Err(err) => {
@@ -199,7 +215,8 @@ pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
         }
     } else {
         display_flag = true;
-        // stdoutput (termcolor crate color output is not csv writer)
+        // No output file was specified, so results go to stdout. Colored display output is
+        // produced through the termcolor writer (disp_wtr), not through this csv writer.
         Box::new(BufWriter::new(io::stdout()))
     };
 
@@ -215,7 +232,7 @@ pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
         _ => WriterBuilder::new().from_writer(target),
     };
 
-    // emit csv
+    // Bundle the display writer and the CSV/JSON writer used by emit_csv and the summary output.
     AfterfactWriter {
         disp_wtr,
         disp_wtr_buf,
@@ -224,6 +241,8 @@ pub fn init_writer(stored_static: &StoredStatic) -> AfterfactWriter {
     }
 }
 
+/// Sorts and deduplicates all collected detections, writes them out, and prints the results
+/// summary. Exits the process if writing fails.
 pub fn output_afterfact(
     detect_infos: &mut [DetectInfo],
     afterfact_writer: &mut AfterfactWriter,
@@ -241,6 +260,10 @@ pub fn output_afterfact(
     }
 }
 
+/// Writes one batch of detections and folds it into the summary statistics. This is the
+/// streaming output path used in low-memory mode, where results are emitted per batch instead
+/// of being collected, sorted, and written all at once by `output_afterfact`. Exits the process
+/// if writing fails.
 pub fn emit_csv(
     detect_infos: &[DetectInfo],
     duplicate_idxes: &HashSet<usize>,
@@ -281,7 +304,8 @@ fn output_afterfact_inner(
         println!();
     }
 
-    // sort and filter detect infos
+    // Sort the detections, then determine which ones to drop as duplicates if the
+    // remove-duplicate-detections option is enabled.
     sort_detect_info(detect_infos);
     let duplicate_idxes = if stored_static
         .output_option
@@ -302,7 +326,7 @@ fn output_afterfact_inner(
         afterfact_info,
     )?;
 
-    // calculate statistic information
+    // Calculate the statistics for the results summary.
     calc_statistic_info(
         detect_infos,
         &duplicate_idxes,
@@ -323,6 +347,12 @@ fn emit_csv_inner(
     afterfact_writer: &mut AfterfactWriter,
     afterfact_info: &mut AfterfactInfo,
 ) -> io::Result<()> {
+    // Control characters in record field values were escaped earlier in the pipeline as
+    // "🛂r"/"🛂n"/"🛂t" (see utils::remove_sp_char). output_replacer first restores them to the
+    // real control characters, then output_remover flattens control characters to spaces for
+    // single-line output. With the multiline (or tab-separator) option, the "🛂🛂" marker used to
+    // join multi-valued entries and the " ¦ " field separator become line breaks (or tabs)
+    // instead.
     let output_replaced_maps: HashMap<&str, &str> =
         HashMap::from_iter(vec![("🛂r", "\r"), ("🛂n", "\n"), ("🛂t", "\t")]);
     let mut removed_replaced_maps: HashMap<&str, &str> =
@@ -343,7 +373,8 @@ fn emit_csv_inner(
         .build(removed_replaced_maps.keys())
         .unwrap();
 
-    // Variable to hold the previous record information for removing duplicate data.
+    // Prepare the per-level color map, then determine the output format and whether duplicate
+    // field data should be replaced with "DUP" (the remove-duplicate-data option).
     let color_map = create_output_color_map(stored_static.common_options.no_color);
     let (json_output_flag, jsonl_output_flag, remove_duplicate_data) =
         match &stored_static.config.action.as_ref().unwrap() {
@@ -364,9 +395,9 @@ fn emit_csv_inner(
             continue;
         }
         if afterfact_writer.display_flag && !(json_output_flag || jsonl_output_flag) {
-            // For standard output.
+            // Terminal display output.
             if !afterfact_info.has_displayed_header {
-                // Output only the header.
+                // Print the header row only once.
                 _get_serialized_disp_output(
                     &afterfact_writer.disp_wtr,
                     profile,
@@ -446,7 +477,7 @@ fn emit_csv_inner(
                 afterfact_writer.csv_writer.write_field("}")?;
             }
         } else {
-            // csv output format
+            // CSV output format
             if !afterfact_info.has_displayed_header {
                 afterfact_writer
                     .csv_writer
@@ -508,6 +539,9 @@ fn emit_csv_inner(
     Ok(())
 }
 
+/// Folds a batch of detections into `afterfact_info`: records the detection timestamps and the
+/// IDs of detected records, and (unless no-summary is set) updates the per-level counts by
+/// date, computer, and rule, plus the rule author statistics used by the results summary.
 fn calc_statistic_info(
     detect_infos: &[DetectInfo],
     duplicate_idxes: &HashSet<usize>,
@@ -625,6 +659,9 @@ fn calc_statistic_info(
     }
 }
 
+/// Prints everything that follows the timeline itself: the rule author table, the detection
+/// frequency timeline (if requested), and the results summary (event counts, detection counts
+/// per level/date/computer/rule). Also accumulates the same content for the HTML report if enabled.
 pub fn output_additional_afterfact(
     stored_static: &StoredStatic,
     afterfact_writer: &mut AfterfactWriter,
@@ -769,12 +806,12 @@ pub fn output_additional_afterfact(
             println!();
         }
 
-        let reducted_record_cnt: u128 =
+        let reduced_record_cnt: u128 =
             afterfact_info.record_cnt - afterfact_info.detected_record_idset.len() as u128;
-        let reducted_percent = if afterfact_info.record_cnt == 0 {
+        let reduced_percent = if afterfact_info.record_cnt == 0 {
             0 as f64
         } else {
-            (reducted_record_cnt as f64) / (afterfact_info.record_cnt as f64) * 100.0
+            (reduced_record_cnt as f64) / (afterfact_info.record_cnt as f64) * 100.0
         };
         write_color_buffer(
             &afterfact_writer.disp_wtr,
@@ -811,7 +848,7 @@ pub fn output_additional_afterfact(
         )
         .ok();
         let saved_alerts_output =
-            (afterfact_info.record_cnt - reducted_record_cnt).to_formatted_string(&Locale::en);
+            (afterfact_info.record_cnt - reduced_record_cnt).to_formatted_string(&Locale::en);
         write_color_buffer(
             &afterfact_writer.disp_wtr,
             get_writable_color(
@@ -850,8 +887,8 @@ pub fn output_additional_afterfact(
         .ok();
         let reduction_output = format!(
             "Data reduction: {} events ({:.2}%)",
-            reducted_record_cnt.to_formatted_string(&Locale::en),
-            reducted_percent
+            reduced_record_cnt.to_formatted_string(&Locale::en),
+            reduced_percent
         );
         write_color_buffer(
             &afterfact_writer.disp_wtr,
@@ -1062,6 +1099,9 @@ pub fn output_additional_afterfact(
     }
 }
 
+/// Sorts detections by detected time, level, event ID, rule path, computer name, record ID,
+/// and finally by the rendered field values, giving a total order so the output is
+/// deterministic.
 pub fn sort_detect_info(detect_infos: &mut [DetectInfo]) {
     detect_infos.sort_unstable_by(|a, b| {
         let cmp_time = a.detected_time.cmp(&b.detected_time);
@@ -1112,8 +1152,14 @@ pub fn sort_detect_info(detect_infos: &mut [DetectInfo]) {
     });
 }
 
+/// Returns the indexes of detections considered duplicates of an earlier detection with the
+/// same timestamp, comparing every profile field except EvtxFile (so the same event ingested
+/// from overlapping evtx files counts as a duplicate). Assumes `detect_infos` is already sorted
+/// by detected time. Note: the first record of each timestamp group is never added to the
+/// comparison set, so the second of two identical records is currently not flagged as a
+/// duplicate — only the third and later identical records are.
 pub fn get_duplicate_idxes(detect_infos: &mut [DetectInfo]) -> HashSet<usize> {
-    // filtet duplicate event
+    // Collect the indexes of duplicate events.
     let mut filtered_detect_infos = HashSet::new();
     let mut prev_detect_infos = HashSet::new();
     for (i, detect_info) in detect_infos.iter().enumerate() {
@@ -1157,7 +1203,8 @@ fn _get_table_color(
     color
 }
 
-/// print timeline histogram
+/// Prints the detection frequency timeline (a sparkline histogram of detection timestamps with
+/// time markers) to stdout. Requires at least 5 events to render.
 fn _print_timeline_hist(timestamps: &[i64], length: usize, side_margin_size: usize) {
     if timestamps.is_empty() {
         return;
@@ -1205,6 +1252,8 @@ fn _print_timeline_hist(timestamps: &[i64], length: usize, side_margin_size: usi
     buf_wtr.print(&wtr).ok();
 }
 
+/// Increments the counter for `entry_key` in the inner map for `level`, falling back to the
+/// UNDEFINED level's map if the level has no entry.
 fn countup_aggregation(
     count_map: &mut HashMap<LEVEL, HashMap<CompactString, i128>>,
     level: &LEVEL,
@@ -1218,16 +1267,19 @@ fn countup_aggregation(
     count_map.insert(level.clone(), detect_counts_by_rules);
 }
 
-/// columnt position. in cell
+/// Column position within a display cell, which determines where padding spaces are added:
 /// First: |<str> |
 /// Last: | <str>|
-/// Othre: | <str> |
+/// Other: | <str> |
 enum ColPos {
     First,
     Last,
     Other,
 }
 
+/// Writes one record (or, when `header` is true, the column header row) to the terminal in the
+/// "·"-separated display format, coloring the timestamp/level/rule-title fields by detection
+/// level and the field names/values inside the details sections individually.
 fn _get_serialized_disp_output(
     disp_wtr: &BufferWriter,
     data: &[(CompactString, Profile)],
@@ -1263,6 +1315,11 @@ fn _get_serialized_disp_output(
         write_color_buffer(
             disp_wtr,
             get_writable_color(None, no_color),
+            // The serializer above uses '|' as its delimiter; show those separators as '·' and
+            // then restore any '🦅' placeholders back to '|'. Historically cell values had
+            // literal '|' replaced with '🦅' before serialization so this delimiter
+            // substitution would not clobber them; nothing currently inserts that placeholder
+            // on this path, so the second replace is defensive/vestigial.
             &String::from_utf8(disp_serializer.into_inner().unwrap_or_default())
                 .unwrap_or_default()
                 .replace('|', "·")
@@ -1364,7 +1421,7 @@ fn _get_serialized_disp_output(
                 )
                 .ok();
             } else {
-                //1レコード分の最後の要素の改行
+                // Line break after the last element of one record (plus a blank separator line).
                 println!();
                 println!();
             }
@@ -1372,7 +1429,7 @@ fn _get_serialized_disp_output(
     }
 }
 
-/// return str position in output file
+/// Pads a cell value with spaces according to its column position in the display output.
 fn _format_cellpos(colval: &str, column: ColPos) -> String {
     match column {
         ColPos::First => format!("{colval} "),
@@ -1381,7 +1438,8 @@ fn _format_cellpos(colval: &str, column: ColPos) -> String {
     }
 }
 
-/// output info which unique detection count and all detection count information(separated by level and total) to stdout.
+/// Prints the total and unique detection counts (overall and per level, with percentages) to
+/// stdout, and accumulates the same information for the HTML report when enabled.
 fn _print_unique_results(
     counts_by_level: &[u128],
     unique_counts_by_level: &[u128],
@@ -1390,13 +1448,14 @@ fn _print_unique_results(
     html_output_stock: &mut Nested<String>,
     html_output_flag: bool,
 ) {
-    // the order in which are registered and the order of levels to be displayed are reversed
+    // The counts are stored in ascending level order, but levels are displayed from highest to
+    // lowest, so iterate over them in reverse.
     let mut counts_by_level_rev = counts_by_level.iter().rev();
     let mut unique_counts_by_level_rev = unique_counts_by_level.iter().rev();
 
     let total_count = counts_by_level.iter().sum::<u128>();
     let unique_total_count = unique_counts_by_level.iter().sum::<u128>();
-    // output total results
+    // Output the totals across all levels first.
     write_color_buffer(
         &BufferWriter::stdout(ColorChoice::Always),
         None,
@@ -1488,7 +1547,8 @@ fn _print_detection_summary_by_date(
         if level == LEVEL::UNDEFINED {
             continue;
         }
-        // output_levels is an array with undefined excluded from levels; each element is guaranteed to be initialized and Some, so unwrap is called directly.
+        // An inner map was inserted for every level when AfterfactInfo was initialized, so the
+        // lookup is guaranteed to be Some and unwrap is called directly.
         let detections_by_day = detect_counts_by_date.get(&level).unwrap();
         let mut max_detect_str = CompactString::default();
         let mut max_date: Option<&CompactString> = None;
@@ -1517,6 +1577,8 @@ fn _print_detection_summary_by_date(
         }
         let output_str = format!("{}: {}", level.to_full(), &max_detect_str);
         write!(wtr, "{output_str}").ok();
+        // Print a ", " separator after every level except the last displayed one (count() - 2
+        // because UNDEFINED, the final item of the reversed iteration, is skipped).
         if i != LEVEL::iter().count() - 2 {
             wtr.set_color(ColorSpec::new().set_fg(None)).ok();
             write!(wtr, ", ").ok();
@@ -1528,7 +1590,8 @@ fn _print_detection_summary_by_date(
     buf_wtr.print(&wtr).ok();
 }
 
-/// Output the computer name with the highest detection count for each level.
+/// Output the top 5 computers with the most unique detections for each level (the HTML report
+/// gets the full list).
 fn _print_detection_summary_by_computer(
     detect_counts_by_computer: &HashMap<LEVEL, HashMap<CompactString, i128>>,
     color_map: &HashMap<LEVEL, Colors>,
@@ -1544,7 +1607,8 @@ fn _print_detection_summary_by_computer(
         if level == LEVEL::UNDEFINED {
             continue;
         }
-        // output_levels is an array with undefined excluded from levels; each element is guaranteed to be initialized and Some, so unwrap is called directly.
+        // An inner map was inserted for every level when AfterfactInfo was initialized, so the
+        // lookup is guaranteed to be Some and unwrap is called directly.
         let detections_by_computer = detect_counts_by_computer.get(&level).unwrap();
         let mut result_vec = Nested::<String>::new();
         // Exclude entries where the computer name is "-" from the aggregation.
@@ -1594,7 +1658,9 @@ fn _print_detection_summary_by_computer(
     buf_wtr.print(&wtr).ok();
 }
 
-/// Function to output rules with the most detections for each level in table format.
+/// Output the rules with the most detections for each level in table format (top 5 per level;
+/// the HTML report gets the full list). Rule titles longer than `limit_num` characters are
+/// truncated with "...".
 fn _print_detection_summary_tables(
     detect_counts_by_rule_and_level: &HashMap<LEVEL, HashMap<CompactString, i128>>,
     color_map: &HashMap<LEVEL, Colors>,
@@ -1621,7 +1687,8 @@ fn _print_detection_summary_tables(
 
         col_color.push(_get_table_color(color_map, &level));
 
-        // output_levels is an array with undefined excluded from levels; each element is guaranteed to be initialized and Some, so unwrap is called directly.
+        // An inner map was inserted for every level when AfterfactInfo was initialized, so the
+        // lookup is guaranteed to be Some and unwrap is called directly.
         let detections_by_computer = detect_counts_by_rule_and_level.get(&level).unwrap();
         let mut sorted_detections: Vec<(&CompactString, &i128)> =
             detections_by_computer.iter().collect();
@@ -1631,7 +1698,7 @@ fn _print_detection_summary_tables(
         // order.
         sorted_detections.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
 
-        // For HTML output, output all content.
+        // For HTML output, list every rule rather than only the top five.
         if stored_static.html_report_flag {
             html_output_stock.push(format!(
                 "### All {} alerts: {{#all_{}_alerts}}",
@@ -1722,7 +1789,8 @@ fn _print_detection_summary_tables(
     println!("{tb}");
 }
 
-/// get timestamp to input datetime.
+/// Converts the given datetime to epoch seconds. Unless UTC or ISO 8601 output was requested,
+/// the local UTC offset is added so the value reflects local wall-clock time.
 fn _get_timestamp(output_option: &TimeFormatOptions, time: &DateTime<Utc>) -> i64 {
     if output_option.utc || output_option.iso_8601 {
         time.timestamp()
@@ -1736,7 +1804,10 @@ fn _get_timestamp(output_option: &TimeFormatOptions, time: &DateTime<Utc>) -> i6
     }
 }
 
-/// Function that returns an array when the value corresponds to details, MitreTactics, MitreTags, or OtherTags that are handled as arrays in JSON output.
+/// Splits the value into its elements for the profile members that are output as JSON arrays or
+/// objects: MitreTactics/MitreTags/OtherTags (": "-separated) and Details/AllFieldInfo/
+/// ExtraFieldInfo (" ¦ "-separated key-value pairs). Returns an empty Vec for everything else,
+/// and also for a details value that is a single element with no "key: value" structure.
 fn _get_json_vec(profile: &Profile, target_data: &String) -> Vec<String> {
     match profile {
         Profile::MitreTactics(_) | Profile::MitreTags(_) | Profile::OtherTags(_) => {
@@ -1754,7 +1825,11 @@ fn _get_json_vec(profile: &Profile, target_data: &String) -> Vec<String> {
     }
 }
 
-/// Function to output a string matching the JSON output format.
+/// Formats one key/value pair as a JSON fragment (`"key": value`), indenting it with
+/// `space_cnt` spaces. Values that parse as integers or booleans are emitted unquoted;
+/// `concat_flag` marks values that are already valid JSON (arrays/objects/pre-quoted strings)
+/// and must not be wrapped in quotes again. Control characters are replaced on both key and
+/// value via CONTROL_CHAR_REPLACE_MAP.
 fn _create_json_output_format(
     key: &str,
     value: &str,
@@ -1765,7 +1840,7 @@ fn _create_json_output_format(
     let head = if key_quote_exclude_flag {
         key.chars()
             .map(|x| {
-                if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                if let Some(c) = CONTROL_CHAR_REPLACE_MAP.get(&x) {
                     c.to_string()
                 } else {
                     String::from(x)
@@ -1776,7 +1851,7 @@ fn _create_json_output_format(
         format!("\"{key}\"")
             .chars()
             .map(|x| {
-                if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                if let Some(c) = CONTROL_CHAR_REPLACE_MAP.get(&x) {
                     c.to_string()
                 } else {
                     String::from(x)
@@ -1784,7 +1859,7 @@ fn _create_json_output_format(
             })
             .collect::<CompactString>()
     };
-    // 4 space is json indent.
+    // The indent is space_cnt spaces: 4 for top-level JSON keys, 8 for nested keys.
     if let Ok(i) = i64::from_str(value) {
         format!("{}{}: {}", " ".repeat(space_cnt), head, i)
     } else if let Ok(b) = bool::from_str(value) {
@@ -1797,7 +1872,7 @@ fn _create_json_output_format(
             value
                 .chars()
                 .map(|x| {
-                    if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                    if let Some(c) = CONTROL_CHAR_REPLACE_MAP.get(&x) {
                         c.to_string()
                     } else {
                         String::from(x)
@@ -1813,7 +1888,7 @@ fn _create_json_output_format(
             value
                 .chars()
                 .map(|x| {
-                    if let Some(c) = CONTROL_CHAT_REPLACE_MAP.get(&x) {
+                    if let Some(c) = CONTROL_CHAR_REPLACE_MAP.get(&x) {
                         c.to_string()
                     } else {
                         String::from(x)
@@ -1824,7 +1899,8 @@ fn _create_json_output_format(
     }
 }
 
-/// Function that converts string values for JSON output to prevent errors in JSON output format.
+/// Escapes a string value (joining multi-part "key: value" input as needed) so it can be
+/// embedded in the JSON output without producing invalid JSON.
 fn _convert_valid_json_str(input: &[&str], concat_flag: bool) -> String {
     let con_cal = if input.len() == 1 {
         input[0].to_string()
@@ -1862,7 +1938,9 @@ fn _convert_valid_json_str(input: &[&str], concat_flag: bool) -> String {
     }
 }
 
-/// Function to output the object string for one detection in JSON output.
+/// Builds the JSON object body for one detection. Returns the body string (without the
+/// surrounding braces, which the caller adds) together with the updated previous-record field
+/// map used for duplicate-data suppression on the next record.
 pub fn output_json_str(
     detect_info: &DetectInfo,
     afterfact_info: &mut AfterfactInfo,
@@ -1904,12 +1982,14 @@ pub fn output_json_str(
                             == profile.to_value())
                         || (!&now.is_empty() && !&prev.is_empty() && now == prev);
                     if dup_flag {
-                        // If matched, update the message for the previous record and change the content of the field map for output.
-                        // Since it matches, do not update the previous message.
-                        // Use Profile::Literal to output the ordinary string "DUP".
+                        // Duplicate of the previous record: output the plain string "DUP"
+                        // instead of the value (Profile::Literal emits it as-is). The previous
+                        // message is intentionally NOT updated, so consecutive duplicates keep
+                        // being compared against the last non-duplicate value.
                         target_ext_field.push((field_name.clone(), Profile::Literal("DUP".into())));
                     } else {
-                        // If not matched, update the message for the previous record.
+                        // Not a duplicate: remember this value for comparison with the next
+                        // record.
                         next_prev_message.insert(field_name.clone(), profile.clone());
                         target_ext_field.push((field_name.clone(), profile.clone()));
                     }
@@ -1922,6 +2002,8 @@ pub fn output_json_str(
     } else {
         target_ext_field.clone_from(&detect_info.ext_field);
     }
+    // GeoIP enrichment fields that are folded into the Details (and AllFieldInfo) objects of
+    // the JSON output instead of being emitted as top-level keys.
     let key_add_to_details = [
         "SrcASN",
         "SrcCountry",
@@ -1972,7 +2054,9 @@ pub fn output_json_str(
             ));
         } else {
             match profile {
-                // process GeoIP profile in details sections to include GeoIP data in details section.
+                // GeoIP profile fields are skipped here because they are emitted inside the
+                // Details/AllFieldInfo sections instead (see the key_add_to_details handling
+                // below).
                 Profile::SrcASN(_)
                 | Profile::SrcCountry(_)
                 | Profile::SrcCity(_)
@@ -2016,12 +2100,12 @@ pub fn output_json_str(
                             }
                             continue;
                         }
-                        let splitted_agg_details = details_target_stock[0]
+                        let split_agg_details = details_target_stock[0]
                             .split(" ¦ ")
                             .map(|x| x.into())
                             .collect_vec();
                         process_target_stock(
-                            &splitted_agg_details,
+                            &split_agg_details,
                             &mut children_output_stock,
                             &mut children_output_order,
                         );
@@ -2042,7 +2126,9 @@ pub fn output_json_str(
                     }
                     output_stock.push(format!("    \"{key}\": {{"));
 
-                    // Array with display order restored to match the display order in the rule.
+                    // Rebuild the field order to match the order in which the fields appear in
+                    // the rule (recorded in children_output_order), since HashMap iteration
+                    // order is arbitrary.
                     let mut sorted_children_output_stock: Vec<(
                         &CompactString,
                         &Vec<CompactString>,
@@ -2178,6 +2264,9 @@ pub fn output_json_str(
     }
 }
 
+/// Splits each "key: value" detail entry and groups the values by key in
+/// `children_output_stock` (a key gets multiple values when it appears more than once, e.g.
+/// Data[1]/Data[2] fields), recording first-seen key order in `children_output_order`.
 fn process_target_stock(
     details_target_stock: &[CompactString],
     children_output_stock: &mut HashMap<CompactString, Vec<CompactString>>,
@@ -2199,7 +2288,8 @@ fn process_target_stock(
             .push(fmted_val.into());
     }
 }
-/// output detected rule author name function.
+/// Prints a table of the detected rule authors and the number of their rules that produced
+/// detections, laid out over `table_column_num` columns.
 fn output_detected_rule_authors(
     rule_author_counter: &HashMap<CompactString, i128>,
     table_column_num: usize,
@@ -2258,12 +2348,13 @@ fn output_detected_rule_authors(
     println!("{tb}");
 }
 
-/// Function to extract the author name from the given yaml_path and return it as an array.
+/// Extracts the individual author names from a rule's author string and returns them as an
+/// array.
 fn extract_author_name(author: &str) -> Nested<String> {
     let mut ret = Nested::<String>::new();
     for author in author.split(',').map(|s| {
-        // Only reference the first element of tmp, as descriptions after parentheses in each element are not treated as a name.
-        // Exclude double quotes and single quotes from the data here.
+        // Keep only the part before '(': a parenthesized remark after a name is a description,
+        // not part of the name. Double and single quotes are stripped from the names below.
         s.split('(').next().unwrap_or_default().to_string()
     }) {
         ret.extend(author.split(';'));
@@ -2278,7 +2369,8 @@ fn extract_author_name(author: &str) -> Nested<String> {
         .collect()
 }
 
-/// Function to add to html_output_stock the string for HTML-outputting the computer name detected by rules with MITRE ATT&CK Tactics attributes.
+/// Appends to `html_output_stock` a Markdown table of computer names and the MITRE ATT&CK
+/// tactics detected on them (with unique and total counts), for the HTML report.
 fn _output_html_computer_by_mitre_attck(html_output_stock: &mut Nested<String>) {
     html_output_stock.push("### MITRE ATT&CK Tactics:{#computers_with_mitre_attck_detections}");
     if COMPUTER_MITRE_ATTCK_MAP.is_empty() {

--- a/src/debug/checkpoint_process_timer.rs
+++ b/src/debug/checkpoint_process_timer.rs
@@ -5,15 +5,22 @@ use chrono::{DateTime, Local};
 use lazy_static::lazy_static;
 
 lazy_static! {
+    /// Global timer used to record how long each processing phase (rule parsing, analysis,
+    /// output) takes. Lap times are always collected; the per-phase breakdown is only printed
+    /// when the --debug option is set, while the accumulated total is always shown as the
+    /// "Elapsed time" in the results summary.
     pub static ref CHECKPOINT: Mutex<CheckPointProcessTimer> =
         Mutex::new(CheckPointProcessTimer::create_checkpoint_timer());
 }
 
+/// Stopwatch-style timer: `set_checkpoint` starts measuring and `lap_checkpoint` records the
+/// elapsed time since the last checkpoint as a labeled lap.
 pub struct CheckPointProcessTimer {
     prev_checkpoint: Option<DateTime<Local>>,
     stocked_results: Vec<CheckPointTimeStore>,
 }
 
+/// One recorded lap: a label and the elapsed time split into seconds and milliseconds.
 pub struct CheckPointTimeStore {
     pub output_str: String,
     pub sec: i64,
@@ -34,8 +41,12 @@ impl CheckPointProcessTimer {
         self.prev_checkpoint = Some(time);
     }
 
-    /// Gets the lap time and stores it in the output array.
-    pub fn rap_checkpoint(&mut self, output_str: &str) {
+    /// Records the time elapsed since the last checkpoint as a lap labeled `output_str` and
+    /// clears the checkpoint. Does nothing if no checkpoint has been set. If the most recently
+    /// stocked lap has the same label, the new lap time is added to it instead of creating a new
+    /// entry, so a phase that is timed repeatedly (e.g. once per input file) is reported as a
+    /// single total.
+    pub fn lap_checkpoint(&mut self, output_str: &str) {
         if self.prev_checkpoint.is_none() {
             return;
         }
@@ -60,7 +71,7 @@ impl CheckPointProcessTimer {
         self.prev_checkpoint = None;
     }
 
-    /// Outputs the stocked results.
+    /// Prints every stocked lap as "label: duration" (used for the --debug breakdown).
     pub fn output_stocked_result(&self) {
         for output in self.stocked_results.iter() {
             println!(
@@ -71,6 +82,9 @@ impl CheckPointProcessTimer {
         }
     }
 
+    /// Returns the sum of all stocked lap times — plus, if a checkpoint is currently running,
+    /// the time elapsed since it was set — formatted as a duration string. Used for the total
+    /// "Elapsed time" line in the results summary.
     pub fn calculate_all_stocked_results(&self) -> String {
         let mut s = 0;
         let mut ms = 0;
@@ -102,15 +116,15 @@ mod tests {
     }
 
     #[test]
-    fn test_rap_checkpoint() {
+    fn test_lap_checkpoint() {
         let mut actual = CheckPointProcessTimer {
             prev_checkpoint: None,
             stocked_results: Vec::new(),
         };
-        actual.rap_checkpoint("Test");
+        actual.lap_checkpoint("Test");
         let now: DateTime<Local> = Local::now();
         actual.set_checkpoint(now);
-        actual.rap_checkpoint("Test2");
+        actual.lap_checkpoint("Test2");
         actual.set_checkpoint(Local::now());
         assert!(actual.prev_checkpoint.is_some());
         assert_eq!(actual.stocked_results.len(), 1);
@@ -127,12 +141,12 @@ mod tests {
             prev_checkpoint: Some(now),
             stocked_results: Vec::new(),
         };
-        actual.rap_checkpoint("Test");
+        actual.lap_checkpoint("Test");
         actual.set_checkpoint(
             now.checked_add_signed(TimeDelta::try_seconds(1).unwrap_or_default())
                 .unwrap(),
         );
-        actual.rap_checkpoint("Test2");
+        actual.lap_checkpoint("Test2");
         actual.set_checkpoint(
             now.checked_add_signed(TimeDelta::try_seconds(1).unwrap_or_default())
                 .unwrap(),

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -35,16 +35,24 @@ lazy_static! {
     pub static ref GEOIP_FILTER: RwLock<Option<Vec<Yaml>>> = RwLock::new(None);
     pub static ref CURRENT_EXE_PATH: PathBuf =
         current_exe().unwrap().parent().unwrap().to_path_buf();
+    // Matches UUID-formatted ids (e.g. the "id" field of Sigma rules).
     pub static ref IDS_REGEX: Regex =
         Regex::new(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$").unwrap();
-    pub static ref CONTROL_CHAT_REPLACE_MAP: HashMap<char, CompactString> =
-        create_control_chat_replace_map();
+    // Maps every C0 control character (0x00-0x1F, except line feed) to its JSON-style \u00XX escape.
+    pub static ref CONTROL_CHAR_REPLACE_MAP: HashMap<char, CompactString> =
+        create_control_char_replace_map();
+    // Matches the placeholder tokens that utils::remove_sp_char substitutes for \r, \n and \t
+    // inside field values, so that output code can later restore or strip them.
     pub static ref ALLFIELDINFO_SPECIAL_CHARS: AhoCorasick = AhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["🛂r", "🛂n", "🛂t"])
         .unwrap();
+    // All-in-one config bundle (embedded file path -> file content). When rules_config_files.txt
+    // exists, its entries are used instead of the individual files under rules/config.
     pub static ref ONE_CONFIG_MAP: HashMap<String, String> =
         read_one_config_file(Path::new("rules_config_files.txt")).unwrap_or_default();
+    // Dash variants (hyphen, en dash, em dash, etc.) that the Sigma "windash" modifier treats as
+    // interchangeable.
     pub static ref WINDASH_CHARACTERS: Vec<char> = load_windash_characters(
         check_setting_path(
             &CURRENT_EXE_PATH.to_path_buf(),
@@ -55,9 +63,14 @@ lazy_static! {
         .to_str()
         .unwrap(),
     );
+    // (OS version, build number) -> (Windows product name, release date), loaded from
+    // windows_versions.csv.
     pub static ref WIN_VERSIONS: HashMap<(String, String), (String, String)> = load_win_versions();
 }
 
+/// Parses the all-in-one config bundle (rules_config_files.txt), in which multiple rule config
+/// files are concatenated with `---FILE_START---` / `path: ` / `---CONTENT---` / `---FILE_END---`
+/// markers. Returns a map from each embedded file path to its content.
 fn read_one_config_file(file_path: &Path) -> io::Result<HashMap<String, String>> {
     let file = File::open(file_path)?;
     let reader = io::BufReader::new(file);
@@ -87,6 +100,7 @@ fn read_one_config_file(file_path: &Path) -> io::Result<HashMap<String, String>>
     Ok(sections)
 }
 
+/// Holds the clap command definition (used for help output) together with the parsed CLI config.
 pub struct ConfigReader {
     pub app: Command,
     pub config: Option<Config>,
@@ -98,6 +112,8 @@ impl Default for ConfigReader {
     }
 }
 
+/// Application state resolved once at startup from the CLI options and config files, then shared
+/// read-only for the rest of the run (also published globally via the STORED_STATIC RwLock).
 #[derive(Debug, Clone)]
 pub struct StoredStatic {
     pub config: Config,
@@ -148,7 +164,7 @@ pub struct StoredStatic {
 }
 
 impl StoredStatic {
-    /// Function to store data from the information parsed in main.rs.
+    /// Builds the StoredStatic data set from the command-line options parsed in main.rs.
     pub fn create_static_data(input_config: Option<Config>) -> StoredStatic {
         let action_id = Action::to_usize(input_config.as_ref().unwrap().action.as_ref());
         let quiet_errors_flag = match &input_config.as_ref().unwrap().action {
@@ -786,6 +802,7 @@ impl StoredStatic {
                     .to_str()
                     .unwrap(),
             ),
+            // The numeric ids compared below come from Action::to_usize.
             logon_summary_flag: action_id == 2,
             metrics_flag: action_id == 3,
             search_flag: action_id == 10,
@@ -869,7 +886,8 @@ impl StoredStatic {
         );
         ret
     }
-    /// Function to read the default values of details from a file.
+    /// Reads the default `details` output templates (per provider and EID) from
+    /// default_details.txt.
     pub fn get_default_details(
         filepath: &str,
         disable_abbreviations: bool,
@@ -884,7 +902,8 @@ impl StoredStatic {
                 HashMap::new()
             }
             Ok(lines) => {
-                // The data is in the following format, listed in order of Provider Name, EID, Details output elements.
+                // Each line has the following format, in order: provider name, EID, then the
+                // default `details` output template, e.g.:
                 // Microsoft-Windows-Sysmon, 1, Cmdline: %CommandLine% ¦ Proc: %Image% ...
 
                 let mut ret: HashMap<CompactString, CompactString> = HashMap::new();
@@ -1104,6 +1123,8 @@ pub enum Action {
 }
 
 impl Action {
+    /// Returns a stable numeric id for the given subcommand (100 when no subcommand was given).
+    /// The action_id comparisons in create_static_data refer to these values.
     pub fn to_usize(action: Option<&Action>) -> usize {
         if let Some(a) = action {
             match a {
@@ -1128,6 +1149,8 @@ impl Action {
             100
         }
     }
+    /// Returns the CLI name of the given subcommand (an empty string when no subcommand was
+    /// given).
     pub fn get_action_name(action: Option<&Action>) -> &str {
         if let Some(a) = action {
             match a {
@@ -1596,7 +1619,7 @@ pub struct LogonSummaryOption {
     pub start_timeline: Option<String>,
 }
 
-/// Options can be set when outputting
+/// Options that can be set when outputting results (flattened into csv-timeline/json-timeline)
 #[derive(Args, Clone, Debug, Default)]
 #[clap(group(ArgGroup::new("level_rule_filtering").args(["min_level", "exact_level"]).multiple(false)))]
 pub struct OutputOption {
@@ -1821,7 +1844,8 @@ pub struct CsvOutputOption {
     #[arg(help_heading = Some("Output"), short = 'S', long="tab-separator", conflicts_with = "multiline", requires = "output", display_order = 490)]
     pub tab_separator: bool,
 
-    // display_order value is defined acronym of long option (A=10,B=20,...,Z=260,a=270, b=280...,z=520)
+    // The display_order value is derived from the first letter of the long option name
+    // (A=10, B=20, ..., Z=260, a=270, b=280, ..., z=520).
     /// Add GeoIP (ASN, city, country) info to IP addresses
     #[arg(
         help_heading = Some("Output"),
@@ -2086,6 +2110,7 @@ impl ConfigReader {
     }
 }
 
+/// A set of event IDs (target_event_IDs.txt) or rule IDs (proven_rules.txt) used as a filter.
 #[derive(Debug, Clone)]
 pub struct TargetIds {
     ids: HashSet<String>,
@@ -2105,7 +2130,8 @@ impl TargetIds {
     }
 
     pub fn is_target(&self, id: &str, flag_in_case_empty: bool) -> bool {
-        // If the content is empty: for EventId, target all EventIds. For RuleId, treat all RuleIds as not subject to filtering.
+        // An empty set means the filter is disabled, so return the caller-supplied default:
+        // for event IDs every event ID is targeted, and for rule IDs no rule is filtered out.
         if self.ids.is_empty() {
             return flag_in_case_empty;
         }
@@ -2118,7 +2144,8 @@ fn load_target_ids(path: &str) -> TargetIds {
     let lines = match utils::read_txt(path) {
         Ok(lines) => lines,
         Err(e) => {
-            // Treat it as an error if the file does not exist.
+            // A missing file is treated as an error: report it and return an empty
+            // (disabled) filter.
             AlertMessage::alert(&e).ok();
             return ret;
         }
@@ -2134,6 +2161,8 @@ fn load_target_ids(path: &str) -> TargetIds {
     ret
 }
 
+/// Event timestamp filter built from --timeline-start / --timeline-end / --time-offset.
+/// Events outside the [start_time, end_time] range are excluded from the scan.
 #[derive(Debug, Clone)]
 pub struct TargetEventTime {
     parse_success_flag: bool,
@@ -2143,6 +2172,8 @@ pub struct TargetEventTime {
 
 impl TargetEventTime {
     pub fn new(stored_static: &StoredStatic) -> Self {
+        // Parses an absolute timestamp into UTC; on failure, prints error_contents and clears
+        // parse_success_flag.
         let get_time =
             |input_time: Option<&String>, error_contents: &str, parse_success_flag: &mut bool| {
                 if let Some(time) = input_time {
@@ -2162,12 +2193,18 @@ impl TargetEventTime {
                 }
             };
 
+        // Converts a relative offset such as "1y3M30d24h30m10s" into an absolute start time
+        // (now minus the offset), returned as a "%Y-%m-%d %H:%M:%S %z" string for get_time.
         let get_time_offset = |time_offset: &Option<String>, parse_success_flag: &mut bool| {
-            if let Some(timeline_offline) = time_offset {
+            if let Some(timeline_offset) = time_offset {
+                // Supported unit suffixes; note that 'M' is months while 'm' is minutes.
                 let timekey = ['y', 'M', 'd', 'h', 'm', 's'];
                 let mut time_num = [0, 0, 0, 0, 0, 0];
                 for (idx, key) in timekey.iter().enumerate() {
-                    let mut timekey_splitter = timeline_offline.split(*key);
+                    // Extract the digits belonging to this unit: take the text before the unit
+                    // character and strip everything up to the last other unit character
+                    // (e.g. for 'M' in "1y3M": "1y3" -> "3").
+                    let mut timekey_splitter = timeline_offset.split(*key);
                     let mix_check = timekey_splitter.next();
                     let mixed_checker: Vec<&str> =
                         mix_check.unwrap_or_default().split(timekey).collect();
@@ -2198,6 +2235,7 @@ impl TargetEventTime {
                     *parse_success_flag = false;
                     return None;
                 }
+                // Subtract each component from the current time; years are folded into months.
                 let target_start_time = Local::now()
                     .checked_sub_months(Months::new(time_num[0] * 12))
                     .and_then(|dt| dt.checked_sub_months(Months::new(time_num[1])))
@@ -2374,6 +2412,7 @@ impl TargetEventTime {
     }
 
     pub fn is_target(&self, eventtime: &Option<DateTime<Utc>>) -> bool {
+        // Records without a timestamp are never filtered out.
         if eventtime.is_none() {
             return true;
         }
@@ -2391,9 +2430,15 @@ impl TargetEventTime {
     }
 }
 
+/// Lookup table built from eventkey_alias.txt that maps the short field aliases used in rules
+/// and config files (e.g. "Computer") to the full dot-separated JSON path of the event record
+/// (e.g. "Event.System.Computer").
 #[derive(Debug, Clone)]
 pub struct EventKeyAliasConfig {
+    // alias -> full event key (e.g. "Computer" -> "Event.System.Computer")
     key_to_eventkey: HashMap<String, String>,
+    // alias -> length of each dot-separated segment of the event key, so that callers can slice
+    // the key string without re-splitting it (see utils::get_event_value)
     key_to_split_eventkey: HashMap<String, Vec<usize>>,
 }
 
@@ -2423,7 +2468,7 @@ impl Default for EventKeyAliasConfig {
 pub fn load_eventkey_alias(path: &str) -> EventKeyAliasConfig {
     let mut config = EventKeyAliasConfig::new();
 
-    // Terminate with an error if eventkey_alias cannot be loaded.
+    // If eventkey_alias.txt cannot be read, report an error and return an empty config.
     let read_result = utils::read_csv(path);
     if let Err(e) = read_result {
         AlertMessage::alert(&e).ok();
@@ -2454,7 +2499,8 @@ pub fn load_eventkey_alias(path: &str) -> EventKeyAliasConfig {
     config
 }
 
-/// Load the config file and load the map of keys and fields into the PIVOT_KEYWORD global variable.
+/// Loads the pivot keyword config file and registers each "keyword.field" line into the
+/// PIVOT_KEYWORD global map.
 pub fn load_pivot_keywords(path: &str) {
     let read_result = match utils::read_txt(path) {
         Ok(v) => v,
@@ -2476,7 +2522,7 @@ pub fn load_pivot_keywords(path: &str) {
         let key = map.next().unwrap();
         let value = map.next().unwrap();
 
-        // If it does not exist, create the key.
+        // Create an empty entry for this keyword if it is not registered yet.
         PIVOT_KEYWORD
             .write()
             .unwrap()
@@ -2493,7 +2539,8 @@ pub fn load_pivot_keywords(path: &str) {
     });
 }
 
-/// Function to return the set of file extensions to investigate, from the extensions added by --target-file-ext. If --json-input is true, only json is targeted.
+/// Returns the set of file extensions to scan: the extra extensions added with
+/// --target-file-ext plus the default extension (evtx, or json/jsonl when --JSON-input is set).
 pub fn get_target_extensions(arg: Option<&Vec<String>>, json_input_flag: bool) -> HashSet<String> {
     let mut target_file_extensions: HashSet<String> = convert_option_vecs_to_hs(arg);
     if json_input_flag {
@@ -2511,6 +2558,7 @@ pub fn convert_option_vecs_to_hs(arg: Option<&Vec<String>>) -> HashSet<String> {
     ret
 }
 
+/// Returns a copy of the search options when the search subcommand was invoked, None otherwise.
 fn extract_search_options(config: &Config) -> Option<SearchOption> {
     match &config.action.as_ref()? {
         Action::Search(option) => Some(SearchOption {
@@ -2544,6 +2592,8 @@ fn extract_search_options(config: &Config) -> Option<SearchOption> {
 }
 
 /// Function to extract a struct containing option values related to output from the config.
+/// For actions other than csv-timeline/json-timeline, an equivalent OutputOption is synthesized
+/// from the action's own options so that downstream code can handle every action uniformly.
 fn extract_output_options(config: &Config) -> Option<OutputOption> {
     match &config.action.as_ref()? {
         Action::CsvTimeline(option) => Some(option.output_options.clone()),
@@ -2684,6 +2734,7 @@ fn extract_output_options(config: &Config) -> Option<OutputOption> {
     }
 }
 
+/// Human-readable title of an event (defaults to "Unknown").
 #[derive(Debug, Clone)]
 pub struct EventInfo {
     pub evttitle: String,
@@ -2701,6 +2752,7 @@ impl EventInfo {
         EventInfo { evttitle }
     }
 }
+/// Lookup of (channel (lowercased), event id) -> event title, loaded from channel_eid_info.txt.
 #[derive(Debug, Clone)]
 pub struct EventInfoConfig {
     eventinfo: HashMap<(String, String), EventInfo>,
@@ -2727,6 +2779,7 @@ impl EventInfoConfig {
 fn load_eventcode_info(path: &str) -> EventInfoConfig {
     let mut infodata = EventInfo::new();
     let mut config = EventInfoConfig::new();
+    // If channel_eid_info.txt cannot be read, report an error and return an empty config.
     let read_result = match utils::read_csv(path) {
         Ok(v) => v,
         Err(e) => {
@@ -2735,7 +2788,7 @@ fn load_eventcode_info(path: &str) -> EventInfoConfig {
         }
     };
 
-    // Terminate with an error if channel_eid_info.txt cannot be loaded.
+    // Each line is expected to contain: channel, event ID, event title.
     read_result.iter().for_each(|line| {
         if line.len() != 3 {
             return;
@@ -2756,7 +2809,9 @@ fn load_eventcode_info(path: &str) -> EventInfoConfig {
     config
 }
 
-fn create_control_chat_replace_map() -> HashMap<char, CompactString> {
+/// Builds a map from each ASCII control character (except line feed) to its JSON-style
+/// uppercase escape sequence (`\u0000` through `\u001F`).
+fn create_control_char_replace_map() -> HashMap<char, CompactString> {
     let mut ret = HashMap::new();
     let replace_char = '\0'..='\x1F';
     for c in replace_char.into_iter().filter(|x| x != &'\x0A') {
@@ -2771,6 +2826,9 @@ fn create_control_chat_replace_map() -> HashMap<char, CompactString> {
     ret
 }
 
+/// Loads the dash variant characters recognized by the Sigma "windash" modifier. The all-in-one
+/// config bundle takes precedence; otherwise the given file is read, and if it cannot be opened
+/// a built-in default set is used.
 pub fn load_windash_characters(file_path: &str) -> Vec<char> {
     if let Some(contents) = ONE_CONFIG_MAP.get("windash_characters.txt") {
         return contents
@@ -2796,6 +2854,8 @@ pub fn load_windash_characters(file_path: &str) -> Vec<char> {
     }
 }
 
+/// Loads windows_versions.csv into a map of (OS version, build number) -> (Windows product
+/// name, release date), used to resolve Windows OS names in computer-metrics.
 pub fn load_win_versions() -> HashMap<(String, String), (String, String)> {
     fn parse_csv<R: std::io::Read>(reader: R) -> HashMap<(String, String), (String, String)> {
         let mut map = HashMap::new();
@@ -2826,7 +2886,7 @@ mod tests {
     use super::{
         Action, CommonOptions, Config, CsvOutputOption, DetectCommonOption, InputOption,
         JSONOutputOption, OutputOption, StoredStatic, TargetEventTime,
-        create_control_chat_replace_map,
+        create_control_char_replace_map,
     };
     use crate::detections::configs::{
         self, EidMetricsOption, LogonSummaryOption, PivotKeywordOption, SearchOption,
@@ -2851,11 +2911,12 @@ mod tests {
     }
 
     #[test]
-    fn target_event_time_filter_containes_on_time() {
+    fn target_event_time_filter_contains_on_time() {
         let start_time = Some("2018-02-20T12:00:09Z".parse::<DateTime<Utc>>().unwrap());
         let end_time = Some("2020-03-30T12:00:09Z".parse::<DateTime<Utc>>().unwrap());
         let time_filter = TargetEventTime::set(true, start_time, end_time);
 
+        // Timestamps exactly on the start/end boundary must be treated as in range.
         assert!(time_filter.is_target(&start_time));
         assert!(time_filter.is_target(&end_time));
     }
@@ -2895,7 +2956,7 @@ mod tests {
                 )
             }));
         expect.remove(&'\x0A');
-        let actual = create_control_chat_replace_map();
+        let actual = create_control_char_replace_map();
         assert_eq!(expect, actual);
     }
 

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -44,7 +44,7 @@ use super::configs::{
 };
 use super::message::{self, COMPUTER_MITRE_ATTCK_MAP, COMPUTER_MITRE_ATTCK_UNIQUE_KEYS};
 
-// Struct to hold information for one record of an event file.
+/// Struct to hold information for one record of an event file.
 #[derive(Clone, Debug)]
 pub struct EvtxRecordInfo {
     pub evtx_filepath: String, // File path of the event file, used when outputting logs.
@@ -60,6 +60,7 @@ impl EvtxRecordInfo {
     }
 }
 
+/// Holds all loaded detection rules and runs them against event records.
 #[derive(Debug)]
 pub struct Detection {
     rules: Vec<RuleNode>,
@@ -74,7 +75,8 @@ impl Detection {
         rt.block_on(self.execute_rules(records))
     }
 
-    // Parse the rule files.
+    /// Parses the rule files under the given path and returns the successfully initialized rules,
+    /// after applying the level/status/ID filters and resolving correlation rules.
     pub fn parse_rule_files(
         min_level: &str,
         target_level: &str,
@@ -138,7 +140,8 @@ impl Detection {
             });
             None
         };
-        // parse rule files
+        // Create a RuleNode from each loaded YAML document and keep only the rules that
+        // initialize successfully.
         let mut ret = rulefile_loader
             .files
             .clone()
@@ -158,10 +161,10 @@ impl Detection {
         ret
     }
 
-    // Execute multiple rules against multiple event records, one rule at a time.
+    // Execute all rules against all event records; each rule runs in its own async task.
     async fn execute_rules(mut self, records: Vec<EvtxRecordInfo>) -> (Self, Vec<DetectInfo>) {
         let records_arc = Arc::new(records);
-        // // Create a thread for each rule and start the threads.
+        // Spawn an async task for each rule and start executing them.
         let rules = self.rules;
         let handles: Vec<JoinHandle<(RuleNode, Vec<DetectInfo>)>> = rules
             .into_iter()
@@ -171,7 +174,7 @@ impl Detection {
             })
             .collect();
 
-        // Wait for all threads to complete execution.
+        // Wait for all tasks to complete execution.
         let mut rules = vec![];
         let mut all_log_records = vec![];
         for handle in handles {
@@ -182,15 +185,19 @@ impl Detection {
             }
         }
 
-        // rules.into_iter() is called at the top of this function, which transfers ownership through the rule in map to the rule passed as an argument to execute_rule, so self.rules no longer has ownership.
-        // Writing code that returns an object with a member variable that has lost ownership causes a compiler error (compile error E0382), so ownership is returned to self.rules here.
-        // To allow self.rules to regain ownership, Detection::execute_rule returns the rule passed as an argument as the return value.
+        // rules.into_iter() at the top of this function moved every rule out of self.rules and
+        // into execute_rule(), so self.rules no longer has ownership. Returning an object whose
+        // member variable has been moved out of is a compile error (E0382), so ownership is given
+        // back to self.rules here. This is why Detection::execute_rule returns the rule it
+        // received as an argument.
         self.rules = rules;
 
         (self, all_log_records)
     }
 
-    pub fn add_aggcondition_msges(
+    /// Creates the detection messages for rules with an aggregation condition
+    /// (count() rules and correlation rules). Must run after all records have been processed.
+    pub fn add_aggcondition_msgs(
         self,
         rt: &Runtime,
         stored_static: &StoredStatic,
@@ -198,6 +205,11 @@ impl Detection {
         rt.block_on(self.add_aggcondition_msg(stored_static))
     }
 
+    /// Evaluates a Sigma temporal correlation: for each aggregation result of the first
+    /// referenced rule (`ids[0]`), checks that every other referenced rule also produced a
+    /// result within `timeframe`. When `temporal_ordered` is true the other results must occur
+    /// at or after the base result; otherwise anywhere within +/- `timeframe` of the base result
+    /// counts. Returns the base results for which all referenced rules matched.
     fn detect_within_timeframe(
         ids: &[String],
         temporal_ref_all_results: &HashMap<String, Vec<AggResult>>,
@@ -243,6 +255,9 @@ impl Detection {
     async fn add_aggcondition_msg(&self, stored_static: &StoredStatic) -> Vec<DetectInfo> {
         let mut ret = vec![];
         let mut detected_temporal_refs: HashMap<String, Vec<AggResult>> = HashMap::new();
+        // First pass: evaluate each rule's aggregation condition. Results of rules referenced by
+        // a temporal correlation rule are stashed in detected_temporal_refs and are only output
+        // directly when the referenced rule has generate: true.
         for rule in &self.rules {
             if !rule.has_agg_condition() {
                 continue;
@@ -261,7 +276,8 @@ impl Detection {
                 }
             }
         }
-        // Temporal rules can only be evaluated after all individual rule evaluations are complete, so loop through rules again to evaluate temporal rules.
+        // Temporal correlation rules can only be evaluated after all individual rule evaluations
+        // are complete, so loop through the rules again to evaluate them.
         for rule in self.rules.iter() {
             let (ref_ids, temporal_ordered) = match &rule.correlation_type {
                 CorrelationType::Temporal(ref_ids) => (ref_ids, false),
@@ -321,7 +337,9 @@ impl Detection {
                 continue;
             }
 
-            // If no aggregation condition exists, proceed with output as-is.
+            // If the rule has no aggregation condition, output the detection as-is. Rules with an
+            // aggregation condition count matches inside rule.select() and their messages are
+            // created later by add_aggcondition_msg().
             if !agg_condition {
                 ret.push(Detection::create_log_record(
                     &rule,
@@ -334,7 +352,9 @@ impl Detection {
         (rule, ret)
     }
 
-    /// create log record
+    /// Creates a DetectInfo detection message for a single record that matched a rule, filling in
+    /// every column requested by the output profile (timestamp, channel, level, MITRE tags,
+    /// GeoIP data, etc.).
     fn create_log_record(
         rule: &RuleNode,
         record_info: &EvtxRecordInfo,
@@ -659,7 +679,7 @@ impl Detection {
                     if profile_converter.contains_key(key.as_str()) {
                         continue;
                     }
-                    // initialize GeoIP Tgt associated fields
+                    // Initialize the GeoIP Tgt-related fields.
                     profile_converter.insert("TgtASN", TgtASN("".into()));
                     profile_converter.insert("TgtCountry", TgtCountry("".into()));
                     profile_converter.insert("TgtCity", TgtCity("".into()));
@@ -731,7 +751,7 @@ impl Detection {
                     if profile_converter.contains_key(key.as_str()) {
                         continue;
                     }
-                    // initialize GeoIP Tgt associated fields
+                    // Initialize the GeoIP Src-related fields.
                     profile_converter.insert("SrcASN", SrcASN("".into()));
                     profile_converter.insert("SrcCountry", SrcCountry("".into()));
                     profile_converter.insert("SrcCity", SrcCity("".into()));
@@ -813,7 +833,9 @@ impl Detection {
                 event_id: eid.clone(),
             }
         };
-        // If the rule has a details entry, output it as-is; otherwise output the details entry configured for the provider and eventid combination.
+        // If the rule has a details entry, output it as-is. Otherwise fall back to the default
+        // details configured for this provider and event ID combination, and if none exists,
+        // output all of the record's field data.
         let details_fmt_str = match rule.yaml["details"].as_str() {
             Some(s) => s.to_string(),
             None => match stored_static
@@ -859,6 +881,9 @@ impl Detection {
         )
     }
 
+    /// Creates a DetectInfo detection message for one aggregation condition (count/correlation)
+    /// result. Record-specific profile columns are filled with "-" or with deduplicated joined
+    /// values taken from all of the records that contributed to the aggregation.
     fn create_agg_log_record(
         rule: &RuleNode,
         agg_result: AggResult,
@@ -1128,6 +1153,8 @@ impl Detection {
         )
     }
 
+    /// Extracts a value from each aggregated record, removes duplicates, and joins the sorted
+    /// values with " ¦ ".
     fn join_agg_values<F>(
         agg_record_time_infos: &[AggRecordTimeInfo],
         extractor: F,
@@ -1164,13 +1191,14 @@ impl Detection {
     /// Function that returns the detection output string for the count portion of the aggregation condition.
     fn create_count_output(rule: &RuleNode, agg_result: &AggResult) -> CompactString {
         let mut ret: String = "".to_string();
-        // Since it is assumed that the aggregation condition already exists when this function is called, the length of the agg_condition array is 2.
+        // This function is only called for rules that have an aggregation condition, so the
+        // unwrap() here is safe.
         let agg_condition = rule.get_agg_condition().unwrap();
         write!(ret, "Count:{}", agg_result.data).ok();
-        let mut sorted_filed_values = agg_result.field_values.clone();
-        sorted_filed_values.sort();
+        let mut sorted_field_values = agg_result.field_values.clone();
+        sorted_field_values.sort();
         if let Some(_field_name) = agg_condition._field_name.as_ref() {
-            write!(ret, " ¦ {}:{}", _field_name, sorted_filed_values.join("/")).ok();
+            write!(ret, " ¦ {}:{}", _field_name, sorted_field_values.join("/")).ok();
         }
 
         if let Some(_by_field_name) = agg_condition._by_field_name.as_ref() {
@@ -1190,6 +1218,9 @@ impl Detection {
         CompactString::from(ret)
     }
 
+    /// Pairs the comma-separated field names in `s1` with the comma-separated values in `s2` and
+    /// joins the resulting "name:value" pairs with " ¦ " (used for `count() by fieldA,fieldB`
+    /// output).
     fn zip_and_concat_strings(s1: &str, s2: &str) -> String {
         let v1: Vec<&str> = s1.split(',').collect();
         let v2: Vec<&str> = s2.split(',').collect();
@@ -1200,6 +1231,9 @@ impl Detection {
             .join(" ¦ ")
     }
 
+    /// Prints the rule loading summary to stdout (rule counts by category, status,
+    /// correlation/expand rules and the total) and accumulates the same lines for the HTML
+    /// report (except the expand-rule lines, which are printed to stdout only).
     pub fn print_rule_load_info(
         parse_yaml: &ParseYaml,
         err_rc: &u128,
@@ -1496,7 +1530,8 @@ impl Detection {
         }
     }
 
-    /// Retrieve the value of a given alias in a record.
+    /// Retrieves the value of the first alias that resolves in the record, or "-" when none of
+    /// the given aliases yield a value.
     fn get_alias_data(
         target_alias: Vec<&str>,
         record: &Value,
@@ -1607,7 +1642,7 @@ mod tests {
     }
 
     #[test]
-    fn test_output_aggregation_output_no_filed_by() {
+    fn test_output_aggregation_output_no_field_by() {
         let default_time = Utc.with_ymd_and_hms(1977, 1, 1, 0, 0, 0).unwrap();
         let agg_result: AggResult =
             AggResult::new(2, "_".to_string(), vec![], default_time, vec![]);

--- a/src/detections/field_data_map.rs
+++ b/src/detections/field_data_map.rs
@@ -11,15 +11,24 @@ use std::path::Path;
 use std::string::String;
 use yaml_rust2::{Yaml, YamlLoader};
 
+/// All field data conversion rules loaded from the data_mapping config files, keyed by the
+/// (channel, event ID) pair each rule set applies to.
 pub type FieldDataMap = HashMap<FieldDataMapKey, FieldDataMapEntry>;
+/// Conversion rules for one event type: lowercase field name -> converter for that field's value.
 pub type FieldDataMapEntry = HashMap<String, FieldDataConverter>;
 
+/// How a raw field value should be rewritten into a more readable form.
 #[derive(Debug, Clone)]
 pub enum FieldDataConverter {
+    /// Converts a hex string such as "0x44c" into its decimal representation.
     HexToDecimal,
+    /// Replaces substrings via an Aho-Corasick automaton whose patterns pair up with the Vec of
+    /// replacement strings (same index = same rule). The HashSet limits the rewrite to events
+    /// whose provider name is in the set; an empty set means any provider.
     ReplaceStr((AhoCorasick, Vec<String>), HashSet<String>),
 }
 
+/// Identifies the event type a mapping applies to: lowercase channel name plus event ID.
 #[derive(Debug, Eq, Hash, PartialEq, Default, Clone)]
 pub struct FieldDataMapKey {
     pub channel: CompactString,
@@ -27,6 +36,7 @@ pub struct FieldDataMapKey {
 }
 
 impl FieldDataMapKey {
+    /// Builds a key from the Channel and EventID values of a data_mapping YAML document.
     fn new(yaml_data: Yaml) -> FieldDataMapKey {
         FieldDataMapKey {
             channel: CompactString::from(
@@ -45,8 +55,13 @@ impl FieldDataMapKey {
     }
 }
 
+/// Parses one data_mapping YAML document (see rules/config/data_mapping/*.yaml) into the event
+/// type key it applies to and the per-field converters it defines. Returns default (empty) values
+/// when the document defines neither RewriteFieldData nor HexToDecimal.
 fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry) {
     let rewrite_field_data = yaml_data["RewriteFieldData"].as_hash();
+    // HexToDecimal may be given as a single scalar or as a list of field names; normalize both
+    // forms into a list of YAML values.
     let hex2decimal = if let Some(s) = yaml_data["HexToDecimal"].as_str() {
         Some(YamlLoader::load_from_str(s).unwrap_or_default())
     } else {
@@ -55,6 +70,8 @@ fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry)
     if rewrite_field_data.is_none() && hex2decimal.is_none() {
         return (FieldDataMapKey::default(), FieldDataMapEntry::default());
     }
+    // Provider_Name is optional and may be a single name or a list. When present, the string
+    // rewrites only apply to events emitted by one of these providers.
     let mut providers = HashSet::new();
     if let Some(providers_yaml) = yaml_data["Provider_Name"].as_vec() {
         for provider in providers_yaml {
@@ -71,6 +88,8 @@ fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry)
             if field.is_empty() || replace_values.is_none() {
                 continue;
             }
+            // Each list element is a one-entry hash of pattern -> replacement. Collect them as
+            // parallel vectors, which is the form AhoCorasick's replace_all expects.
             let mut ptns = vec![];
             let mut reps = vec![];
             for rep_val in replace_values.unwrap() {
@@ -104,6 +123,11 @@ fn build_field_data_map(yaml_data: Yaml) -> (FieldDataMapKey, FieldDataMapEntry)
     (FieldDataMapKey::new(yaml_data), mapping)
 }
 
+/// Rewrites a field value according to the loaded data_mapping rules. Returns None when no
+/// mapping exists for the (channel, event ID) key or for the field (lowercase), in which case the
+/// caller should keep the original value. When a mapping exists but does not change the value
+/// (e.g. the provider does not match, or the value is not a valid hex string), the original
+/// string is returned wrapped in Some.
 pub fn convert_field_data(
     data_map: &FieldDataMap,
     data_map_key: &FieldDataMapKey,
@@ -116,6 +140,8 @@ pub fn convert_field_data(
         Some(data_map_entry) => match data_map_entry.get(field) {
             None => None,
             Some(ReplaceStr(x, providers)) => {
+                // A provider restriction is defined: pass the value through unchanged when this
+                // record's provider is not in the set.
                 if !providers.is_empty() {
                     let provider = get_serde_number_to_string(
                         &record["Event"]["System"]["Provider_attributes"]["Name"],
@@ -131,6 +157,8 @@ pub fn convert_field_data(
                 let _ = ac.try_stream_replace_all(field_data_str.as_bytes(), &mut wtr, rep);
                 Some(CompactString::from(std::str::from_utf8(&wtr).unwrap()))
             }
+            // Only values with a 0x/0X prefix that parse as u64 are converted; anything else is
+            // passed through unchanged.
             Some(HexToDecimal) => match field_data_str
                 .strip_prefix("0x")
                 .or_else(|| field_data_str.strip_prefix("0X"))
@@ -145,6 +173,7 @@ pub fn convert_field_data(
     }
 }
 
+/// Loads every YAML document from the .yaml files directly under the given directory.
 fn load_yaml_files(dir_path: &Path) -> Result<Vec<Yaml>, String> {
     let path = dir_path.as_os_str().to_str().unwrap_or_default();
     if !dir_path.exists() || !dir_path.is_dir() {
@@ -162,6 +191,9 @@ fn load_yaml_files(dir_path: &Path) -> Result<Vec<Yaml>, String> {
             .collect()),
         Err(e) => {
             let mut msg = format!("Failed to open field mapping dir[{path}]. ",);
+            // Windows OS error 123 (ERROR_INVALID_NAME): invalid path syntax. This typically
+            // happens when a quoted path ends with a backslash, which escapes the closing quote
+            // and mangles the command-line argument.
             if e.to_string().ends_with("123)") {
                 msg = format!(
                     "{msg}. You may not be able to load evtx files when there are spaces in the directory path. Please enclose the path with double quotes and remove any trailing slash at the end of the path."
@@ -173,7 +205,12 @@ fn load_yaml_files(dir_path: &Path) -> Result<Vec<Yaml>, String> {
     }
 }
 
+/// Builds the whole field data map, either from the all-in-one config bundle (when present) or
+/// from the .yaml files in the given data_mapping directory. Returns None when the directory
+/// cannot be read.
 pub fn create_field_data_map(dir_path: &Path) -> Option<FieldDataMap> {
+    // In the all-in-one config bundle, every embedded .yaml file except the GeoIP field mapping
+    // is assumed to be a data_mapping file.
     let one_config_values: Vec<String> = ONE_CONFIG_MAP
         .iter()
         .filter(|(key, _)| key.contains(".yaml") && !key.contains("geoip_field_mapping.yaml"))

--- a/src/detections/field_extract.rs
+++ b/src/detections/field_extract.rs
@@ -1,6 +1,12 @@
 use hashbrown::HashMap;
 use serde_json::Value;
 
+/// Extracts extra fields from classic PowerShell events (channel "Windows PowerShell", event IDs
+/// 400/403/600/800). These events pack most of their useful information into one element of the
+/// EventData "Data" array as "Key=Value" lines, which rules cannot reference as fields. This
+/// parses that element and inserts each pair as a regular field of the record. Event ID 800
+/// stores the pairs in the second Data element (array index 1); the other event IDs store them
+/// in the third element (array index 2).
 pub fn extract_fields(
     channel: Option<String>,
     event_id: Option<String>,
@@ -17,6 +23,11 @@ pub fn extract_fields(
     }
 }
 
+/// Recursively searches `data` for an array node (the EventData "Data" array), parses its
+/// `data_index` element as "Key=Value" lines, and inserts the parsed pairs into the object that
+/// directly contains the array (i.e. as siblings of "Data" inside EventData), also recording the
+/// string values in `key_2_values`. The Some return value is only used internally to hand the
+/// parsed fields up one level to the containing object; the outermost call always returns None.
 fn extract_powershell_classic_fields(
     data: &mut Value,
     data_index: usize,
@@ -31,6 +42,8 @@ fn extract_powershell_classic_fields(
                     break;
                 }
             }
+            // A direct child array yielded fields: merge them into this object so they sit
+            // alongside the original "Data" array.
             if let Some(Value::Object(fields)) = extracted_fields {
                 for (key, val) in fields {
                     map.insert(key.clone(), val.clone());
@@ -44,6 +57,8 @@ fn extract_powershell_classic_fields(
             if let Some(val) = vec.get(data_index)
                 && let Some(powershell_data_str) = val.as_str()
             {
+                // Each "Key=Value" pair sits on its own line separated by "\n\t"; trailing
+                // CR/CRLF is trimmed and lines without '=' are ignored.
                 let fields_data: std::collections::HashMap<&str, &str> = powershell_data_str
                     .trim()
                     .split("\n\t")

--- a/src/detections/message.rs
+++ b/src/detections/message.rs
@@ -27,9 +27,8 @@ use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use std::sync::Mutex;
 use termcolor::{BufferWriter, Color, ColorChoice};
-/*
- * This struct express log record
-*/
+/// Represents a single detection result: metadata of the matched rule, key values taken from the
+/// matched event record (or aggregation result), and the output profile fields to render.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DetectInfo {
     pub detected_time: DateTime<Utc>,
@@ -41,24 +40,38 @@ pub struct DetectInfo {
     pub computername: CompactString,
     pub rec_id: CompactString,
     pub eventid: CompactString,
+    // The rendered Details text. create_message() moves it into ext_field and clears it afterwards
+    // to save memory.
     pub detail: CompactString,
+    // Output profile columns as (column name, value) pairs.
     pub ext_field: Vec<(CompactString, Profile)>,
+    // Set only when the detection comes from an aggregation (count/correlation) rule.
     pub agg_result: Option<AggResult>,
+    // Per-field values keyed by "#Details" / "#AllFieldInfo" / "#ExtraFieldInfo", used by the JSON
+    // output writers to expand those profile fields themselves.
     pub details_convert_map: HashMap<CompactString, Vec<CompactString>>,
 }
 
+/// Namespace for console error/warning output and for writing the error log file.
 pub struct AlertMessage {}
 
+// Embedded fallback copy of config/mitre_tactics.txt, used when the file cannot be read from disk.
 #[derive(Embed)]
 #[folder = "config"]
 #[include = "mitre_tactics.txt"]
 struct Mitretactics;
 
 lazy_static! {
+    // Matches a %EventKeyAlias% placeholder in details/profile templates, e.g. %CommandLine%.
     #[derive(Debug,PartialEq, Eq, Ord, PartialOrd)]
     pub static ref ALIASREGEX: Regex = Regex::new(r"%[a-zA-Z0-9-_\[\]]+%").unwrap();
+    // Matches the 1-based array index suffix in aliases such as %Data[1]%.
     pub static ref SUFFIXREGEX: Regex = Regex::new(r"\[([0-9]+)\]").unwrap();
+    // Errors collected while a run is in progress; flushed to ./logs/errorlog-<timestamp>.log by
+    // AlertMessage::create_error_log().
     pub static ref ERROR_LOG_STACK: Mutex<Nested<String>> = Mutex::new(Nested::<String>::new());
+    // Maps a MITRE tag (e.g. "attack.impact") to its display name (e.g. "Impact"), loaded from
+    // config/mitre_tactics.txt.
     pub static ref TAGS_CONFIG: HashMap<CompactString, CompactString> = create_output_filter_config(
         utils::check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), "config/mitre_tactics.txt", true)
             .unwrap().to_str()
@@ -66,12 +79,18 @@ lazy_static! {
         true,
         false
     );
+    // Per-computer MITRE ATT&CK tactic counts as (tactic, unique detection count, total detection
+    // count) tuples, collected for the HTML report.
     pub static ref COMPUTER_MITRE_ATTCK_MAP : DashMap<CompactString, Vec<(CompactString, i64, i64)>> = DashMap::new();
+    // "computer|tactic|rulepath" keys that have already been seen, so each rule increments the
+    // unique count in COMPUTER_MITRE_ATTCK_MAP only once per computer and tactic.
     pub static ref COMPUTER_MITRE_ATTCK_UNIQUE_KEYS : DashSet<CompactString> = DashSet::new();
 }
 
-/// Function to create a HashMap of full names for tags described by file paths and the strings to be replaced during display.
-/// ex. attack.impact,Impact
+/// Creates a HashMap from a CSV config file (e.g. mitre_tactics.txt or channel_abbreviations.txt)
+/// that maps a full name to the abbreviated string shown in its place in the output.
+/// e.g. the line "attack.impact,Impact" maps "attack.impact" to "Impact".
+/// Returns an empty map when `disable_abbreviation` is set, so that no abbreviation takes place.
 pub fn create_output_filter_config(
     path: &str,
     is_lower_case: bool,
@@ -84,6 +103,8 @@ pub fn create_output_filter_config(
     let read_result = match utils::read_csv(path) {
         Ok(c) => c,
         Err(e) => {
+            // Fall back to the embedded copy of mitre_tactics.txt when the file on disk cannot be
+            // read.
             if path.contains("mitre_tactics.txt") {
                 let mitre_tactics = Mitretactics::get("mitre_tactics.txt").unwrap();
                 utils::parse_csv(
@@ -109,6 +130,13 @@ pub fn create_output_filter_config(
     ret
 }
 
+/// Builds the final per-detection output by filling in each profile field of
+/// `detect_info.ext_field`: the Details template (`output`) and the other %alias% placeholders are
+/// replaced with values from the event record, AllFieldInfo is generated from all of the record's
+/// fields, and ExtraFieldInfo receives the record fields whose values do not already appear in
+/// Details. For the JSON timeline, per-field values are additionally stored in
+/// `details_convert_map` ("#Details" / "#AllFieldInfo" / "#ExtraFieldInfo") because the JSON
+/// writers expand those fields themselves.
 pub fn create_message(
     event_record: &Value,
     output: CompactString,
@@ -124,7 +152,8 @@ pub fn create_message(
     let mut record_details_info_map = HashMap::new();
     let mut sp_removed_details_in_record = vec![];
     if !is_agg {
-        // At this stage, get the map containing the content with aliases replaced in details and various key-value combinations.
+        // At this stage, obtain the details text with its %alias% placeholders replaced by record
+        // values, along with the individual key/value pairs that make up the details.
         let (removed_sp_parsed_detail, mut details_in_record) = parse_message(
             event_record,
             &output,
@@ -139,8 +168,9 @@ pub fn create_message(
         if is_json_timeline {
             record_details_info_map.insert("#Details".into(), sp_removed_details_in_record.clone());
         }
-        // retain processing to exclude special characters.
-        // To avoid excluding newline characters within Details, convert them to special characters including emoji.
+        // remove_sp_char() strips special (control) characters via retain(). So that the newline
+        // characters inside Details survive this, they are first converted to special placeholder
+        // sequences that include an emoji (e.g. "🛂n").
         let parsed_detail = remove_sp_char(removed_sp_parsed_detail);
         detect_info.detail = if parsed_detail.is_empty() {
             CompactString::from("-")
@@ -166,7 +196,8 @@ pub fn create_message(
                     replaced_profiles
                         .push((key.to_owned(), Details(detect_info.detail.clone().into())));
 
-                    // Empty the Details content to save memory.
+                    // Clear the Details content to save memory; the value now lives in
+                    // replaced_profiles.
                     detect_info.detail = CompactString::default();
                 }
             }
@@ -217,10 +248,14 @@ pub fn create_message(
                     continue;
                 }
                 let profile_all_field_info_prof = record_details_info_map.get("#AllFieldInfo");
+                // Collect the values already shown in Details so that ExtraFieldInfo only reports
+                // the record fields whose values are not part of Details.
                 let details_splits: HashSet<&str> = {
                     let details = sp_removed_details_in_record.iter().map(|x| {
                         let v = x.split_once(": ").unwrap_or_default().1;
-                        // Remove the trailing comma from the hash set used for matching, because the match determination in ExtraFieldInfo differs depending on whether a trailing comma is present.
+                        // Strip any trailing comma from the values put into the matching hash set;
+                        // otherwise the ExtraFieldInfo match result would differ depending on
+                        // whether or not a value carries a trailing comma.
                         v.strip_suffix(',').unwrap_or(v)
                     });
                     HashSet::from_iter(details)
@@ -286,7 +321,11 @@ pub fn create_message(
     detect_info
 }
 
-/// Function to replace sections enclosed in % in the message by referencing record information as aliases.
+/// Treats each %...% section in `output` as an alias and replaces it with the corresponding value
+/// looked up in the event record (via eventkey_alias.txt, falling back to Event.EventData.<name>).
+/// Returns the replaced message together with the "key: value" pairs that make up the details.
+/// For the JSON timeline the message itself is returned with its placeholders intact, because the
+/// afterfact output functions perform the replacement in that case.
 pub fn parse_message(
     event_record: &Value,
     output: &CompactString,
@@ -308,6 +347,8 @@ pub fn parse_message(
         let array_str = if let Some(_array_str) = eventkey_alias.get_event_key(target_str) {
             _array_str.to_string()
         } else {
+            // No alias definition exists, so fall back to looking the field up directly under
+            // Event.EventData.
             format!("Event.EventData.{target_str}")
         };
 
@@ -319,6 +360,9 @@ pub fn parse_message(
                 field = s;
             }
         }
+        // An alias like %Data[2]% selects a single element of the EventData "Data" array; the
+        // bracketed index is 1-based. A value below 1 skips the element selection, and since the
+        // bracketed name itself does not resolve to a record field, such an alias yields "n/a".
         let suffix_match = SUFFIXREGEX.captures(target_str);
         let suffix: i64 = match suffix_match {
             Some(cap) => cap.get(1).map_or(-1, |a| a.as_str().parse().unwrap_or(-1)),
@@ -357,6 +401,7 @@ pub fn parse_message(
                 }
             }
         } else {
+            // The alias could not be resolved to a value in this record.
             hash_map.push((
                 CompactString::from(full_target_str),
                 ["n/a".into()].to_vec(),
@@ -365,7 +410,8 @@ pub fn parse_message(
     }
     let mut details_key_and_value: Vec<CompactString> = vec![];
     for (k, v) in hash_map.iter() {
-        // For JSON output, the alias replacement processing is handled by the afterfact output functions, so it is not done here.
+        // For JSON output, the alias replacement processing is handled by the afterfact output
+        // functions, so it is not done here.
         if !json_timeline_flag {
             return_message = CompactString::new(return_message.replace(k.as_str(), v[0].as_str()));
         }
@@ -387,6 +433,8 @@ pub fn parse_message(
     (return_message, details_key_and_value)
 }
 
+/// Returns the record's creation time: Event.System.@timestamp for JSON input, or the SystemTime
+/// attribute of Event.System.TimeCreated for evtx input.
 pub fn get_event_time(event_record: &Value, json_input_flag: bool) -> Option<DateTime<Utc>> {
     let system_time = if json_input_flag {
         &event_record["Event"]["System"]["@timestamp"]
@@ -397,7 +445,9 @@ pub fn get_event_time(event_record: &Value, json_input_flag: bool) -> Option<Dat
 }
 
 impl AlertMessage {
-    /// Function that confirms the target directory exists, adds the initial boilerplate, and returns a BufWriter for the file.
+    /// Writes all errors accumulated in ERROR_LOG_STACK to ./logs/errorlog-<timestamp>.log
+    /// (creating the logs directory if needed and recording the command line that was run first),
+    /// then prints a red notice pointing to that file. Does nothing when --quiet-errors is set.
     pub fn create_error_log(quiet_errors_flag: bool, no_color: bool) {
         if quiet_errors_flag {
             return;
@@ -439,7 +489,7 @@ impl AlertMessage {
         write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, "", false).ok();
     }
 
-    /// Function to display an ERROR message.
+    /// Function to display an [ERROR] message on stderr.
     pub fn alert(contents: &str) -> io::Result<()> {
         write_color_buffer(
             &BufferWriter::stderr(ColorChoice::Always),
@@ -449,7 +499,7 @@ impl AlertMessage {
         )
     }
 
-    /// Function to display a WARN message.
+    /// Function to display a [WARN] message on stderr.
     pub fn warn(contents: &str) -> io::Result<()> {
         write_color_buffer(
             &BufferWriter::stderr(ColorChoice::Always),
@@ -486,7 +536,8 @@ mod tests {
     }
 
     #[test]
-    /// Function to verify that the message is parsed using information from the target record for keys specified in output (already set in eventkey_alias.txt).
+    /// Verifies that %alias% keys in output (defined in eventkey_alias.txt) are replaced with the
+    /// corresponding values from the target record.
     fn test_parse_message() {
         let json_str = r#"
         {
@@ -529,6 +580,8 @@ mod tests {
     }
 
     #[test]
+    /// Verifies that a key with no eventkey_alias.txt entry is automatically looked up directly
+    /// under Event.EventData.
     fn test_parse_message_auto_search() {
         let json_str = r#"
         {
@@ -565,7 +618,8 @@ mod tests {
     }
 
     #[test]
-    /// Output test for when the key specified in output is not set in eventkey_alias.txt.
+    /// Output test for when the key specified in output is neither set in eventkey_alias.txt nor
+    /// present in the record: the value becomes "n/a".
     fn test_parse_message_not_exist_key_in_output() {
         let json_str = r#"
         {
@@ -606,7 +660,8 @@ mod tests {
         );
     }
     #[test]
-    /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
+    /// Output test for when the key specified in output is defined in eventkey_alias.txt but the
+    /// target record contains no corresponding value: the value becomes "n/a".
     fn test_parse_message_not_exist_value_in_record() {
         let json_str = r#"
         {
@@ -647,7 +702,8 @@ mod tests {
         );
     }
     #[test]
-    /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
+    /// Output test for an alias that refers to an array field (Data) without an index suffix: the
+    /// whole array is output as-is in its JSON form.
     fn test_parse_message_multiple_no_suffix_in_record() {
         let json_str = r#"
         {
@@ -693,7 +749,8 @@ mod tests {
         );
     }
     #[test]
-    /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
+    /// Output test for an alias with an index suffix (%Data[2]%): the second element of the Data
+    /// array is selected, since the suffix is 1-based.
     fn test_parse_message_multiple_with_suffix_in_record() {
         let json_str = r#"
         {
@@ -739,7 +796,8 @@ mod tests {
         );
     }
     #[test]
-    /// output test when no exist info in target record output and described key-value data in eventkey_alias.txt
+    /// Output test for an alias with an invalid index suffix (%Data[0]%): index suffixes are
+    /// 1-based, so no array element is selected and the value becomes "n/a".
     fn test_parse_message_multiple_no_exist_in_record() {
         let json_str = r#"
         {
@@ -785,7 +843,7 @@ mod tests {
         );
     }
     #[test]
-    /// test of loading output filter config by mitre_tactics.txt
+    /// Loading test for the output filter config in mitre_tactics.txt.
     fn test_load_mitre_tactics_log() {
         let actual =
             create_output_filter_config("test_files/config/mitre_tactics.txt", true, false);
@@ -797,8 +855,8 @@ mod tests {
     }
 
     #[test]
-    /// loading test to channel_abbrevations.txt
-    fn test_load_abbrevations() {
+    /// Loading test for channel_abbreviations.txt.
+    fn test_load_abbreviations() {
         let actual =
             create_output_filter_config("test_files/config/channel_abbreviations.txt", true, false);
         let actual2 =
@@ -812,7 +870,7 @@ mod tests {
     }
 
     #[test]
-    fn _get_default_defails() {
+    fn _get_default_details() {
         let expected: HashMap<CompactString, CompactString> = HashMap::from([
             ("Microsoft-Windows-PowerShell_4104".into(),"%ScriptBlockText%".into()),("Microsoft-Windows-Security-Auditing_4624".into(), "User: %TargetUserName% | Comp: %WorkstationName% | IP Addr: %IpAddress% | LID: %TargetLogonId% | Process: %ProcessName%".into()),
             ("Microsoft-Windows-Sysmon_1".into(), "Cmd: %CommandLine% | Process: %Image% | User: %User% | Parent Cmd: %ParentCommandLine% | LID: %LogonId% | PID: %ProcessId% | PGUID: %ProcessGuid%".into()),
@@ -831,7 +889,8 @@ mod tests {
         _check_hashmap_element(&expected, actual);
     }
 
-    /// check two HashMap element length and value
+    /// Asserts that both HashMaps have the same length and that every expected entry is present in
+    /// `actual` with the same value.
     fn _check_hashmap_element(
         expected: &HashMap<CompactString, CompactString>,
         actual: HashMap<CompactString, CompactString>,

--- a/src/detections/rule/aggregation_parser.rs
+++ b/src/detections/rule/aggregation_parser.rs
@@ -3,7 +3,8 @@ use regex::Regex;
 
 lazy_static! {
     // Define the list of regular expressions used for lexical analysis here.
-    // This is based on the tokendefs of SigmaConditionTokenizer in toos/sigma/parser/condition.py in the Sigma GitHub repository.
+    // This is based on the tokendefs of SigmaConditionTokenizer in tools/sigma/parser/condition.py
+    // in the Sigma GitHub repository.
     pub static ref AGGREGATION_REGEXMAP: Vec<Regex> = vec![
         Regex::new(r"^count\( *\w* *\)").unwrap(), // count expression
         Regex::new(r"^ ").unwrap(),
@@ -15,40 +16,45 @@ lazy_static! {
         Regex::new(r"^>").unwrap(),
         Regex::new(r"^(\s*\w+\s*,)+\s*\w+|^\w+").unwrap(),
     ];
+    // Matches the aggregation part of a condition: everything from the pipe character to the end.
     pub static ref RE_PIPE: Regex = Regex::new(r"\|.*").unwrap();
 }
 
+/// Parsed form of an aggregation condition such as "count(SubjectUserName) by Computer >= 10".
 #[derive(Debug)]
 pub struct AggregationParseInfo {
-    pub _field_name: Option<String>, // Characters enclosed in parentheses of count.
-    pub _by_field_name: Option<String>, // String specified after count() by.
-    pub _cmp_op: AggregationConditionToken, // (Required) What was specified, such as < or >.
-    pub _cmp_num: i64,               // (Required) The number after < or > etc.
+    pub _field_name: Option<String>, // Field name inside the parentheses of count(); None for a plain count().
+    pub _by_field_name: Option<String>, // Field name(s) after the "by" keyword; comma-separated when multiple.
+    pub _cmp_op: AggregationConditionToken, // (Required) The comparison operator, e.g. < or >.
+    pub _cmp_num: i64,                  // (Required) The number to compare the count against.
 }
 
+/// A lexical token of an aggregation condition.
 #[derive(Debug)]
 pub enum AggregationConditionToken {
-    Count(String),   // count
-    Space,           // Whitespace
-    BY,              // by
-    EQ,              // Equal to ..
-    LE,              // Less than or equal to ..
-    LT,              // Less than ..
-    GE,              // Greater than or equal to ..
-    GT,              // Greater than .
-    Keyword(String), // Field name for BY
+    Count(String), // count(...); the String is the field name in the parentheses (may be empty)
+    Space,         // Whitespace
+    BY,            // by
+    EQ,            // Equal to (==)
+    LE,            // Less than or equal to (<=)
+    LT,            // Less than (<)
+    GE,            // Greater than or equal to (>=)
+    GT,            // Greater than (>)
+    Keyword(String), // Bare word: the field name(s) after "by" or the number after a comparison operator
 }
 
 /// Parses the AggregationCondition as defined in SIGMA rules.
 /// AggregationCondition refers to the part after the pipe in the expression specified in condition.
 #[derive(Debug)]
-pub struct AggegationConditionCompiler {}
+pub struct AggregationConditionCompiler {}
 
-impl AggegationConditionCompiler {
+impl AggregationConditionCompiler {
     pub fn new() -> Self {
-        AggegationConditionCompiler {}
+        AggregationConditionCompiler {}
     }
 
+    /// Compiles the aggregation part (everything after the pipe) of a condition string.
+    /// Returns Ok(None) when the condition contains no pipe, i.e. has no aggregation condition.
     pub fn compile(&self, condition_str: &str) -> Result<Option<AggregationParseInfo>, String> {
         let result = self.compile_body(condition_str);
         if let Result::Err(msg) = result {
@@ -96,7 +102,8 @@ impl AggegationConditionCompiler {
                 .iter()
                 .find_map(|regex| regex.captures(cur_condition_str));
             if captured.is_none() {
-                // Parsing is done under the policy that failing to match a token is not possible.
+                // The token definitions are meant to cover every valid input, so any character
+                // sequence that matches no token is treated as an error.
                 return Result::Err("An unusable character was found.".to_string());
             }
 
@@ -147,13 +154,15 @@ impl AggegationConditionCompiler {
                 count_field_name = Option::Some(field_name);
             }
         } else {
-            // Various patterns exist which makes this complex, but it should be noted that only the "count" keyword can be used.
+            // The Sigma spec defines other aggregation functions besides count, but supporting
+            // the many possible patterns would get complex, so only the count keyword is
+            // accepted here.
             return Result::Err("The aggregation condition can only use count.".to_string());
         }
 
         let token = token_ite.next();
         if token.is_none() {
-            // Missing logical operator is invalid.
+            // Missing comparison operator is invalid.
             return Result::Err(
                 "The count keyword needs a compare operator and number like '> 3'".to_string(),
             );
@@ -185,7 +194,7 @@ impl AggegationConditionCompiler {
 
         // Parse comparison operator and number.
         if token.is_none() {
-            // Missing logical operator is invalid.
+            // Missing comparison operator is invalid.
             return Result::Err(
                 "The count keyword needs a compare operator and number like '> 3'".to_string(),
             );
@@ -198,6 +207,8 @@ impl AggegationConditionCompiler {
             );
         }
 
+        // Space serves as a dummy token here: if the input ends right after the comparison
+        // operator, the if-let below falls through to the "needs a number" error.
         let token = token_ite.next().unwrap_or(AggregationConditionToken::Space);
         let cmp_number = if let AggregationConditionToken::Keyword(number) = token {
             let number: Result<i64, _> = number.parse();
@@ -225,7 +236,7 @@ impl AggegationConditionCompiler {
         Result::Ok(Option::Some(info))
     }
 
-    /// Converts a string to a ConditionToken.
+    /// Converts a matched token string into an AggregationConditionToken.
     fn to_enum(&self, token: &str) -> AggregationConditionToken {
         if token.starts_with("count(") {
             let count_field = token
@@ -256,13 +267,13 @@ impl AggegationConditionCompiler {
 #[cfg(test)]
 mod tests {
     use super::super::aggregation_parser::{
-        AggegationConditionCompiler, AggregationConditionToken,
+        AggregationConditionCompiler, AggregationConditionToken,
     };
 
     #[test]
-    fn test_aggegation_condition_compiler_no_count() {
+    fn test_aggregation_condition_compiler_no_count() {
         // Pattern without count.
-        let compiler = AggegationConditionCompiler::new();
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 and select2");
         assert!(result.is_ok());
         let result = result.unwrap();
@@ -270,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_ope() {
+    fn test_aggregation_condition_compiler_count_ope() {
         // Normal case: no field inside count, try various operators.
         let token =
             check_aggregation_condition_ope("select1 and select2|count() > 32".to_string(), 32);
@@ -294,8 +305,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_by() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_count_by() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count() by iiibbb > 27");
 
         assert!(result.is_ok());
@@ -310,8 +321,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_by_multiple_fieilds() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_count_by_multiple_fields() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count() by iiibbb,aaabbb > 27");
         assert!(result.is_ok());
         let result = result.unwrap();
@@ -324,8 +335,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_by_multiple_fieilds_with_space() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_count_by_multiple_fields_with_space() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count() by iiibbb, aaabbb > 27");
         assert!(result.is_ok());
         let result = result.unwrap();
@@ -338,8 +349,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_field() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_count_field() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge    ) > 3");
 
         assert!(result.is_ok());
@@ -354,8 +365,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_count_all_field() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_count_all_field() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge) by snsn > 3");
 
         assert!(result.is_ok());
@@ -370,8 +381,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_only_pipe() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_only_pipe() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 |");
 
         assert!(result.is_err());
@@ -383,8 +394,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_unused_character() {
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_unused_character() {
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogeess ) by ii-i > 33");
 
         assert!(result.is_err());
@@ -396,9 +407,9 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_not_count() {
+    fn test_aggregation_condition_compiler_not_count() {
         // Something other than count is at the beginning.
-        let compiler = AggegationConditionCompiler::new();
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | by count( hogehoge) by snsn > 3");
 
         assert!(result.is_err());
@@ -406,9 +417,9 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_no_ope() {
+    fn test_aggregation_condition_compiler_no_ope() {
         // Missing comparison operator.
-        let compiler = AggegationConditionCompiler::new();
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge) 3");
 
         assert!(result.is_err());
@@ -416,9 +427,9 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_by() {
+    fn test_aggregation_condition_compiler_by() {
         // Nothing after by.
-        let compiler = AggegationConditionCompiler::new();
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge) by");
 
         assert!(result.is_err());
@@ -426,9 +437,9 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_no_ope_afterby() {
-        // Nothing after by.
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_no_ope_afterby() {
+        // No number after the comparison operator.
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge ) by hoe >");
 
         assert!(result.is_err());
@@ -436,9 +447,9 @@ mod tests {
     }
 
     #[test]
-    fn test_aggegation_condition_compiler_unneccesary_word() {
-        // Nothing after by.
-        let compiler = AggegationConditionCompiler::new();
+    fn test_aggregation_condition_compiler_unnecessary_word() {
+        // An extra token after the number.
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile("select1 or select2 | count( hogehoge ) by hoe > 3 33");
 
         assert!(result.is_err());
@@ -450,7 +461,7 @@ mod tests {
     }
 
     fn check_aggregation_condition_ope(expr: String, cmp_num: i64) -> AggregationConditionToken {
-        let compiler = AggegationConditionCompiler::new();
+        let compiler = AggregationConditionCompiler::new();
         let result = compiler.compile(&expr);
 
         assert!(result.is_ok());

--- a/src/detections/rule/base64_match.rs
+++ b/src/detections/rule/base64_match.rs
@@ -5,10 +5,15 @@ use base64::engine::general_purpose;
 use std::io::Write;
 use std::string::FromUtf8Error;
 
+/// Implements the Sigma base64offset modifier. Base64 encodes each group of 3 input bytes into 4
+/// output characters, so a value embedded somewhere inside an encoded stream can appear in one of
+/// three forms depending on its byte offset (0, 1 or 2) within a group. This generates all three
+/// variants and returns them as FastMatch::Contains patterns (any one of them matching is a hit).
+/// `encode` optionally converts the pattern to UTF-16LE/BE before base64-encoding it.
 pub fn convert_to_base64_str(
     encode: Option<&PipeElement>,
     org_str: &str,
-    err_msges: &mut Vec<String>,
+    err_msgs: &mut Vec<String>,
 ) -> Option<Vec<FastMatch>> {
     let mut fastmatches = vec![];
     for i in 0..3 {
@@ -23,7 +28,7 @@ pub fn convert_to_base64_str(
                 }
             }
             Err(e) => {
-                err_msges.push(format!("Failed base64 encoding: {e}"));
+                err_msgs.push(format!("Failed base64 encoding: {e}"));
             }
         }
     }
@@ -33,6 +38,10 @@ pub fn convert_to_base64_str(
     Some(fastmatches)
 }
 
+/// Base64-encodes `org_str` (as UTF-8, or as UTF-16LE/BE when `encode` says so) after prepending
+/// `variant_index` (0-2) dummy NUL bytes, which shifts the value to the corresponding offset
+/// within the base64 3-byte groups. The result can contain trailing NUL bytes because the output
+/// buffer is oversized; the caller strips them.
 fn make_base64_str(
     encode: Option<&PipeElement>,
     org_str: &str,
@@ -40,6 +49,7 @@ fn make_base64_str(
 ) -> Result<String, FromUtf8Error> {
     let mut b64_result = vec![];
     let mut target_byte = vec![];
+    // Prepend variant_index dummy NUL bytes to shift the encoding alignment.
     target_byte.resize_with(variant_index, || 0b0);
     if let Some(en) = encode.as_ref() {
         match en {
@@ -62,6 +72,7 @@ fn make_base64_str(
     } else {
         target_byte.extend_from_slice(org_str.as_bytes());
     }
+    // Reserve more than enough space for encode_slice(); unused bytes stay NUL.
     b64_result.resize_with(target_byte.len() * 4 / 3 + 4, || 0b0);
     general_purpose::STANDARD
         .encode_slice(target_byte, &mut b64_result)
@@ -69,6 +80,16 @@ fn make_base64_str(
     String::from_utf8(b64_result)
 }
 
+/// Cuts off the characters of an offset-shifted base64 string that are not fully determined by
+/// the original value, leaving a substring that always appears in a real encoded stream:
+/// - Start: the characters produced by the dummy NUL bytes plus the one character that mixes
+///   dummy and real bits, i.e. offset + 1 characters when offset != 0.
+/// - End: the characters that share bits with whatever (unknown) bytes follow the value in the
+///   stream, derived from the padding position. A first '=' at index % 4 == 2 means the last
+///   group held one real byte, so the ambiguous second character and "==" are dropped (3 chars);
+///   index % 4 == 3 means two real bytes, so one character and '=' are dropped (2 chars). With no
+///   padding the last group is complete and nothing is dropped (find() returns None and
+///   unwrap_or_default() yields 0, which selects the fall-through arm).
 fn base64_offset(offset: usize, b64_str: String, b64_str_null_filtered: String) -> String {
     match b64_str.find('=').unwrap_or_default() % 4 {
         2 => {
@@ -97,10 +118,15 @@ fn base64_offset(offset: usize, b64_str: String, b64_str_null_filtered: String) 
     }
 }
 
+/// Base64-encodes `input` as UTF-8 without padding, so that the result can be used as a substring
+/// (contains) pattern inside a longer base64 stream.
 pub fn to_base64_utf8(input: &str) -> String {
     general_purpose::STANDARD_NO_PAD.encode(input)
 }
 
+/// Base64-encodes `input` as UTF-16LE without padding, optionally prefixed with a BOM
+/// (0xFF 0xFE): Sigma's |utf16|base64 implies UTF-16LE with a BOM, whereas |utf16le|/|wide|
+/// encode without one.
 pub fn to_base64_utf16le_with_bom(input: &str, with_bom: bool) -> String {
     let mut utf16_bytes: Vec<u8> = Vec::new();
 
@@ -117,6 +143,7 @@ pub fn to_base64_utf16le_with_bom(input: &str, with_bom: bool) -> String {
     general_purpose::STANDARD_NO_PAD.encode(&utf16_bytes)
 }
 
+/// Base64-encodes `input` as UTF-16BE without padding.
 pub fn to_base64_utf16be(input: &str) -> String {
     let utf16_bytes: Vec<u8> = input
         .encode_utf16()
@@ -149,9 +176,9 @@ mod tests {
 
     #[test]
     fn test_convert_to_base64_str_utf8() {
-        let mut err_msges = vec![];
+        let mut err_msgs = vec![];
         let val = "Hello, world!";
-        let m = convert_to_base64_str(None, val, &mut err_msges).unwrap();
+        let m = convert_to_base64_str(None, val, &mut err_msgs).unwrap();
         assert_eq!(m[0], FastMatch::Contains("SGVsbG8sIHdvcmxkI".to_string()));
         assert_eq!(m[1], FastMatch::Contains("hlbGxvLCB3b3JsZC".to_string()));
         assert_eq!(m[2], FastMatch::Contains("IZWxsbywgd29ybGQh".to_string()));
@@ -159,9 +186,9 @@ mod tests {
 
     #[test]
     fn test_convert_to_base64_str_wide() {
-        let mut err_msges = vec![];
+        let mut err_msgs = vec![];
         let val = "Hello, world!";
-        let m = convert_to_base64_str(Some(&PipeElement::Wide), val, &mut err_msges).unwrap();
+        let m = convert_to_base64_str(Some(&PipeElement::Wide), val, &mut err_msgs).unwrap();
         assert_eq!(
             m[0],
             FastMatch::Contains("SABlAGwAbABvACwAIAB3AG8AcgBsAGQAIQ".to_string())
@@ -177,9 +204,9 @@ mod tests {
     }
     #[test]
     fn test_convert_to_base64_str_utf16le() {
-        let mut err_msges = vec![];
+        let mut err_msgs = vec![];
         let val = "Hello, world!";
-        let m = convert_to_base64_str(Some(&PipeElement::Utf16Le), val, &mut err_msges).unwrap();
+        let m = convert_to_base64_str(Some(&PipeElement::Utf16Le), val, &mut err_msgs).unwrap();
         assert_eq!(
             m[0],
             FastMatch::Contains("SABlAGwAbABvACwAIAB3AG8AcgBsAGQAIQ".to_string())
@@ -196,9 +223,9 @@ mod tests {
 
     #[test]
     fn test_convert_to_base64_str_utf16be() {
-        let mut err_msges = vec![];
+        let mut err_msgs = vec![];
         let val = "Hello, world!";
-        let m = convert_to_base64_str(Some(&PipeElement::Utf16Be), val, &mut err_msges).unwrap();
+        let m = convert_to_base64_str(Some(&PipeElement::Utf16Be), val, &mut err_msgs).unwrap();
         assert_eq!(
             m[0],
             FastMatch::Contains("AEgAZQBsAGwAbwAsACAAdwBvAHIAbABkAC".to_string())
@@ -223,12 +250,12 @@ mod tests {
 
     #[test]
     fn test_to_base64_utf16le_with_bom() {
-        // BOMなしの場合（既存の関数と同じ結果）
+        // Without a BOM (same result as the pre-existing function)
         assert_eq!(to_base64_utf16le_with_bom("A", false), "QQA");
         assert_eq!(to_base64_utf16le_with_bom("Hello", false), "SABlAGwAbABvAA");
         assert_eq!(to_base64_utf16le_with_bom("", false), "");
 
-        // BOMありの場合（先頭に0xFF 0xFEが追加される）
+        // With a BOM (0xFF 0xFE is prepended)
         assert_eq!(to_base64_utf16le_with_bom("A", true), "//5BAA");
         assert_eq!(
             to_base64_utf16le_with_bom("Hello", true),
@@ -236,7 +263,7 @@ mod tests {
         );
         assert_eq!(to_base64_utf16le_with_bom("", true), "//4");
 
-        // 日本語文字列のテスト
+        // Test with Japanese strings
         assert_eq!(
             to_base64_utf16le_with_bom("こんにちは", false),
             "UzCTMGswYTBvMA"
@@ -253,10 +280,10 @@ mod tests {
         let utf16le = to_base64_utf16le_with_bom(input, false);
         let utf16be = to_base64_utf16be(input);
 
-        // UTF-16LEとUTF-16BEは異なる結果になることを確認
+        // Verify that UTF-16LE and UTF-16BE produce different results
         assert_ne!(utf16le, utf16be);
 
-        // UTF-8とUTF-16も異なる結果になることを確認
+        // Verify that UTF-8 and UTF-16 also produce different results
         let utf8 = to_base64_utf8(input);
         assert_ne!(utf8, utf16le);
         assert_ne!(utf8, utf16be);
@@ -264,26 +291,26 @@ mod tests {
 
     #[test]
     fn test_to_base64_utf8() {
-        // 基本的な英語文字列
+        // Basic English strings
         assert_eq!(to_base64_utf8("Hello"), "SGVsbG8");
         assert_eq!(to_base64_utf8("A"), "QQ");
         assert_eq!(to_base64_utf8("Hello, World!"), "SGVsbG8sIFdvcmxkIQ");
 
-        // 空文字列
+        // Empty string
         assert_eq!(to_base64_utf8(""), "");
 
-        // 日本語文字列
+        // Japanese strings
         assert_eq!(to_base64_utf8("こんにちは"), "44GT44KT44Gr44Gh44Gv");
         assert_eq!(to_base64_utf8("テスト"), "44OG44K544OI");
 
-        // 数字と記号
+        // Digits and symbols
         assert_eq!(to_base64_utf8("123"), "MTIz");
         assert_eq!(to_base64_utf8("!@#$%"), "IUAjJCU");
 
-        // 改行文字を含む文字列
+        // String containing a newline character
         assert_eq!(to_base64_utf8("line1\nline2"), "bGluZTEKbGluZTI");
 
-        // UTF-8の特殊文字
+        // Special UTF-8 characters
         assert_eq!(to_base64_utf8("🎉"), "8J+OiQ");
         assert_eq!(to_base64_utf8("café"), "Y2Fmw6k");
     }

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -10,19 +10,22 @@ use itertools::Itertools;
 use std::{sync::Arc, vec::IntoIter};
 
 lazy_static! {
+    // Token patterns tried in order during lexing: "(", ")", a space, and a selection name or
+    // keyword (and/or/not).
     pub static ref CONDITION_REGEXMAP: Vec<Regex> = vec![
         Regex::new(r"^\(").unwrap(),
         Regex::new(r"^\)").unwrap(),
         Regex::new(r"^ ").unwrap(),
         Regex::new(r"^[\w+]+").unwrap(),
     ];
+    // Matches the pipe character and everything after it (the aggregation part of a condition).
     pub static ref RE_PIPE: Regex = Regex::new(r"\|.*").unwrap();
     // Regular expression matching "all of selection*" and "1 of selection*".
     pub static ref OF_SELECTION: Regex = Regex::new(r"(all|1) of ([^*]+)\*").unwrap();
 }
 
 #[derive(Debug, Clone)]
-/// Tokens appearing during lexical analysis.
+/// Tokens appearing during lexical analysis of a condition expression.
 pub enum ConditionToken {
     LeftParenthesis,
     RightParenthesis,
@@ -33,14 +36,15 @@ pub enum ConditionToken {
     SelectionReference(String),
 
     // Pseudo tokens created to facilitate processing during parsing.
-    ParenthesisContainer(Box<ConditionToken>), // Token representing parentheses.
+    ParenthesisContainer(Box<ConditionToken>), // Token representing a parenthesized subexpression.
     AndContainer(IntoIter<ConditionToken>),    // Token to group conditions connected by AND.
     OrContainer(IntoIter<ConditionToken>),     // Token to group conditions connected by OR.
-    NotContainer(Box<ConditionToken>), // 「NOT」と「NOTで否定される式」をまとめるためのトークン この配列には要素が一つしか入らないが、他のContainerと同じように扱えるようにするためにVecにしている。あんまり良くない。
+    NotContainer(Box<ConditionToken>), // Token grouping a NOT and the expression it negates.
 }
 
 impl ConditionToken {
-    /// convert from ConditionToken into SelectionNode
+    /// Converts this ConditionToken into a SelectionNode. `name_2_node` maps the selection names
+    /// defined in the rule's detection section to their parsed selection nodes.
     pub fn into_selection_node(
         self,
         name_2_node: &HashMap<String, Arc<Box<dyn SelectionNode>>>,
@@ -82,6 +86,8 @@ impl ConditionToken {
                 let select_not_node = NotSelectionNode::new(select_sub_node);
                 Result::Ok(Box::new(select_not_node))
             }
+            // The raw lexer tokens below should all have been consumed while parsing, so reaching
+            // them here is an internal error.
             ConditionToken::LeftParenthesis => Result::Err("Unknown error".to_string()),
             ConditionToken::RightParenthesis => Result::Err("Unknown error".to_string()),
             ConditionToken::Space => Result::Err("Unknown error".to_string()),
@@ -91,6 +97,8 @@ impl ConditionToken {
         }
     }
 
+    /// Converts a lexed string into its ConditionToken. Anything that is not an operator,
+    /// a parenthesis or a space is treated as a selection name reference.
     pub fn to_condition_token(token: &str) -> ConditionToken {
         if token == "(" {
             ConditionToken::LeftParenthesis
@@ -110,15 +118,17 @@ impl ConditionToken {
     }
 }
 
+/// Compiles the condition expression of a rule's detection section into a SelectionNode tree.
 #[derive(Debug)]
 pub struct ConditionCompiler {}
 
-// Class that reads condition expressions.
 impl ConditionCompiler {
     pub fn new() -> Self {
         ConditionCompiler {}
     }
 
+    /// Compiles a condition string into a SelectionNode tree. `name_2_node` maps the selection
+    /// names defined in the rule's detection section to their parsed selection nodes.
     pub fn compile_condition(
         &self,
         condition_str: &str,
@@ -126,7 +136,8 @@ impl ConditionCompiler {
     ) -> Result<Box<dyn SelectionNode>, String> {
         let node_keys: Vec<String> = name_2_node.keys().cloned().collect();
         let condition_str = Self::convert_condition(condition_str, &node_keys);
-        // Pipes are not processed here.
+        // The aggregation part after a pipe (e.g. "| count() >= 1") is parsed elsewhere
+        // (see aggregation_parser.rs), so strip it here.
         let captured = self::RE_PIPE.captures(condition_str.as_str());
         let replaced_condition = if let Some(cap) = captured {
             let captured = cap.get(0).unwrap().as_str();
@@ -143,7 +154,9 @@ impl ConditionCompiler {
         }
     }
 
-    // Convert "all of selection*" and "1 of selection*" to normal and/or.
+    /// Expands the Sigma "all of selection*" and "1 of selection*" syntax into plain and/or
+    /// expressions over every selection name starting with the given prefix, e.g.
+    /// "all of selection*" becomes "(selection1 and selection2 and ...)".
     pub fn convert_condition(condition_str: &str, node_keys: &[String]) -> String {
         let mut converted_str = condition_str.to_string();
         for matched in OF_SELECTION.find_iter(condition_str) {
@@ -199,7 +212,8 @@ impl ConditionCompiler {
                 .iter()
                 .find_map(|regex| regex.captures(cur_condition_str));
             if captured.is_none() {
-                // Parsing is done under the policy that failing to match a token is not possible.
+                // Every character of a valid condition must match one of the token regexes, so
+                // failing to match means the condition contains an unusable character.
                 return Result::Err("An unusable character was found.".to_string());
             }
 
@@ -218,7 +232,9 @@ impl ConditionCompiler {
         Result::Ok(tokens)
     }
 
-    /// Parses only left and right parentheses. The returned array does not contain LeftParenthesis or RightParenthesis; instead they are converted to TokenContainers. A TokenContainer represents the section enclosed in parentheses.
+    /// Parses only the parentheses. The returned array contains no LeftParenthesis or
+    /// RightParenthesis tokens; each parenthesized section is recursively parsed and replaced
+    /// with a single ParenthesisContainer token.
     fn parse_parenthesis(
         &self,
         mut tokens: IntoIter<ConditionToken>,
@@ -252,7 +268,7 @@ impl ConditionCompiler {
                 return Result::Err("')' was expected but not found.".to_string());
             }
 
-            // Call recursively here.
+            // Recursively parse the tokens inside the parentheses.
             let parsed_sub_token = self.parse(sub_tokens.into_iter())?;
             let parenthesis_token =
                 ConditionToken::ParenthesisContainer(Box::new(parsed_sub_token));
@@ -270,14 +286,18 @@ impl ConditionCompiler {
         Result::Ok(ret)
     }
 
-    /// Parses AND and OR.
+    /// Parses AND and OR operators. AND binds tighter than OR: runs of AND-connected operands
+    /// are grouped into AndContainers first, and the resulting groups are then combined with an
+    /// OrContainer.
     fn parse_and_or_operator(&self, tokens: Vec<ConditionToken>) -> Result<ConditionToken, String> {
         if tokens.is_empty() {
             // Must not be called with length 0.
             return Result::Err("Unknown error.".to_string());
         }
 
-        // First, group tokens connected by AND or OR, like selection1 and "not selection2" in an expression like "selection1 and not selection2".
+        // First, collapse each operand between the logical operators into a single token; e.g. in
+        // "selection1 and not selection2", both "selection1" and "not selection2" become one
+        // token each.
         let tokens = self.to_operand_container(tokens)?;
 
         // AND/OR at the beginning or end is invalid.
@@ -285,19 +305,19 @@ impl ConditionCompiler {
             return Result::Err("An illegal logical operator(and, or) was found.".to_string());
         }
 
-        // OperandContainers and LogicalOperators (And and OR) alternate, so add each to their respective lists.
+        // Operands and logical operators (And/Or) must alternate, so split them into their
+        // respective lists while verifying the alternation.
         let mut operand_list = vec![];
         let mut operator_list = vec![];
         for (i, token) in tokens.into_iter().enumerate() {
             if (i % 2 == 1) != self.is_logical(&token) {
-                // At odd indices it is a LogicalOperator; at even indices it is an OperandContainer.
+                // Operands must sit at even indices and logical operators at odd indices.
                 return Result::Err(
                     "The use of a logical operator(and, or) was wrong.".to_string(),
                 );
             }
 
             if i % 2 == 0 {
-                // Call the function to recursively parse AND and OR here.
                 operand_list.push(token);
             } else {
                 operator_list.push(token);
@@ -307,19 +327,19 @@ impl ConditionCompiler {
         // First, group all parts connected by AND.
         let mut operand_ite = operand_list.into_iter();
         let mut operands = vec![];
-        let mut and_grops = vec![];
-        operator_list.push(ConditionToken::Or); // add "or token" as a sentinel
+        let mut and_groups = vec![];
+        operator_list.push(ConditionToken::Or); // sentinel Or to flush the final AND group
         for token in operator_list.iter() {
             if let ConditionToken::Or = token {
-                if and_grops.is_empty() {
+                if and_groups.is_empty() {
                     operands.push(operand_ite.next().unwrap());
                 } else {
-                    and_grops.push(operand_ite.next().unwrap());
-                    operands.push(ConditionToken::AndContainer(and_grops.into_iter()));
+                    and_groups.push(operand_ite.next().unwrap());
+                    operands.push(ConditionToken::AndContainer(and_groups.into_iter()));
                 }
-                and_grops = vec![];
+                and_groups = vec![];
             } else {
-                and_grops.push(operand_ite.next().unwrap());
+                and_groups.push(operand_ite.next().unwrap());
             }
         }
 
@@ -330,9 +350,11 @@ impl ConditionCompiler {
         Result::Ok(ConditionToken::OrContainer(operands.into_iter()))
     }
 
-    /// Parses the contents of an OperandContainer. Currently exists only to parse Not.
+    /// Parses one operand group (the tokens between two logical operators). Currently this only
+    /// needs to handle an optional leading Not.
     fn parse_operand_container(sub_tokens: Vec<ConditionToken>) -> Result<ConditionToken, String> {
-        // Currently, in the NOT case, there should be two items: "not" and "the name of the selection node modified by not".
+        // Currently, in the NOT case, there should be two items: "not" and "the name of the
+        // selection node negated by not".
         // If there is no NOT, there should be only one item: "the name of the selection node".
 
         // As stated above, there should never be three or more items.
@@ -343,12 +365,12 @@ impl ConditionCompiler {
             );
         }
 
-        // 0 should not be possible.
+        // An empty group should be impossible.
         if sub_tokens.is_empty() {
             return Result::Err("Unknown error.".to_string());
         }
 
-        // If there is only one item, NOT is not possible.
+        // With only one token, it must not be a Not (a lone "not" has nothing to negate).
         if sub_tokens.len() == 1 {
             let operand_subtoken = sub_tokens.into_iter().next().unwrap();
             if let ConditionToken::Not = operand_subtoken {
@@ -358,7 +380,8 @@ impl ConditionCompiler {
             return Result::Ok(operand_subtoken);
         }
 
-        // If there are two items, the first should be Not and the next should be something that is not Not.
+        // If there are two items, the first should be Not and the next should be something that
+        // is not Not.
         let mut sub_ite = sub_tokens.into_iter();
         let first_token = sub_ite.next().unwrap();
         let second_token = sub_ite.next().unwrap();
@@ -382,16 +405,20 @@ impl ConditionCompiler {
         matches!(token, ConditionToken::And | ConditionToken::Or)
     }
 
-    /// Converts sections that can be converted to ConditionToken::OperandContainer.
+    /// Collapses each run of consecutive non-operator tokens into a single operand token, so the
+    /// result alternates between operands and logical operators (And/Or).
     fn to_operand_container(
         &self,
         tokens: Vec<ConditionToken>,
     ) -> Result<Vec<ConditionToken>, String> {
         let mut ret = vec![];
-        let mut grouped_operands = vec![]; // Represents tokens between AND and OR. The Operand when AND and OR are treated as Operators.
+        // Tokens between two logical operators, i.e. one operand when And/Or are viewed as
+        // operators.
+        let mut grouped_operands = vec![];
         for token in tokens.into_iter() {
             if self.is_logical(&token) {
-                // This should be an error, but since errors are output later, do not output an error here.
+                // A logical operator with no preceding operand is really an error, but
+                // parse_and_or_operator reports it later, so just pass the token through here.
                 if grouped_operands.is_empty() {
                     ret.push(token);
                     continue;
@@ -428,6 +455,7 @@ mod tests {
     use crate::detections::{self, utils};
     use yaml_rust2::YamlLoader;
 
+    // Minimal event record shared by most of the tests in this module.
     const SIMPLE_RECORD_STR: &str = r#"
     {
       "Event": {
@@ -938,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_condition_notparenthesis_detect() {
-        // Test using many parentheses in condition.
+        // Test combining parentheses and not in condition.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1122,8 +1150,9 @@ mod tests {
     }
 
     #[test]
-    fn test_condition_err_condition_forbit_character() {
-        // An unreadable character is specified in condition.
+    fn test_condition_err_condition_forbid_character() {
+        // The condition contains a character that cannot be tokenized (the hyphen in
+        // "selection-1").
         let rule_str = r#"
         enabled: true
         detection:
@@ -1216,7 +1245,7 @@ mod tests {
 
     #[test]
     fn test_condition_err_no_logical() {
-        // Not connected by AND or OR.
+        // Using two selection names not connected by AND or OR is an error.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1234,7 +1263,7 @@ mod tests {
 
     #[test]
     fn test_condition_err_first_logical() {
-        //
+        // A logical operator at the beginning of the condition is an error.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1258,7 +1287,7 @@ mod tests {
 
     #[test]
     fn test_condition_err_last_logical() {
-        //
+        // A logical operator at the end of the condition is an error.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1282,7 +1311,7 @@ mod tests {
 
     #[test]
     fn test_condition_err_consecutive_logical() {
-        //
+        // Consecutive logical operators are an error.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1300,7 +1329,7 @@ mod tests {
 
     #[test]
     fn test_condition_err_only_not() {
-        //
+        // A not without an operand is an error.
         let rule_str = r#"
         enabled: true
         detection:

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -14,8 +14,12 @@ use uuid::Uuid;
 use yaml_rust2::Yaml;
 use yaml_rust2::yaml::Hash;
 
+// Maps a selection name (e.g. "selection1") to its compiled selection node, collected from the
+// rules referenced by a correlation rule.
 type Name2Selection = HashMap<String, Arc<Box<dyn SelectionNode>>>;
 
+/// Returns true if the rule's `id`, `title` or `name` equals the given reference string
+/// (a correlation rule may reference other rules by any of the three).
 fn is_referenced_rule(rule_node: &RuleNode, id_or_title: &str) -> bool {
     if let Some(hash) = rule_node.yaml.as_hash() {
         if let Some(id) = hash.get(&Yaml::String("id".to_string()))
@@ -36,6 +40,9 @@ fn is_referenced_rule(rule_node: &RuleNode, id_or_title: &str) -> bool {
     }
     false
 }
+/// Looks for a `field` entry among the `correlation.condition` key/value pairs. Only meaningful
+/// for `value_count` rules, where `field` names the field whose distinct values are counted;
+/// returns None for every other correlation type.
 fn find_condition_field_value(
     rule_type: Option<&Yaml>,
     pair: Vec<(&Yaml, &Yaml)>,
@@ -51,6 +58,8 @@ fn find_condition_field_value(
     None
 }
 
+/// Finds the first comparison entry (eq/lte/gte/lt/gt) among the `correlation.condition`
+/// key/value pairs and returns it as (operator token, threshold, optional value_count field).
 fn process_condition_pairs(
     pair: Vec<(&Yaml, &Yaml)>,
     field: Option<String>,
@@ -74,6 +83,8 @@ fn process_condition_pairs(
     Err("Failed to match any condition".into())
 }
 
+/// Parses the `condition` mapping of a correlation rule (the argument is the whole `correlation`
+/// mapping) into (comparison operator, threshold, optional `field` for value_count rules).
 fn parse_condition(
     yaml: &Yaml,
 ) -> Result<(AggregationConditionToken, i64, Option<String>), Box<dyn Error>> {
@@ -90,6 +101,8 @@ fn parse_condition(
     Err("Failed to parse condition".into())
 }
 
+/// ORs together the referenced rules' condition trees so that the merged correlation rule
+/// matches any event matched by any of the referenced rules.
 fn to_or_selection_node(related_rule_nodes: Vec<RuleNode>) -> OrSelectionNode {
     let mut or_selection_node = OrSelectionNode::new();
     for rule_node in related_rule_nodes {
@@ -100,6 +113,7 @@ fn to_or_selection_node(related_rule_nodes: Vec<RuleNode>) -> OrSelectionNode {
     or_selection_node
 }
 
+/// Returns the list of references (rule IDs, titles or names) under `correlation.rules`.
 fn get_related_rules_id(yaml: &Yaml) -> Result<Vec<String>, Box<dyn Error>> {
     let correlation = yaml["correlation"]
         .as_hash()
@@ -123,6 +137,8 @@ fn get_related_rules_id(yaml: &Yaml) -> Result<Vec<String>, Box<dyn Error>> {
     Ok(rules)
 }
 
+/// Returns the `correlation.group-by` field names joined with "," (the comma-separated format
+/// that count::create_count_key expects), or Ok(None) if the rule has no group-by key.
 fn get_group_by_from_yaml(yaml: &Yaml) -> Result<Option<String>, Box<dyn Error>> {
     let correlation = yaml["correlation"]
         .as_hash()
@@ -142,6 +158,9 @@ fn get_group_by_from_yaml(yaml: &Yaml) -> Result<Option<String>, Box<dyn Error>>
     }
     Ok(Some(group_by.join(",")))
 }
+/// Parses a `correlation.timespan` value such as "5m" into a TimeFrameInfo. Nearly the same as
+/// TimeFrameInfo::parse_tframe in count.rs, but returns an Err for an unknown unit suffix
+/// instead of logging it.
 fn parse_tframe(value: String) -> Result<TimeFrameInfo, Box<dyn Error>> {
     let ttype;
     let mut target_val = value.as_str();
@@ -165,6 +184,8 @@ fn parse_tframe(value: String) -> Result<TimeFrameInfo, Box<dyn Error>> {
     })
 }
 
+/// Resolves each reference in `correlation.rules` to freshly initialized copies of every
+/// matching rule and collects their named selections. Fails if a reference matches no rule.
 fn create_related_rule_nodes(
     related_rules_ids: &Vec<String>,
     other_rules: &[RuleNode],
@@ -191,6 +212,9 @@ fn create_related_rule_nodes(
     Ok((related_rule_nodes, name_to_selection))
 }
 
+/// Builds the DetectionNode of a merged `event_count`/`value_count` correlation rule: an OR over
+/// the referenced rules' conditions, plus an aggregation condition assembled from the rule's
+/// `condition`, `group-by` and `timespan` settings.
 fn create_detection(
     rule_node: &RuleNode,
     related_rule_nodes: Vec<RuleNode>,
@@ -220,6 +244,8 @@ fn create_detection(
     }
 }
 
+/// Records a correlation rule parse failure: prints the message when --verbose is set, stacks it
+/// for the error log file unless --quiet-errors is set, and bumps the parse error counter.
 fn error_log(
     rule_path: &str,
     reason: &str,
@@ -239,6 +265,13 @@ fn error_log(
     *parseerror_count += 1;
 }
 
+/// Converts an `event_count`/`value_count` correlation rule into a single self-contained
+/// RuleNode whose detection is an OR over the rules it references, tagged with the aggregation
+/// condition to evaluate. The `temporal`/`temporal_ordered` early-return is defensive only: in
+/// the current flow parse_correlation_rules partitions temporal rules out before this function
+/// is called, so they are expanded (without this validation) by parse_temporal_rules instead.
+/// On any validation failure the reason is logged and the rule is returned unchanged (it will
+/// simply never match).
 fn merge_referenced_rule(
     rule: RuleNode,
     other_rules: &mut Vec<RuleNode>,
@@ -302,6 +335,8 @@ fn merge_referenced_rule(
             && !referenced_ids.contains(&title.to_string())
             && !referenced_ids.contains(&name.to_string())
     };
+    // Unless `generate: true` is set, remove the referenced rules from the rule set so they do
+    // not also emit detections of their own.
     if !rule.yaml["correlation"]["generate"]
         .as_bool()
         .unwrap_or_default()
@@ -324,6 +359,9 @@ fn merge_referenced_rule(
             return rule;
         }
     };
+    // Build the merged rule: the correlation rule's own YAML (metadata and correlation settings)
+    // with the referenced rules' YAML embedded under the `detection` key, plus the pre-built
+    // DetectionNode.
     let referenced_yaml: Yaml =
         Yaml::Array(referenced_hashes.into_iter().map(Yaml::Hash).collect());
     let mut merged_yaml = rule.yaml.as_hash().unwrap().clone();
@@ -331,6 +369,20 @@ fn merge_referenced_rule(
     RuleNode::new_with_detection(rule.rulepath, Yaml::Hash(merged_yaml), detection)
 }
 
+/// Expands `temporal`/`temporal_ordered` correlation rules. Each referenced rule must be
+/// evaluated with the temporal rule's own group-by/timespan, so for every reference:
+/// - a referenced rule that is itself a correlation rule (e.g. an already merged event_count
+///   rule) is re-tagged CorrelationType::TemporalRef in place and kept under its existing id;
+/// - otherwise a copy of the referenced rule is registered under a fresh UUID, tagged
+///   TemporalRef, and given a "count() >= 1" aggregation condition over the temporal rule's
+///   group-by/timespan (one match per referenced rule suffices for a temporal correlation).
+///
+/// The temporal rule itself is rewritten to reference the ids actually used and receives the
+/// same "count() >= 1" aggregation condition; Detection::add_aggcondition_msg later combines the
+/// TemporalRef results per time window (each result is already aggregated per group-by value by
+/// its own rule, but group equality is not checked when combining). Unless `generate: true` is
+/// set, the original
+/// referenced rules are removed so they do not also emit detections of their own.
 fn parse_temporal_rules(
     temporal_rules: Vec<RuleNode>,
     other_rules: &mut Vec<RuleNode>,
@@ -351,12 +403,17 @@ fn parse_temporal_rules(
                             .as_bool()
                             .unwrap_or_default();
                         let mut new_yaml = other_rule.yaml.clone();
+                        // A referenced rule that is already a correlation rule aggregates its own
+                        // matches, so tag it in place and keep referencing it by its existing id.
                         if other_rule.correlation_type != CorrelationType::None {
                             other_rule.correlation_type =
                                 CorrelationType::TemporalRef(generate, ref_id.to_string());
                             temporal_ref_ids.push(Yaml::String(ref_id.to_string()));
                             continue;
                         }
+                        // Otherwise register a copy of the referenced rule under a fresh UUID so
+                        // that each temporal rule gets its own evaluation of the referenced rule
+                        // (group-by and timespan differ per temporal rule).
                         let new_id = Uuid::new_v4().to_string();
                         if let Some(hash) = new_yaml.as_mut_hash() {
                             hash.insert(
@@ -368,6 +425,9 @@ fn parse_temporal_rules(
                         let _ = node.init(stored_static);
                         node.correlation_type =
                             CorrelationType::TemporalRef(generate, new_id.to_string());
+                        // The copy counts matches per group-by value within the temporal rule's
+                        // timespan; "count() >= 1" because a single match of each referenced
+                        // rule is enough for the temporal correlation.
                         let group_by = get_group_by_from_yaml(&temporal.yaml);
                         let timespan = &temporal.yaml["correlation"]["timespan"].as_str().unwrap();
                         let time_frame = parse_tframe(timespan.to_string());
@@ -385,12 +445,16 @@ fn parse_temporal_rules(
                         node.detection = detection;
                         temporal_ref_rules.push(node);
                         temporal_ref_ids.push(Yaml::String(new_id.to_string()));
+                        // With generate: false (the default), the original referenced rule must
+                        // not emit detections of its own, so remember it for removal.
                         if !generate {
                             referenced_del_ids.insert(ref_id.to_string());
                         }
                     }
                 }
             }
+            // Rewrite the temporal rule so its correlation.rules list points at the ids the
+            // TemporalRef rules were registered under.
             let mut new_yaml = temporal_yaml.clone();
             new_yaml["correlation"]["rules"] = Yaml::Array(temporal_ref_ids);
             let mut node = RuleNode::new(temporal.rulepath.clone(), new_yaml);
@@ -407,6 +471,10 @@ fn parse_temporal_rules(
             parsed_temporal_rules.push(node);
         }
     }
+    // Remove the originals that were replaced by TemporalRef copies (generate: false), then add
+    // the copies. The copies must be added after the retain: they keep the original title/name,
+    // so when a rule was referenced by title or name, adding the copies earlier would delete
+    // them too.
     other_rules.retain(|rule| {
         let id = rule.yaml["id"].as_str().unwrap_or_default();
         let title = rule.yaml["title"].as_str().unwrap_or_default();
@@ -419,6 +487,13 @@ fn parse_temporal_rules(
     parsed_temporal_rules
 }
 
+/// Entry point for Sigma correlation rule support, called once after all rule files have been
+/// loaded: rewrites the rule set so that correlation rules become directly evaluable RuleNodes.
+/// `event_count`/`value_count` rules are merged with the rules they reference
+/// (merge_referenced_rule) first, then `temporal`/`temporal_ordered` rules are expanded
+/// (parse_temporal_rules) — in that order, so temporal rules can also reference already merged
+/// count-based correlation rules. Rules referenced with `generate: false` (the default) no
+/// longer emit their own detections. Non-correlation rules pass through unchanged.
 pub fn parse_correlation_rules(
     rule_nodes: Vec<RuleNode>,
     stored_static: &StoredStatic,

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -17,6 +17,8 @@ use std::path::Path;
 use crate::detections::utils;
 
 /// Function to insert count information when a detection occurs.
+/// Called once per record that matched the rule's selection when the rule has an aggregation
+/// condition; it groups the record under its `count() by` key and stores the count() field value.
 pub fn count(
     rule: &mut RuleNode,
     evtx_rec: &EvtxRecordInfo,
@@ -53,7 +55,9 @@ pub fn count(
     countup(rule, key, field_value, evtx_rec, json_input_flag);
 }
 
-/// Function to increment the count of detected records matching the count by condition.
+/// Function to increment the count of detected records for the given `count() by` grouping key,
+/// by appending an AggRecordTimeInfo entry (count() field value, timestamp and identifying
+/// metadata) to the rule's per-key count data.
 pub fn countup(
     rule: &mut RuleNode,
     key: String,
@@ -100,9 +104,10 @@ pub fn countup(
     });
 }
 
-/// Function to get the value in the target record from the given alias and remove double quotes.
-///  The reason for removing double quotes is to prevent extra double quotes from appearing in the result display.
-/// is_by_alias is bool because when calling this function, it is either the by value or the field value of count.
+/// Function to get the value in the target record from the given alias, with double quotes
+/// removed. The double quotes are removed to prevent extra quotes from appearing in the result
+/// display. `is_by_alias` indicates whether the alias came from the `count() by` clause (true) or
+/// from the field inside the count() parentheses (false); it only affects the error message text.
 fn get_alias_value_in_record(
     rule: &RuleNode,
     alias: &str,
@@ -150,9 +155,10 @@ fn get_alias_value_in_record(
     }
 }
 
-/// Function to create hashmap keys for grouping information such as groupby in count.
-/// Returns empty string in the following cases:
-/// If groupby is not specified, or the alias specified by groupby does not exist in the record, use only "_". An empty string could not be used to retrieve data by key.
+/// Function to create the hashmap key used to group count() data, e.g. by the `count() by`
+/// clause. If no `by` clause is specified, or an alias named in the `by` clause does not exist in
+/// the record, the placeholder "_" is used instead, because an empty string could not be used to
+/// retrieve data by key.
 pub fn create_count_key(
     rule: &RuleNode,
     record: &Value,
@@ -199,12 +205,13 @@ pub fn create_count_key(
     }
 }
 
-/// Function to determine whether the current state of the record matches the condition expression.
+/// Function to evaluate the aggregation condition against all counted data, returning an
+/// AggResult for every timeframe window that satisfies it.
 pub fn aggregation_condition_select(
     rule: &RuleNode,
     stored_static: &StoredStatic,
 ) -> Vec<AggResult> {
-    // Assumes that aliases are registered in the record.
+    // Assumes count() has already registered the records' alias values into countdata.
     let value_map = &rule.countdata;
     let mut ret = Vec::new();
     for (key, value) in value_map {
@@ -214,7 +221,8 @@ pub fn aggregation_condition_select(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-/// Struct holding information inside the parentheses of count and record information.
+/// Per-record data kept for count() evaluation: the value of the field named inside the count()
+/// parentheses, plus the record's timestamp and identifying metadata.
 pub struct AggRecordTimeInfo {
     pub field_value: String,
     pub time: DateTime<Utc>,
@@ -225,14 +233,18 @@ pub struct AggRecordTimeInfo {
 }
 
 #[derive(Debug)]
-/// Information set in timeframe. A struct that stores only the type and number, since there were no SIGMA rules with multiple units (days, hours, minutes, seconds) combined in timeframe.
+/// Information from the rule's timeframe setting. Only a single unit type and number are stored,
+/// since no SIGMA rule was found that combines multiple units (days, hours, minutes, seconds) in
+/// timeframe.
 pub struct TimeFrameInfo {
     pub timetype: String,
     pub timenum: Result<i64, ParseIntError>,
 }
 
 impl TimeFrameInfo {
-    /// Function to parse the timeframe string and return a struct.
+    /// Function to parse a timeframe string such as "15m" and return a struct. An unknown unit
+    /// suffix is reported here; a non-numeric number part is kept as an Err in `timenum` and
+    /// reported later by get_sec_timeframe().
     pub fn parse_tframe(value: String, stored_static: &StoredStatic) -> TimeFrameInfo {
         let mut ttype = "";
         let mut target_val = value.as_str();
@@ -297,7 +309,8 @@ pub fn get_sec_timeframe(rule: &RuleNode, stored_static: &StoredStatic) -> Optio
         }
     }
 }
-/// Function to evaluate whether the condition is satisfied by checking AggregationParseInfo for the processing after the pipe in condition.
+/// Function to evaluate whether the given count satisfies the comparison stored in
+/// AggregationParseInfo, i.e. the part after the pipe in `condition` such as `>= 3`.
 pub fn select_aggcon(cnt: i64, rule: &RuleNode) -> bool {
     let agg_condition = rule.detection.aggregation_condition.as_ref();
     if agg_condition.is_none() {
@@ -315,7 +328,8 @@ pub fn select_aggcon(cnt: i64, rule: &RuleNode) -> bool {
     }
 }
 
-/// Generics for if-let that returns the same type depending on the branch of condition.
+/// Generic helper for an if-else where both branches must return the same type: calls
+/// `process_true` when `condition` holds, otherwise `process_false`.
 fn _if_condition_fn_caller<T: FnMut() -> S, S, U: FnMut() -> S>(
     condition: bool,
     mut process_true: T,
@@ -329,7 +343,8 @@ fn _if_condition_fn_caller<T: FnMut() -> S, S, U: FnMut() -> S>(
 }
 
 /**
- * Trait to absorb differences in how count() counts.
+ * Trait to absorb differences in how count() counts
+ * (distinct field values vs. plain record count).
  */
 trait CountStrategy {
     /**
@@ -351,7 +366,8 @@ trait CountStrategy {
 }
 
 /**
- * Struct representing the calculation method of judge when a field is specified in count.
+ * Counting strategy used when a field is specified inside the count() parentheses:
+ * counts the number of distinct values that field takes within the timeframe.
  */
 struct FieldStrategy {
     value_2_cnt: HashMap<String, i64>,
@@ -403,7 +419,9 @@ impl CountStrategy for FieldStrategy {
         _cnt: i64,
         key: &str,
     ) -> AggResult {
-        let values: Vec<String> = self.value_2_cnt.drain().map(|(key, _)| key).collect(); // Initialize with drain.
+        // drain() empties the map as it yields entries, so this also resets the counter for the
+        // next timeframe window.
+        let values: Vec<String> = self.value_2_cnt.drain().map(|(key, _)| key).collect();
         AggResult::new(
             values.len() as i64,
             key.to_string(),
@@ -415,7 +433,8 @@ impl CountStrategy for FieldStrategy {
 }
 
 /**
- * Struct representing the calculation method of judge when no field is specified in count.
+ * Counting strategy used when no field is specified inside the count() parentheses:
+ * simply counts the number of records within the timeframe.
  */
 struct NoFieldStrategy {
     cnt: i64,
@@ -450,11 +469,12 @@ impl CountStrategy for NoFieldStrategy {
             datas.first().unwrap().time,
             datas.to_vec(),
         );
-        self.cnt = 0; // Initialize cnt.
+        self.cnt = 0; // Reset the counter for the next timeframe window.
         ret
     }
 }
 
+/// Picks the counting strategy depending on whether a field is named inside count()'s parentheses.
 fn _create_counter(rule: &RuleNode) -> Box<dyn CountStrategy> {
     let agg_cond = rule.get_agg_condition().unwrap();
     if agg_cond._field_name.is_some() {
@@ -474,11 +494,15 @@ fn _get_timestamp_subsec_nano(idx: i64, datas: &[AggRecordTimeInfo]) -> u32 {
     datas[idx as usize].time.timestamp_subsec_nanos()
 }
 
-// Determine whether data from data[left] to data[right-1] fits within the timeframe.
+// Determine whether all data from data[left] through data[right] (inclusive) fits within the
+// timeframe, i.e. whether the window can be extended to include data[right].
+// Assumes datas is sorted in ascending time order.
 fn _is_in_timeframe(left: i64, right: i64, frame: i64, datas: &[AggRecordTimeInfo]) -> bool {
     let left_time = _get_timestamp(left, datas);
     let left_time_nano = _get_timestamp_subsec_nano(left, datas);
-    // evtx SystemTime is recorded with up to 7 decimal places of seconds, so this is taken into account.
+    // evtx SystemTime is recorded with up to 7 fractional digits of seconds, but timestamp()
+    // truncates to whole seconds. When the right edge has a larger fractional part than the left,
+    // round the difference up by one second so the sub-second part is taken into account.
     let mut right_time = _get_timestamp(right, datas);
     let right_time_nano = _get_timestamp_subsec_nano(right, datas);
     if right_time_nano > left_time_nano {
@@ -487,7 +511,8 @@ fn _is_in_timeframe(left: i64, right: i64, frame: i64, datas: &[AggRecordTimeInf
     right_time - left_time <= frame
 }
 
-/// Function that returns as an array the AggResults where records satisfying the select condition within the timeframe in the counted data meet the count condition per timeframe.
+/// Function that slides a window over the time-sorted records of one grouping key and returns an
+/// AggResult for each timeframe window whose records satisfy the count condition.
 pub fn judge_timeframe(
     rule: &RuleNode,
     time_datas: &[AggRecordTimeInfo],
@@ -499,11 +524,12 @@ pub fn judge_timeframe(
         return ret;
     }
 
-    // Proceed with processing assuming AggRecordTimeInfo is sorted in time order.
+    // The processing below assumes the AggRecordTimeInfo entries are sorted in time order.
     let mut datas = time_datas.to_owned();
     datas.sort_by_key(|a| a.time);
 
-    // If the timeframe setting is not in the rule, set the time difference between the first and last elements as the timeframe.
+    // If the rule has no timeframe setting, use the time difference between the first and last
+    // elements as the timeframe.
     let def_frame =
         datas.last().unwrap().time.timestamp() - datas.first().unwrap().time.timestamp();
     let frame = get_sec_timeframe(rule, stored_static).unwrap_or(def_frame);
@@ -513,7 +539,7 @@ pub fn judge_timeframe(
     let mut right: i64 = 0;
     let mut counter = _create_counter(rule);
     let data_len = datas.len() as i64;
-    // right is an open interval, so +1.
+    // right is exclusive, so it may go one past the last index (hence the +1).
     while left < data_len && right < data_len + 1 {
         // Increment right as long as it is within the timeframe range.
         while right < data_len && _is_in_timeframe(left, right, frame, &datas) {
@@ -527,7 +553,8 @@ pub fn judge_timeframe(
             ret.push(counter.create_agg_result(&datas[left as usize..right as usize], cnt, key));
             left = right;
         } else {
-            // The condition was not satisfied, so shift right and left by +1.
+            // The condition was not satisfied, so slide the window: take in data[right] and drop
+            // data[left]. add_data/remove_data bounds-check, so right == data_len is a no-op.
             counter.add_data(right, &datas, rule);
             right += 1;
             counter.remove_data(left, &datas, rule);
@@ -589,7 +616,8 @@ mod tests {
     }
 
     #[test]
-    /// Test that detection by rule works when there is no description inside count parentheses and no count by description (without timeframe).
+    /// Test that rule detection works when count() has no field argument and no `by` clause
+    /// (without timeframe).
     fn test_count_no_field_and_by() {
         let record_str: &str = r#"
         {
@@ -640,7 +668,8 @@ mod tests {
     }
 
     #[test]
-    /// Test that detection by rule works when there is no description inside count parentheses and no count by description (with timeframe).
+    /// Test that rule detection works when count() has no field argument and no `by` clause
+    /// (with timeframe).
     fn test_count_no_field_and_by_with_timeframe() {
         let record_str: &str = r#"
         {
@@ -701,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    /// Verify that count detection by rule works when there is a description inside the count parentheses.
+    /// Verify that count detection by rule works when count() has a field argument.
     fn test_count_exist_field() {
         let rule_str = r#"
         enabled: true
@@ -795,7 +824,8 @@ mod tests {
     }
 
     #[test]
-    /// Verify that count detection by rule works when both a description inside parentheses and a by description are present.
+    /// Verify that count detection by rule works when count() has both a field argument and a
+    /// `by` clause.
     fn test_count_exist_field_and_by() {
         let record_str: &str = r#"
         {
@@ -853,7 +883,8 @@ mod tests {
     }
 
     #[test]
-    /// Verify that count is executed separately for each combination of values when both a description in parentheses and a by description are present in count (when the values specified inside parentheses differ across multiple records).
+    /// Verify that when count() has both a field argument and a `by` clause, counting is done
+    /// separately per `by` value (with the count() field values differing across records).
     fn test_count_exist_field_and_by_with_othervalue_in_timeframe() {
         let record_str: &str = r#"
         {
@@ -911,7 +942,8 @@ mod tests {
     }
 
     #[test]
-    /// Verify that an empty array is returned when the count condition of the rule is not satisfied due to the timeframe condition.
+    /// Verify that an empty array is returned when the rule's count condition is not satisfied
+    /// because of the timeframe condition.
     fn test_count_not_satisfy_in_timeframe() {
         let record_str: &str = r#"
         {
@@ -974,7 +1006,8 @@ mod tests {
         assert_eq!(judge_result.len(), 0);
     }
     #[test]
-    /// Verify that count detection by rule works when both a description inside parentheses and a by description are present and exist within the timeframe.
+    /// Verify that count detection by rule works when count() has both a field argument and a
+    /// `by` clause and the records fall within the timeframe.
     fn test_count_exist_field_and_by_with_timeframe() {
         let record_str: &str = r#"
         {
@@ -1023,7 +1056,9 @@ mod tests {
     }
 
     #[test]
-    /// Verify that count detection by rule works when both a description inside parentheses and a by description are present and exist within the timeframe (when the items inside the count parentheses differ).
+    /// Verify that count detection by rule works when count() has both a field argument and a
+    /// `by` clause and the records fall within the timeframe (with differing count() field
+    /// values).
     fn test_count_exist_field_and_by_with_timeframe_other_field_value() {
         let record_str: &str = r#"
         {
@@ -1081,7 +1116,7 @@ mod tests {
             test_create_recstr_std("3", "1977-01-09T00:30:20Z"),
         ];
 
-        // timeframe=20s is a just-barely-hit.
+        // timeframe=20s just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "20s");
             let default_time = Utc.with_ymd_and_hms(1977, 1, 9, 0, 30, 0).unwrap();
@@ -1108,14 +1143,14 @@ mod tests {
 
     // Verify that timeframe minutes work.
     #[test]
-    fn test_count_timeframe_minitues() {
+    fn test_count_timeframe_minutes() {
         let recs = vec![
             test_create_recstr_std("1", "1977-01-09T00:30:00Z"),
             test_create_recstr_std("2", "1977-01-09T00:40:00Z"),
             test_create_recstr_std("3", "1977-01-09T00:50:00Z"),
         ];
 
-        // timeframe=20m is a just-barely-hit.
+        // timeframe=20m just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "20m");
             let default_time = Utc.with_ymd_and_hms(1977, 1, 9, 0, 30, 0).unwrap();
@@ -1165,7 +1200,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, expected_agg_result);
         }
 
-        // timeframe=2h is a just-barely-hit.
+        // timeframe=2h just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "2h");
             let default_time = Utc.with_ymd_and_hms(1977, 1, 9, 0, 30, 0).unwrap();
@@ -1189,7 +1224,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, Vec::new());
         }
 
-        // timeframe=120min is a just-barely-hit.
+        // timeframe=120m just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "120m");
             let default_time = Utc.with_ymd_and_hms(1977, 1, 9, 0, 30, 0).unwrap();
@@ -1205,7 +1240,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, expected_agg_result);
         }
 
-        // timeframe=119min just barely does not hit.
+        // timeframe=119m just barely does not hit.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "119m");
             let mut expected_count = HashMap::new();
@@ -1223,7 +1258,7 @@ mod tests {
             test_create_recstr_std("3", "1977-01-20T00:30:00Z"),
         ];
 
-        // timeframe=11d is a just-barely-hit.
+        // timeframe=11d just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "11d");
             let default_time = Utc.with_ymd_and_hms(1977, 1, 9, 0, 30, 0).unwrap();
@@ -1248,7 +1283,7 @@ mod tests {
         }
     }
 
-    // In evtx, seconds with decimal points may be specified, so verify that this is correctly handled.
+    // evtx timestamps may contain fractional seconds, so verify they are handled correctly.
     #[test]
     fn test_count_timeframe_milsecs() {
         let recs = vec![
@@ -1257,7 +1292,7 @@ mod tests {
             test_create_recstr_std("3", "2021-12-21T10:40:10.0003000Z"),
         ];
 
-        // timeframe=11sec is a just-barely-hit.
+        // timeframe=11s just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "11s");
             let default_time = Utc.with_ymd_and_hms(2021, 12, 21, 10, 40, 0).unwrap();
@@ -1273,7 +1308,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, expected_agg_result);
         }
 
-        // timeframe=10d just barely does not hit.
+        // timeframe=10s just barely does not hit.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "10s");
             let mut expected_count = HashMap::new();
@@ -1282,7 +1317,7 @@ mod tests {
         }
     }
 
-    // In evtx, seconds with decimal points may be specified, so verify that this is correctly handled.
+    // evtx timestamps may contain fractional seconds, so verify they are handled correctly.
     #[test]
     fn test_count_timeframe_milsecs2() {
         let recs = vec![
@@ -1291,7 +1326,7 @@ mod tests {
             test_create_recstr_std("3", "2021-12-21T10:40:10.0400000Z"),
         ];
 
-        // timeframe=10sec is a just-barely-hit.
+        // timeframe=10s just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "10s");
             let default_time = DateTime::<Utc>::from_naive_utc_and_offset(
@@ -1313,7 +1348,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, expected_agg_result);
         }
 
-        // timeframe=10d just barely does not hit.
+        // timeframe=9s just barely does not hit.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "9s");
             let mut expected_count = HashMap::new();
@@ -1322,7 +1357,7 @@ mod tests {
         }
     }
 
-    // In evtx, seconds with decimal points may be specified, so verify that this is correctly handled.
+    // evtx timestamps may contain fractional seconds, so verify they are handled correctly.
     #[test]
     fn test_count_timeframe_milsecs3() {
         let recs = vec![
@@ -1331,7 +1366,7 @@ mod tests {
             test_create_recstr_std("3", "2021-12-21T10:40:10.0600000Z"),
         ];
 
-        // timeframe=11sec is a just-barely-hit.
+        // timeframe=11s just barely hits.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "11s");
             let default_time = DateTime::<Utc>::from_naive_utc_and_offset(
@@ -1353,7 +1388,7 @@ mod tests {
             check_count(&rule_str, &recs, expected_count, expected_agg_result);
         }
 
-        // timeframe=10d just barely does not hit.
+        // timeframe=10s just barely does not hit.
         {
             let rule_str = create_std_rule("count(EventID) >= 3", "10s");
             let mut expected_count = HashMap::new();
@@ -1424,11 +1459,10 @@ mod tests {
         }
     }
 
-    // Inspection of timeframe.
-    // timeframe=2h, and after the pipe: count(EventID) >= 3.
+    // Timeframe inspection: timeframe=2h with `count(EventID) >= 3` after the pipe.
     //
-    // In this case, the first 3 rows should not be detected, but rows 2 through 4 should be detected.
-    // Check patterns that detect starting from the middle rather than from the first row.
+    // Here the first 3 rows should not be detected, but rows 2 through 4 should be.
+    // Checks the pattern where detection starts in the middle rather than at the first row.
     // 0:30 EventID=1
     // 1:30 EventID=1
     // 2:30 EventID=2
@@ -1461,7 +1495,7 @@ mod tests {
         check_count(&rule_str, &recs, expected_count, expected_agg_result);
     }
 
-    // Never quite detects.
+    // Comes close but never detects: every 2h window holds only 2 distinct EventIDs.
     #[test]
     fn test_count_timeframe2() {
         let recs = vec![
@@ -1514,8 +1548,9 @@ mod tests {
         }
     }
 
-    // No sentinel is placed in the count implementation; check that it works correctly.
-    // Check that no error occurs when the timeframe of all hit records is narrower than the condition timeframe.
+    // The count implementation places no sentinel at the end of the data; check it still works.
+    // Verify that no error occurs when the time span of all matching records is narrower than the
+    // rule's timeframe.
     #[test]
     fn test_count_sentinel() {
         let recs = vec![
@@ -1550,8 +1585,8 @@ mod tests {
         }
     }
 
-    // There are 4 types of EventIDs from 1:30 to 4:30, and 4 types from 2:30 to 5:30,
-    // Verify that once 4 types are found from 1:30 to 4:30, counting restarts from 5:30.
+    // There are 4 distinct EventIDs from 1:30 to 4:30, and likewise 4 from 2:30 to 5:30.
+    // Verify that once 4 distinct values are found in 1:30-4:30, counting restarts from 5:30.
     #[test]
     fn test_count_timeframe_reset() {
         let recs = vec![
@@ -1617,10 +1652,9 @@ mod tests {
         }
     }
 
-    // Inspection of timeframe.
-    // timeframe=2h, and after the pipe: count(EventID) >= 3.
+    // Timeframe inspection: timeframe=2h with `count(EventID) >= 3` after the pipe.
     //
-    // When the test_count_timeframe() pattern repeats twice.
+    // The test_count_timeframe1() pattern repeated twice.
     #[test]
     fn test_count_timeframe_twice() {
         let recs = vec![
@@ -1705,7 +1739,8 @@ mod tests {
             .replace("${TIME_FRAME}", timeframe)
     }
 
-    /// Test function to verify target numbers for count.
+    /// Test helper: runs the rule against the given records, then asserts both the per-key
+    /// countdata sizes and the resulting AggResults against the expected values.
     fn check_count(
         rule_str: &str,
         records_str: &[String],
@@ -1768,7 +1803,8 @@ mod tests {
         }
         for agg_result in agg_results {
             println!("{}", &agg_result.start_timedate);
-            // Storage of start_timedate has already been verified here.
+            // The unwrap doubles as the check that start_timedate was stored correctly:
+            // binary_search fails if it is not among the expected values.
             let index = expect_start_timedate
                 .binary_search(&agg_result.start_timedate)
                 .unwrap();
@@ -1776,8 +1812,10 @@ mod tests {
             assert_eq!(agg_result.key, expect_key[index]);
             assert!(agg_result.field_values.len() == expect_field_values[index].len());
             for expect_field_value in &expect_field_values[index] {
-                // Depending on the test, the array order may differ from expected due to timeframe values and field values, so verify the array length and then check whether each expected element exists.
-                // The order of field elements is not relevant for subsequent processing.
+                // Depending on the test, timeframe values and field values can make the array
+                // order differ from the expectation, so verify the array length and then check
+                // that each expected element exists. The order of the field elements does not
+                // matter for subsequent processing.
                 assert!(agg_result.field_values.contains(expect_field_value));
             }
         }

--- a/src/detections/rule/fast_match.rs
+++ b/src/detections/rule/fast_match.rs
@@ -2,16 +2,20 @@ use crate::detections::configs::WINDASH_CHARACTERS;
 use crate::detections::rule::matchers::PipeElement;
 use crate::detections::utils;
 
-// Since regex matching is slow, this enum is used to match using the faster std::string methods: len/starts_with/ends_with/contains.
+/// Since regex matching is slow, patterns that allow it are instead matched with the faster
+/// std::string methods (len/starts_with/ends_with/contains) via this enum.
 #[derive(PartialEq, Debug)]
 pub enum FastMatch {
     Exact(String),
     StartsWith(String),
     EndsWith(String),
     Contains(String),
+    // Produced by a leading "|all" modifier (a key such as "|all" with no field name); matched
+    // the same way as Contains, but kept distinct so that callers can tell the two apart.
     AllOnly(String),
 }
 
+/// ASCII case-insensitive string equality.
 pub fn eq_ignore_case(event_value_str: &str, match_str: &str) -> bool {
     if match_str.len() == event_value_str.len() {
         return match_str.eq_ignore_ascii_case(event_value_str);
@@ -19,6 +23,8 @@ pub fn eq_ignore_case(event_value_str: &str, match_str: &str) -> bool {
     false
 }
 
+/// ASCII case-insensitive starts_with. Returns None when the event value is not pure ASCII, in
+/// which case the caller has to fall back to a regex match.
 pub fn starts_with_ignore_case(event_value_str: &str, match_str: &str) -> Option<bool> {
     let len = match_str.len();
     if len > event_value_str.len() {
@@ -32,6 +38,8 @@ pub fn starts_with_ignore_case(event_value_str: &str, match_str: &str) -> Option
     None
 }
 
+/// ASCII case-insensitive ends_with. Returns None when the event value is not pure ASCII, in
+/// which case the caller has to fall back to a regex match.
 pub fn ends_with_ignore_case(event_value_str: &str, match_str: &str) -> Option<bool> {
     let len1 = match_str.len();
     let len2 = event_value_str.len();
@@ -46,17 +54,27 @@ pub fn ends_with_ignore_case(event_value_str: &str, match_str: &str) -> Option<b
     None
 }
 
-// Function to convert wildcard matching to the faster std::string methods: len/starts_with/ends_with.
+/// Converts a wildcard pattern to FastMatch operations backed by the faster std::string methods
+/// (len/starts_with/ends_with/contains) where possible, returning None for patterns that only
+/// the regex engine can handle. When `ignore_case` is true, Contains/AllOnly patterns are stored
+/// lowercased and check_fast_match() lowercases the event value before comparing;
+/// Exact/StartsWith/EndsWith compare ASCII case-insensitively at match time instead.
 pub fn convert_to_fast_match(s: &str, ignore_case: bool) -> Option<Vec<FastMatch>> {
     let wildcard_count = s.chars().filter(|c| *c == '*').count();
+    // A pattern ending in \* is a literal asterisk rather than a wildcard, whereas \\* is an
+    // escaped backslash followed by a wildcard.
     let is_literal_asterisk = |s: &str| s.ends_with(r"\*") && !s.ends_with(r"\\*");
     if utils::contains_str(s, "?")
         || s.ends_with(r"\\\*")
         || (!s.is_ascii() && utils::contains_str(s, "*"))
     {
-        // Patterns that cannot be converted to fast matching use regex match only.
+        // Patterns that fast matching cannot express use the regex match only: '?' wildcards,
+        // a literal backslash followed by a literal asterisk at the end, and non-ASCII patterns
+        // that contain wildcards.
         return None;
     } else if s.starts_with("allOnly*") && s.ends_with('*') && wildcard_count == 2 {
+        // "allOnly*" is the sentinel prefix added by create_fast_match() for the "|all" modifier:
+        // strip it (8 chars) and the trailing '*', and unescape doubled backslashes.
         let removed_asterisk = s[8..(s.len() - 1)].replace(r"\\", r"\");
         if ignore_case {
             return Some(vec![FastMatch::AllOnly(removed_asterisk.to_lowercase())]);
@@ -82,13 +100,19 @@ pub fn convert_to_fast_match(s: &str, ignore_case: bool) -> Option<Vec<FastMatch
             s[..(s.len() - 1)].replace(r"\\", r"\"),
         )]);
     } else if utils::contains_str(s, "*") {
-        // Patterns where * appears in positions other than the beginning or end cannot be converted to starts_with/ends_with, so use regex match only.
+        // Patterns with * in the middle cannot be converted to starts_with/ends_with, so use the
+        // regex match only.
         return None;
     }
-    // If * is not included, convert to string length match.
+    // If the pattern contains no wildcard at all, it is an exact (case-insensitive) match.
     Some(vec![FastMatch::Exact(s.replace(r"\\", r"\"))])
 }
 
+/// Evaluates the fast matchers against a field value. Returns None when the fast path cannot
+/// decide (a non-ASCII value in a starts_with/ends_with comparison); the caller then falls back
+/// to the regex match. A matcher list with more than one element holds alternative variants of a
+/// single pattern (windash dash replacements or base64offset alignments), so any one Contains hit
+/// is a match; base64 is case-sensitive, which is why that branch compares without lowercasing.
 pub fn check_fast_match(
     pipes: &[PipeElement],
     event_value_str: &str,
@@ -113,6 +137,8 @@ pub fn check_fast_match(
                 }
             }
             FastMatch::Contains(s) | FastMatch::AllOnly(s) => {
+                // For windash, compare with the value's first dash-like character replaced by
+                // "/", mirroring how the windash pattern variants were generated.
                 if pipes.contains(&PipeElement::Windash) {
                     Some(utils::contains_str(
                         &event_value_str
@@ -141,11 +167,15 @@ pub fn check_fast_match(
                     utils::contains_str(event_value_str, s)
                 }
             }
+            // Variant lists are only ever built from Contains entries.
             _ => false,
         }))
     }
 }
 
+/// Builds the fast matcher for a field with a single leading pipe modifier by rewriting the
+/// pattern into the wildcard form understood by convert_to_fast_match(). "allOnly" uses the
+/// internal "allOnly*" sentinel prefix, which is not Sigma syntax.
 pub fn create_fast_match(pipes: &[PipeElement], pattern: &[String]) -> Option<Vec<FastMatch>> {
     if let Some(element) = pipes.first() {
         match element {

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -17,22 +17,24 @@ use crate::detections::rule::fast_match::{
 use crate::detections::{detection::EvtxRecordInfo, utils};
 use downcast_rs::Downcast;
 
-// Represents the logic for comparing EventLog values at leaf nodes.
-// A class implementing this trait exists for each comparison logic, such as regex matching and character count limits.
-//
-// When creating a new class that implements LeafMatcher,
-// add an instance of the newly created class to the return value array of the get_matchers method of LeafSelectionNode.
+/// Represents the logic for comparing event log values at leaf nodes.
+/// A class implementing this trait exists for each kind of comparison logic, such as regex
+/// matching and character count limits.
+///
+/// When creating a new class that implements LeafMatcher,
+/// add an instance of the newly created class to the array returned by
+/// LeafSelectionNode::get_matchers().
 pub trait LeafMatcher: Downcast + Send + Sync {
     /// Determines whether this is a LeafMatcher matching the specified key_list.
     fn is_target_key(&self, key_list: &Nested<String>) -> bool;
 
-    /// Determines whether the JSON-format data specified as an argument matches.
-    /// Windows Event Log is converted to JSON format in main.rs, and that JSON-format Windows event log data comes here.
-    /// For example, for logic that matches using regex, write the regex matching process here.
+    /// Determines whether the given event value matches. The value comes from the Windows event
+    /// record after conversion to JSON in main.rs; e.g. a regex-based matcher performs its regex
+    /// matching here.
     fn is_match(&self, event_value: Option<&String>, recinfo: &EvtxRecordInfo) -> bool;
 
-    /// Describe the initialization logic here.
-    /// If parsing from the rule file fails due to an incorrect rule file format, etc., return an error in the Result return type.
+    /// Initializes the matcher from the rule file. Returns Err with parse error messages when
+    /// the rule file format is invalid.
     fn init(&mut self, key_list: &Nested<String>, select_value: &Yaml) -> Result<(), Vec<String>>;
 }
 downcast_rs::impl_downcast!(LeafMatcher);
@@ -189,8 +191,8 @@ impl LeafMatcher for AllowlistFileMatcher {
     }
 }
 
-/// Default match class.
-/// Handling wildcards and pipes.
+/// Default match class, used when no special matcher (min_length/regexes/allowlist) applies.
+/// Handles wildcards and pipes.
 pub struct DefaultMatcher {
     re: Option<Vec<Regex>>,
     fast_match: Option<Vec<FastMatch>>,
@@ -208,20 +210,26 @@ impl DefaultMatcher {
         }
     }
 
+    /// Returns the field name referenced by an equalsfield/endswithfield/fieldref-style pipe,
+    /// if this matcher uses one.
     pub fn get_eqfield_key(&self) -> Option<&String> {
         let pipe = self.pipes.first()?;
         pipe.get_eqfield()
     }
 
-    /// Determines whether this matcher matches the given regex.
+    /// Returns true if the value matches any of this matcher's compiled regexes.
+    /// Note that Regex::is_match() performs a substring search, so any anchoring must be
+    /// expressed in the pattern itself.
     fn is_regex_fullmatch(&self, value: &str) -> bool {
         self.re.as_ref().unwrap().iter().any(|x| x.is_match(value))
     }
 
-    /// Converts the field name in Hayabusa rule files and the pipe specified after it to a regex-format string.
-    /// Processing to convert wildcard strings to regex is also implemented in this method. Specify the wildcard string in pattern and PipeElement::Wildcard in pipes.
+    /// Converts a rule value (pattern) into a regex string by applying, in order, the pipes
+    /// specified after the field name in the rule file.
+    /// Wildcard-to-regex conversion is also implemented through this method: pass the wildcard
+    /// string as `pattern` and include PipeElement::Wildcard in `pipes`.
     fn from_pattern_to_regex_str(pattern: String, pipes: &[PipeElement]) -> String {
-        // Process the pattern with Pipe.
+        // Process the pattern with each pipe.
         pipes
             .iter()
             .fold(pattern, |acc, pipe| pipe.pipe_pattern(acc))
@@ -245,7 +253,7 @@ impl LeafMatcher for DefaultMatcher {
             return Ok(());
         }
 
-        // patternをパースする
+        // Parse the pattern.
         let yaml_value = match select_value {
             Yaml::Boolean(b) => Some(b.to_string()),
             Yaml::Integer(i) => Some(i.to_string()),
@@ -262,23 +270,29 @@ impl LeafMatcher for DefaultMatcher {
         }
         let mut pattern = Vec::new();
         pattern.push(yaml_value.unwrap());
-        // Pipeが指定されていればパースする
+        // If pipes are specified, parse them.
         let emp = String::default();
-        // 一つ目はただのキーで、2つめ以降がpipe
+        // The first element is just the field key; the second and subsequent elements are pipes.
 
         let mut keys_all: Vec<&str> = key_list.get(0).unwrap_or(&emp).split('|').collect(); // key_list cannot be empty.
 
-        // Correspondence between all and allOnly.
+        // Maps shorthand pipe names to the internal names accepted by PipeElement::new():
+        // "all" -> "allOnly" (for a leading "|all" key) and the regex flags "i"/"m"/"s" ->
+        // "reignorecase"/"remultiline"/"resingleline".
         let mut change_map: HashMap<&str, &str> = HashMap::new();
         change_map.insert("all", "allOnly");
         change_map.insert("i", "reignorecase");
         change_map.insert("m", "remultiline");
         change_map.insert("s", "resingleline");
 
-        // Detect the case where | is at the beginning, and change all -> allOnly.
+        // Detect the case where "|" is at the beginning of the key (no field name, e.g. "|all"),
+        // and rename all -> allOnly.
         if keys_all[0].is_empty() && keys_all.len() == 2 && keys_all[1] == "all" {
             keys_all[1] = change_map["all"];
         }
+        // Collapse two-part modifiers into a single pipe name so that each remaining element maps
+        // to exactly one PipeElement: "re|i"/"re|m"/"re|s" become the corresponding regex-flag
+        // pipes, and "fieldref|startswith" etc. become the dedicated fieldref pipes.
         if keys_all.len() >= 3 {
             if keys_all[1] == "re" {
                 if keys_all[2] == "i" {
@@ -303,7 +317,7 @@ impl LeafMatcher for DefaultMatcher {
 
         let keys_without_head = &keys_all[1..];
 
-        let mut err_msges = vec![];
+        let mut err_msgs = vec![];
         for key in keys_without_head.iter() {
             let pipe_element = PipeElement::new(key, &pattern[0], key_list);
             match pipe_element {
@@ -311,19 +325,19 @@ impl LeafMatcher for DefaultMatcher {
                     self.pipes.push(element);
                 }
                 Err(e) => {
-                    err_msges.push(e);
+                    err_msgs.push(e);
                 }
             }
         }
-        if !err_msges.is_empty() {
-            return Err(err_msges);
+        if !err_msgs.is_empty() {
+            return Err(err_msgs);
         }
         let n = self.pipes.len();
         if n == 0 {
             // Case without pipe.
             self.fast_match = convert_to_fast_match(&pattern[0], true);
         } else if n == 1 {
-            // Case with pipe.
+            // Case with a single pipe.
             self.fast_match = create_fast_match(&self.pipes, &pattern);
         } else if n == 2 {
             if self.pipes[0] == PipeElement::Base64 && self.pipes[1] == PipeElement::Contains {
@@ -334,15 +348,18 @@ impl LeafMatcher for DefaultMatcher {
             } else if self.pipes[0] == PipeElement::Base64offset
                 && self.pipes[1] == PipeElement::Contains
             {
-                self.fast_match = convert_to_base64_str(None, pattern[0].as_str(), &mut err_msges);
+                self.fast_match = convert_to_base64_str(None, pattern[0].as_str(), &mut err_msgs);
             } else if self.pipes[0] == PipeElement::Contains && self.pipes[1] == PipeElement::All
-            // For |contains|all, it has been designated as AndSelectionNode in a prior branch, so treat it as contains only here.
+            // |contains|all was already turned into an AndSelectionNode during parsing
+            // (rule/mod.rs), so treat it as a plain contains here.
             {
                 self.fast_match = convert_to_fast_match(format!("*{}*", pattern[0]).as_str(), true);
             } else if self.pipes[0] == PipeElement::Contains
                 && self.pipes[1] == PipeElement::Windash
             {
-                // For |contains|windash
+                // For |contains|windash: also match a variant of the pattern whose first
+                // dash-like character (hyphen, en/em dash, etc.) is replaced with "/", to cover
+                // the interchangeable option prefixes accepted by Windows commands.
                 let mut fastmatches =
                     convert_to_fast_match(format!("*{}*", pattern[0]).as_str(), true)
                         .unwrap_or_default();
@@ -370,7 +387,8 @@ impl LeafMatcher for DefaultMatcher {
             if self.pipes.contains(&PipeElement::Contains)
                 && self.pipes.contains(&PipeElement::All)
                 && self.pipes.contains(&PipeElement::Windash)
-            // For |contains|all|windash, it has been designated as AndSelectionNode in a prior branch, so treat it as contains and windash only here.
+            // |contains|all|windash was already turned into an AndSelectionNode during parsing
+            // (rule/mod.rs), so treat it as contains plus windash here.
             {
                 let mut fastmatches =
                     convert_to_fast_match(format!("*{}*", pattern[0]).as_str(), true)
@@ -395,6 +413,11 @@ impl LeafMatcher for DefaultMatcher {
                     || self.pipes[1] == PipeElement::Base64)
                 && self.pipes[2] == PipeElement::Contains
             {
+                // Encoding modifiers such as |utf16|base64offset|contains: the pattern is first
+                // encoded as UTF-16, then base64-encoded, and searched with contains.
+                // With base64offset, all three byte-alignment variants are generated, and plain
+                // |utf16| tries both byte orders; with base64, a single encoding is used
+                // (|utf16| meaning UTF-16LE with a BOM).
                 if self.pipes[1] == PipeElement::Base64offset {
                     let encode = &self.pipes[0];
                     let org_str = pattern[0].as_str();
@@ -402,12 +425,12 @@ impl LeafMatcher for DefaultMatcher {
                         let utf16_le_match = convert_to_base64_str(
                             Some(&PipeElement::Utf16Le),
                             org_str,
-                            &mut err_msges,
+                            &mut err_msgs,
                         );
                         let utf16_be_match = convert_to_base64_str(
                             Some(&PipeElement::Utf16Be),
                             org_str,
-                            &mut err_msges,
+                            &mut err_msgs,
                         );
                         if let Some(utf16_le_match) = utf16_le_match
                             && let Some(utf16_be_match) = utf16_be_match
@@ -418,7 +441,7 @@ impl LeafMatcher for DefaultMatcher {
                         }
                     } else {
                         self.fast_match =
-                            convert_to_base64_str(Some(encode), org_str, &mut err_msges);
+                            convert_to_base64_str(Some(encode), org_str, &mut err_msgs);
                     }
                 } else if self.pipes[1] == PipeElement::Base64 {
                     let encode = &self.pipes[0];
@@ -452,6 +475,7 @@ impl LeafMatcher for DefaultMatcher {
                 }
             }
         } else {
+            // Four or more pipes are not supported.
             let errmsg = format!(
                 "Multiple pipe elements cannot be used. key:{}",
                 utils::concat_selection_key(key_list)
@@ -465,7 +489,9 @@ impl LeafMatcher for DefaultMatcher {
             )
             && !self.key_list.is_empty()
         {
-            // Regex is not needed when replaced with FastMatch::Exact/Contains search.
+            // No regex needs to be compiled when the pattern was fully replaced with a
+            // FastMatch::Exact/Contains search. (Grep searches with an empty key list still need
+            // the regex, so they are excluded here.)
             return Ok(());
         }
         let is_eqfield = self.pipes.iter().any(|pipe_element| {
@@ -480,8 +506,9 @@ impl LeafMatcher for DefaultMatcher {
             )
         });
         if !is_eqfield {
-            // If it is not a regex, it represents a wildcard.
-            // Wildcards are matched using regex, so internally add a Pipe that converts wildcards to regex.
+            // If the pattern is not a regex (no |re pipe), it is interpreted as a wildcard
+            // expression. Wildcards are matched using regex internally, so append a pipe that
+            // converts the wildcard string into a regex.
             let is_re = self.pipes.iter().any(|pipe_element| {
                 matches!(
                     pipe_element,
@@ -498,7 +525,7 @@ impl LeafMatcher for DefaultMatcher {
             let mut re_result_vec = vec![];
             for p in pattern {
                 let pattern = DefaultMatcher::from_pattern_to_regex_str(p, &self.pipes);
-                // Convert the pattern processed by Pipe to regex.
+                // Compile the pipe-processed pattern into a regex.
                 if let Ok(re_result) = Regex::new(&pattern) {
                     re_result_vec.push(re_result);
                 } else {
@@ -516,6 +543,8 @@ impl LeafMatcher for DefaultMatcher {
 
     fn is_match(&self, event_value: Option<&String>, recinfo: &EvtxRecordInfo) -> bool {
         let pipe: &PipeElement = self.pipes.first().unwrap_or(&PipeElement::Wildcard);
+        // Pipes that implement their own matching (cidr, exists, field references and numeric
+        // comparisons) are handled first; all other kinds fall through to fast match/regex.
         let match_result = match pipe {
             PipeElement::Cidr(ip_result) => match ip_result {
                 Ok(matcher_ip) => {
@@ -524,10 +553,10 @@ impl LeafMatcher for DefaultMatcher {
                     let event_ip = IpAddr::from_str(event_value_str);
                     match event_ip {
                         Ok(target_ip) => Some(matcher_ip.contains(&target_ip)),
-                        Err(_) => Some(false), // For formats other than IP addresses.
+                        Err(_) => Some(false), // The event value is not an IP address.
                     }
                 }
-                Err(_) => Some(false), // For formats other than IP addresses.
+                Err(_) => Some(false), // The rule's cidr value is not a valid CIDR range.
             },
             PipeElement::Exists(..)
             | PipeElement::EqualsField(_)
@@ -551,7 +580,7 @@ impl LeafMatcher for DefaultMatcher {
                         };
                         Some(cmp_result)
                     }
-                    Err(_) => Some(false), // For non-numeric values.
+                    Err(_) => Some(false), // The event value is not numeric.
                 }
             }
             _ => None,
@@ -560,15 +589,15 @@ impl LeafMatcher for DefaultMatcher {
             return result;
         }
 
-        // If null is set in yaml.
-        // If keylist is empty (== JSON grep search), ignore.
+        // If null is set in the yaml and the key list is empty (i.e. a grep-style search over the
+        // whole record), there is nothing to match against, so never detect.
         if self.key_list.is_empty() && self.re.is_none() && self.fast_match.is_none() {
             return false;
         }
 
-        // If null is set in yaml.
+        // If null is set in the yaml.
         if self.re.is_none() && self.fast_match.is_none() {
-            // If the target field does not exist in the record, treat it as detected.
+            // A null value matches when the target field does not exist in the record.
             for v in self.key_list.iter() {
                 if recinfo.get_value(v).is_none() {
                     return true;
@@ -596,12 +625,13 @@ impl LeafMatcher for DefaultMatcher {
                 return is_match;
             }
         }
-        // If it could not be converted to character count/starts_with/ends_with search, compare using regex match.
+        // Fall back to a regex match when the pattern could not be handled by the fast match path
+        // (exact/starts_with/ends_with/contains).
         self.is_regex_fullmatch(event_value_str)
     }
 }
 
-/// Class representing elements specified by pipes (|).
+/// Represents the modifiers specified after pipes (|) in a rule field key.
 /// Needs refactoring.
 #[derive(PartialEq)]
 pub enum PipeElement {
@@ -709,8 +739,8 @@ impl PipeElement {
             _ => None,
         };
 
-        if let Some(elment) = pipe_element {
-            Ok(elment)
+        if let Some(element) = pipe_element {
+            Ok(element)
         } else {
             Err(format!(
                 "An unknown pipe element was specified. key:{}",
@@ -738,7 +768,7 @@ impl PipeElement {
             }
             PipeElement::EqualsField(eq_key) | PipeElement::FieldRef(eq_key) => {
                 let eq_value = recinfo.get_value(eq_key);
-                // If an eventkey specified does not exist in the Evtx record, set to false.
+                // If the specified event key does not exist in the evtx record, return false.
                 if event_value.is_none() || eq_value.is_none() {
                     return false;
                 }
@@ -755,7 +785,7 @@ impl PipeElement {
             }
             PipeElement::Endswithfield(eq_key) | PipeElement::FieldRefEndswith(eq_key) => {
                 let ends_value = recinfo.get_value(eq_key);
-                // If an eventkey specified does not exist in the Evtx record, set to false.
+                // If the specified event key does not exist in the evtx record, return false.
                 if event_value.is_none() || ends_value.is_none() {
                     return false;
                 }
@@ -777,9 +807,10 @@ impl PipeElement {
         }
     }
 
-    /// Processes the pattern with pipe.
+    /// Applies this pipe's transformation to the pattern.
     fn pipe_pattern(&self, pattern: String) -> String {
-        // When implementing polymorphism with an enum, all type implementations go into one method. For Java developers, this might feel odd.
+        // When implementing polymorphism with an enum, every variant's implementation ends up in a
+        // single method. This may feel odd to developers used to Java-style class hierarchies.
         let fn_add_asterisk_end = |patt: String| {
             if patt.ends_with("//*") {
                 patt
@@ -788,8 +819,9 @@ impl PipeElement {
             } else if patt.ends_with('*') {
                 patt
             } else if patt.ends_with('\\') {
-                // If the end is \ (one backslash), convert the end to \\* (two backslashes and an asterisk).
-                // A trailing \\* means one backslash followed by a wildcard pattern.
+                // If the pattern ends with \ (a single backslash), turn the ending into \\*
+                // (two backslashes and an asterisk): in wildcard notation a trailing \\* means a
+                // literal backslash followed by the * wildcard.
                 patt + "\\*"
             } else {
                 patt + "*"
@@ -824,7 +856,8 @@ impl PipeElement {
     }
 
     /// Pipe processing for PipeElement::Wildcard.
-    /// This processing could be included in pipe_pattern(), but became complex so it was separated into a separate function.
+    /// This processing could have been included in pipe_pattern(), but it became complex, so it
+    /// was split out into its own function.
     fn pipe_pattern_wildcard(pattern: String) -> String {
         let wildcards = vec!["*", "?"];
 
@@ -861,7 +894,8 @@ impl PipeElement {
                     break;
                 }
             }
-            // If hit in the above For loop, continue.
+            // If one of the wildcard branches above matched, idx has already been advanced, so
+            // continue with the next chunk.
             if prev_idx != idx {
                 continue;
             }
@@ -886,7 +920,9 @@ impl PipeElement {
                     // If not a wildcard, return the escaped string.
                     regex::escape(pattern)
                 } else {
-                    // When it is a wildcard.、"*"は".*"という正規表現に変換し、"?"は"."に変換する。
+                    // When it is a wildcard, convert "*" into a ".*"-style regex (an alternation
+                    // that additionally matches the newline, which "." alone does not) and convert
+                    // "?" into ".".
                     let wildcard_regex_value = if *pattern == "*" {
                         "(.|\\a|\\f|\\t|\\n|\\r|\\v)*"
                     } else {
@@ -899,8 +935,8 @@ impl PipeElement {
             },
         );
 
-        // sigma wildcards are case insensitive.
-        // Therefore, prepend a symbol indicating case insensitivity to the regex.
+        // Sigma wildcards are case-insensitive.
+        // Therefore, prepend the case-insensitive flag to the regex.
         "(?i)".to_string() + &ret
     }
 }
@@ -961,7 +997,7 @@ mod tests {
 
     #[test]
     fn test_rule_parse() {
-        // ルールファイルをYAML形式で読み込み
+        // Load the rule file in YAML format.
         let rule_str = r#"
         title: PowerShell Execution Pipeline
         description: hogehoge
@@ -991,19 +1027,19 @@ mod tests {
         let selection_node = &rule_node.detection.name_to_selection["selection"];
 
         // Root
-        let detection_childs = selection_node.get_childs();
-        assert_eq!(detection_childs.len(), 4);
+        let detection_children = selection_node.get_children();
+        assert_eq!(detection_children.len(), 4);
 
         // Channel
         {
             // Verify that LeafSelectionNode is correctly loaded.
-            let child_node = detection_childs[0];
+            let child_node = detection_children[0];
             assert!(child_node.is::<LeafSelectionNode>());
             let child_node = child_node.downcast_ref::<LeafSelectionNode>().unwrap();
             assert_eq!(child_node.get_key(), "Channel");
-            assert_eq!(child_node.get_childs().len(), 0);
+            assert_eq!(child_node.get_children().len(), 0);
 
-            // Verify that the comparison regex is correct.
+            // Verify that the comparison matcher is correct.
             let matcher = &child_node.matcher;
             assert!(matcher.is_some());
             let matcher = child_node.matcher.as_ref().unwrap();
@@ -1023,13 +1059,13 @@ mod tests {
         // EventID
         {
             // Verify that LeafSelectionNode is correctly loaded.
-            let child_node = detection_childs[1] as &dyn SelectionNode;
+            let child_node = detection_children[1] as &dyn SelectionNode;
             assert!(child_node.is::<LeafSelectionNode>());
             let child_node = child_node.downcast_ref::<LeafSelectionNode>().unwrap();
             assert_eq!(child_node.get_key(), "EventID");
-            assert_eq!(child_node.get_childs().len(), 0);
+            assert_eq!(child_node.get_children().len(), 0);
 
-            // Verify that the comparison regex is correct.
+            // Verify that the comparison matcher is correct.
             let matcher = &child_node.matcher;
             assert!(matcher.is_some());
             let matcher = child_node.matcher.as_ref().unwrap();
@@ -1041,10 +1077,10 @@ mod tests {
         // ContextInfo
         {
             // Verify that OrSelectionNode is correctly loaded.
-            let child_node = detection_childs[2] as &dyn SelectionNode;
+            let child_node = detection_children[2] as &dyn SelectionNode;
             assert!(child_node.is::<OrSelectionNode>());
             let child_node = child_node.downcast_ref::<OrSelectionNode>().unwrap();
-            let ancestors = child_node.get_childs();
+            let ancestors = child_node.get_children();
             assert_eq!(ancestors.len(), 2);
 
             // Test patterns where LeafSelectionNode is under OrSelectionNode.
@@ -1065,7 +1101,8 @@ mod tests {
                 vec![FastMatch::Exact("Host Application".to_string())]
             );
 
-            // Verify that the host application node, which is a LeafSelectionNode, is correct.
+            // Verify that the Japanese-locale host application node, which is a LeafSelectionNode,
+            // is correct.
             let hostapp_jp_node = ancestors[1] as &dyn SelectionNode;
             assert!(hostapp_jp_node.is::<LeafSelectionNode>());
             let hostapp_jp_node = hostapp_jp_node.downcast_ref::<LeafSelectionNode>().unwrap();
@@ -1086,10 +1123,10 @@ mod tests {
         // ImagePath
         {
             // Verify that AndSelectionNode is correctly loaded.
-            let child_node = detection_childs[3] as &dyn SelectionNode;
+            let child_node = detection_children[3] as &dyn SelectionNode;
             assert!(child_node.is::<AndSelectionNode>());
             let child_node = child_node.downcast_ref::<AndSelectionNode>().unwrap();
-            let ancestors = child_node.get_childs();
+            let ancestors = child_node.get_children();
             assert_eq!(ancestors.len(), 3);
 
             // Verify that min-len is correctly loaded.
@@ -1120,7 +1157,7 @@ mod tests {
                     .downcast_ref::<RegexesFileMatcher>()
                     .unwrap();
 
-                // Verify that the content matches regexes.txt.
+                // Verify that the contents match the regexes file.
                 let csvcontent = &ancestor_matcher.regexes;
 
                 assert_eq!(csvcontent.len(), 16);
@@ -1134,7 +1171,7 @@ mod tests {
                 );
             }
 
-            // Verify that allowlist.txt can be loaded.
+            // Verify that the allowlist file can be loaded.
             {
                 let ancestor_node = ancestors[2] as &dyn SelectionNode;
                 assert!(ancestor_node.is::<LeafSelectionNode>());
@@ -1287,7 +1324,7 @@ mod tests {
 
     #[test]
     fn test_notdetect_regex_emptystr() {
-        // Verify that exact matching also works with string-like data.
+        // Verify that an empty string value does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1307,7 +1344,7 @@ mod tests {
 
     #[test]
     fn test_notdetect_minlen() {
-        // Verify that minlen is correctly detected.
+        // Verify that min_length does not match when the value is shorter.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1391,7 +1428,7 @@ mod tests {
 
     #[test]
     fn test_notdetect_minlen_and() {
-        // Verify that minlen is correctly detected.
+        // Verify that min_length does not match when the value is shorter.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1452,8 +1489,10 @@ mod tests {
 
     #[test]
     fn test_detect_regexes() {
-        // Verify that regexes.txt is correctly detected.
-        // In this case, the EventID matches, but since it matches the allowlist, it should not be detected.
+        // Verify that the allowlist file is correctly handled (despite the test name, the rule
+        // only uses an allowlist).
+        // In this case, the EventID matches, but since it matches the allowlist, it should not be
+        // detected.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2131,7 +2170,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pipe_pattern_wildcard_backshash() {
+    fn test_pipe_pattern_wildcard_backslash() {
         let value = PipeElement::pipe_pattern_wildcard(r"\\ho\\ge\\".to_string());
         assert_eq!(r"(?i)\\\\ho\\\\ge\\\\", value);
     }
@@ -2146,7 +2185,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pipe_pattern_wildcard_many_backshashs() {
+    fn test_pipe_pattern_wildcard_many_backslashes() {
         let value = PipeElement::pipe_pattern_wildcard(r"\\\*ho\\\*ge\\\".to_string());
         assert_eq!(
             r"(?i)\\\\(.|\a|\f|\t|\n|\r|\v)*ho\\\\(.|\a|\f|\t|\n|\r|\v)*ge\\\\\\",
@@ -2156,7 +2195,8 @@ mod tests {
 
     #[test]
     fn test_grep_match() {
-        // Wildcards match regardless of case.
+        // A selection written as a bare list (no field name) performs a grep-style match against
+        // the whole record.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2175,7 +2215,8 @@ mod tests {
 
     #[test]
     fn test_grep_not_match() {
-        // Wildcards match regardless of case.
+        // A grep-style match (bare list, no field name) does not match a record that does not
+        // contain the value.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2195,8 +2236,7 @@ mod tests {
 
     #[test]
     fn test_detect_value_keyword() {
-        // Also verify with string-like data.
-        // Since it is an exact match, verify that it does not match as a prefix.
+        // Verify that the "value:" keyword form matches exactly.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2217,8 +2257,8 @@ mod tests {
 
     #[test]
     fn test_notdetect_value_keyword() {
-        // Also verify with string-like data.
-        // Since it is an exact match, verify that it does not match as a prefix.
+        // Verify that the "value:" keyword form is an exact match: a similar but different
+        // value (rule "Securiteen" vs record "Security") does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2573,7 +2613,7 @@ mod tests {
 
     #[test]
     fn test_field_null() {
-        // Verify that the target field does not exist when the value is null.
+        // Verify that a null value matches when the target field does not exist in the record.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2595,7 +2635,8 @@ mod tests {
 
     #[test]
     fn test_field_null_not_detect() {
-        // Verify that the target field does not exist when the value is null.するテスト
+        // Test that a null value requires the target field to be absent: here the field exists,
+        // so the rule does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2671,7 +2712,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_converted_starts_with_shorter_val_notdetect() {
-        // When a single wildcard is at the end but the characters to compare have fewer characters, it does not match.
+        // When a single wildcard is at the end but the event value is shorter than the pattern,
+        // it does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2747,7 +2789,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_converted_ends_with_shorter_val_notdetect() {
-        // When a single wildcard is at the beginning but the characters to compare have fewer characters, it does not match.
+        // When a single wildcard is at the beginning, a value that does not end with the
+        // pattern's suffix does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2766,7 +2809,8 @@ mod tests {
 
     #[test]
     fn test_only_wildcard() {
-        // When there is only a wildcard, it is equivalent to ends_with matching.
+        // A pattern consisting of only a wildcard is converted to ends_with("") and therefore
+        // matches any value.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2804,7 +2848,7 @@ mod tests {
 
     #[test]
     fn test_base64_contains() {
-        // Match for base64|contains.
+        // A pattern that matches base64|contains.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2824,7 +2868,7 @@ mod tests {
 
     #[test]
     fn test_base64offset_contains() {
-        // Match for base64offset|contains.
+        // A pattern that matches base64offset|contains.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2844,7 +2888,7 @@ mod tests {
 
     #[test]
     fn test_base64offset_contains_not_match() {
-        // Match for base64offset|contains.しないパターン
+        // A pattern that does not match base64offset|contains.
         let rule_str = r#"
         enabled: true
         detection:
@@ -2940,7 +2984,7 @@ mod tests {
 
     #[test]
     fn test_cidr_ip_field_not_exists_not_detect() {
-        // IPs not matching CIDR.
+        // When the IP address field does not exist in the record, the rule does not match.
         let rule_str = r#"
         enabled: true
         detection:
@@ -3033,7 +3077,7 @@ mod tests {
           }
         }"#;
 
-        check_select(rule_str, record_json_str, false); //★ expect false
+        check_select(rule_str, record_json_str, false); // Expect false: the backslash must match literally.
     }
 
     #[test]

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -26,13 +26,26 @@ pub fn create_rule(rulepath: String, yaml: Yaml) -> RuleNode {
     RuleNode::new(rulepath, yaml)
 }
 
+/// The `correlation.type` of a Sigma correlation rule.
 #[derive(Debug, PartialEq, Eq)]
 pub enum CorrelationType {
+    /// Not a correlation rule (also used for unknown correlation types).
     None,
+    /// `event_count`: counts matching events per group.
     EventCount,
+    /// `value_count`: counts distinct field values per group.
     ValueCount,
+    /// `temporal`: all referenced rules (matched by id, title or name) must match within the
+    /// timespan, in any order.
     Temporal(Vec<String>),
+    /// `temporal_ordered`: like `temporal`, but the referenced rules are expected to occur in
+    /// the listed order (the current implementation only checks order relative to the first
+    /// referenced rule's results).
     TemporalOrdered(Vec<String>),
+    /// Assigned by the correlation parser (never by `CorrelationType::new`) to a rule that is
+    /// referenced by a temporal correlation rule. The bool is the correlation rule's `generate`
+    /// flag (whether the referenced rule's own matches are also output) and the String is the
+    /// rule id used to link its results to the temporal rule.
     TemporalRef(bool, String),
 }
 
@@ -58,6 +71,8 @@ impl CorrelationType {
                     CorrelationType::TemporalOrdered(rules)
                 }
             }
+            // Unknown correlation types map to None; the correlation parser later rejects such
+            // rules with a parse error, so they never match.
             _ => CorrelationType::None,
         }
     }
@@ -72,6 +87,8 @@ pub struct RuleNode {
     pub correlation_type: CorrelationType,
 }
 
+// Debug cannot be derived because DetectionNode holds `dyn SelectionNode` trait objects, so this
+// implementation intentionally produces no output.
 impl Debug for RuleNode {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Result::Ok(())
@@ -89,6 +106,8 @@ impl RuleNode {
         }
     }
 
+    /// Creates a RuleNode with a pre-built DetectionNode. Used by the correlation parser, which
+    /// assembles the detection from the rules referenced by a correlation rule.
     fn new_with_detection(
         rule_path: String,
         yaml_data: Yaml,
@@ -103,13 +122,16 @@ impl RuleNode {
         }
     }
 
+    /// Parses and validates the rule's detection section, collecting all error messages.
     pub fn init(&mut self, stored_static: &StoredStatic) -> Result<(), Vec<String>> {
         let mut errmsgs: Vec<String> = vec![];
+        // Correlation rules get their DetectionNode built later by
+        // correlation_parser::parse_correlation_rules, so there is nothing to initialize here.
         if !&self.yaml["correlation"].is_badvalue() {
             return Result::Ok(());
         }
 
-        // detection node initialization
+        // Initialize the detection node.
         let detection_result = self.detection.init(&self.yaml["detection"], stored_static);
         if let Err(err_detail) = detection_result {
             errmsgs.extend(err_detail);
@@ -122,6 +144,9 @@ impl RuleNode {
         }
     }
 
+    /// Evaluates this rule's condition against a single event record. When the record matches and
+    /// the rule has an aggregation condition (count etc.), the record is also registered in
+    /// countdata for later aggregation evaluation.
     pub fn select(
         &mut self,
         event_record: &EvtxRecordInfo,
@@ -142,11 +167,11 @@ impl RuleNode {
         }
         result
     }
-    /// Function that returns whether an aggregation condition exists.
+    /// Returns whether an aggregation condition exists.
     pub fn has_agg_condition(&self) -> bool {
         self.detection.aggregation_condition.is_some()
     }
-    /// Function that returns the results of the Aggregation Condition as an array.
+    /// Returns the results of evaluating the aggregation condition as an array.
     pub fn judge_satisfy_aggcondition(&self, stored_static: &StoredStatic) -> Vec<AggResult> {
         let mut ret = Vec::new();
         if !self.has_agg_condition() {
@@ -158,10 +183,11 @@ impl RuleNode {
         ));
         ret
     }
+    /// Returns whether any records have been accumulated for count aggregation.
     pub fn check_exist_countdata(&self) -> bool {
         !self.countdata.is_empty()
     }
-    /// Function to get the AggregationParseInfo (Aggregation Condition) within a rule.
+    /// Returns the AggregationParseInfo (aggregation condition) of this rule, if any.
     pub fn get_agg_condition(&self) -> Option<&AggregationParseInfo> {
         if self.detection.aggregation_condition.as_ref().is_some() {
             return self.detection.aggregation_condition.as_ref();
@@ -170,7 +196,8 @@ impl RuleNode {
     }
 }
 
-// Get the list of keys defined in the detection of RuleNode.
+/// Collects every field key referenced by the leaf selection nodes in the rule's detection
+/// section. These keys determine which values are extracted up front from each event record.
 pub fn get_detection_keys(node: &RuleNode) -> Nested<String> {
     let mut ret = Nested::<String>::new();
     let detection = &node.detection;
@@ -199,9 +226,13 @@ pub fn get_detection_keys(node: &RuleNode) -> Nested<String> {
 
 /// Node representing the detection of a Rule file.
 pub struct DetectionNode {
+    /// Compiled selection trees, keyed by their name under the detection node (e.g. "selection").
     pub name_to_selection: HashMap<String, Arc<Box<dyn SelectionNode>>>,
+    /// The condition expression compiled into a single selection tree.
     pub condition: Option<Box<dyn SelectionNode>>,
+    /// The aggregation part of the condition (after the pipe), e.g. `count() by field > 3`.
     pub aggregation_condition: Option<AggregationParseInfo>,
+    /// The parsed `timeframe` value, used when evaluating the aggregation condition.
     pub timeframe: Option<TimeFrameInfo>,
 }
 
@@ -215,6 +246,7 @@ impl DetectionNode {
         }
     }
 
+    /// Builds a DetectionNode directly from pre-compiled parts. Used by the correlation parser.
     pub fn new_with_data(
         name_to_selection: HashMap<String, Arc<Box<dyn SelectionNode>>>,
         condition: Option<Box<dyn SelectionNode>>,
@@ -251,7 +283,8 @@ impl DetectionNode {
         let condition_str = if let Some(cond_str) = condition {
             *cond_str
         } else {
-            // If condition is not specified, adopt the selection if there is only one selection.
+            // If condition is not specified, use the sole selection as the condition; having two
+            // or more selections without a condition is an error.
             let mut keys = self.name_to_selection.keys();
             if keys.len() >= 2 {
                 return Result::Err(vec![
@@ -273,7 +306,7 @@ impl DetectionNode {
         }
 
         // Parse the aggregation condition (the part after the pipe in condition).
-        let agg_compiler = aggregation_parser::AggegationConditionCompiler::new();
+        let agg_compiler = aggregation_parser::AggregationConditionCompiler::new();
         let compile_result = agg_compiler.compile(condition_str);
         if let Result::Err(err_msg) = compile_result {
             err_msgs.push(err_msg);
@@ -301,7 +334,8 @@ impl DetectionNode {
         condition.select(event_record, eventkey_alias)
     }
 
-    /// Parses selection nodes.
+    /// Parses every named selection under the detection node into a selection tree and stores it
+    /// in name_to_selection.
     fn parse_name_to_selection(&mut self, detection_yaml: &Yaml) -> Result<(), Vec<String>> {
         let detection_hash = detection_yaml.as_hash();
         if detection_hash.is_none() {
@@ -350,7 +384,7 @@ impl DetectionNode {
         Result::Ok(())
     }
 
-    /// Parses selection.
+    /// Parses a single named selection into a selection tree.
     fn parse_selection(&self, selection_yaml: &Yaml) -> Option<Box<dyn SelectionNode>> {
         Option::Some(Self::parse_selection_recursively(
             &Nested::<String>::new(),
@@ -358,7 +392,9 @@ impl DetectionNode {
         ))
     }
 
-    /// Parses selection.
+    /// Recursively converts a selection's YAML into a tree of SelectionNodes: hashes become AND
+    /// nodes, arrays become OR nodes (or AND/All nodes when the `|all` modifier is present), and
+    /// scalars become leaf nodes holding the key path (`key_list`) and the value to match.
     fn parse_selection_recursively(
         key_list: &Nested<String>,
         yaml: &Yaml,
@@ -377,7 +413,8 @@ impl DetectionNode {
             });
             Box::new(and_node)
         } else if yaml.as_vec().is_some() && key_list.len() == 1 && key_list[0].eq("|all") {
-            // In the case of |all only,
+            // If the key is just "|all" (the keyless all modifier), every keyword in the list has
+            // to match, so combine the children with an AllSelectionNode (AND semantics).
             let mut or_node = selectionnodes::AllSelectionNode::new();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);
@@ -385,7 +422,8 @@ impl DetectionNode {
             });
             Box::new(or_node)
         } else if yaml.as_vec().is_some() && key_list.iter().any(|k: &str| k.contains("|all")) {
-            // If "all" is in key_list, the child element array is interpreted as an AND condition.
+            // If the key carries the |all modifier (e.g. field|contains|all), the array of child
+            // elements is interpreted as an AND condition.
             let mut and_node = selectionnodes::AndSelectionNode::new();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);
@@ -413,11 +451,12 @@ impl DetectionNode {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 /// Struct that outputs the results of aggregation such as count.
 pub struct AggResult {
-    /// Value such as count.
+    /// The aggregated value, e.g. the count.
     pub data: i64,
-    /// Value within the record for the condition specified by count by.
+    /// The grouping value taken from the record for the field specified by "count() by".
     pub key: String,
-    /// Array of values in detected records for items specified inside the parentheses of count. If nothing is specified inside the parentheses, this is an array of length 0.
+    /// Array of values in detected records for the field specified inside the parentheses of
+    /// count. If nothing is specified inside the parentheses, this is an array of length 0.
     pub field_values: Vec<String>,
     /// Time of the first record in the detected block.
     pub start_timedate: DateTime<Utc>,
@@ -508,7 +547,8 @@ mod tests {
 
     #[test]
     fn test_detect_dotkey() {
-        // Cases where values are connected with "." instead of alias can be correctly detected.
+        // Verify that a key written as a dot-joined path (instead of an alias) is detected
+        // correctly.
         let rule_str = r#"
         enabled: true
         detection:
@@ -527,7 +567,8 @@ mod tests {
 
     #[test]
     fn test_notdetect_dotkey() {
-        // Verify that cases which should not be detected are not detected, for cases using "." instead of alias.
+        // Verify that a record which should not be detected is not detected when the key is a
+        // dot-joined path instead of an alias.
         let rule_str = r#"
         enabled: true
         detection:
@@ -546,7 +587,8 @@ mod tests {
 
     #[test]
     fn test_notdetect_differentkey() {
-        // Verify that cases which should not be detected are not detected, for cases using "." instead of alias.
+        // Verify that a record is not detected when the value of the rule's field (here the
+        // aliased key Channel) differs from the value in the record.
         let rule_str = r#"
         enabled: true
         detection:
@@ -566,8 +608,10 @@ mod tests {
 
     #[test]
     fn test_detect_attribute() {
-        // Test for cases where JSON is parsed in a special way when a value exists in the attribution part of an XML tag.
-        // The original XML looks like the following, and this is a test to detect Name or Guid in the Provider tag.
+        // Test for cases where JSON is parsed in a special way when a value exists in the
+        // attribute part of an XML tag.
+        // The original XML looks like the following, and this is a test to detect Name or Guid
+        // in the Provider tag.
         /*         - <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
         - <System>
           <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" />
@@ -638,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_notdetect_attribute() {
-        // Verify cases where XML tag attribution is not detected.
+        // Verify a case where a value in an XML tag attribute should not be detected.
         let rule_str = r#"
         enabled: true
         detection:
@@ -686,7 +730,8 @@ mod tests {
 
     #[test]
     fn test_detect_eventdata() {
-        // In a special XML format pattern, there is a tag called EventData, and a key-like value comes in the Name= part.
+        // In a special XML format pattern, there is a tag called EventData, and the value that
+        // acts as the field key comes in the Name= attribute.
         /* - <EventData>
         <Data Name="SubjectUserSid">S-1-5-21-2673273881-979819022-3746999991-1001</Data>
         <Data Name="SubjectUserName">takai</Data>
@@ -697,7 +742,8 @@ mod tests {
         <Data Name="TargetDomainName">DESKTOP-ICHIICH</Data>
         </EventData> */
 
-        // In that case, the JSON of the event parser looks like the following, so test that it can be correctly detected.
+        // In that case, the JSON produced by the event parser looks like the following, so test
+        // that it can be correctly detected.
         /*         {
             "Event": {
               "EventData": {
@@ -741,6 +787,8 @@ mod tests {
 
     #[test]
     fn test_detect_eventdata2() {
+        // Verify that an EventData field can be matched by its bare name: keys without an alias
+        // or dots fall back to Event.EventData.<key>.
         let rule_str = r#"
         enabled: true
         detection:
@@ -808,7 +856,8 @@ mod tests {
 
     #[test]
     fn test_detect_special_eventdata() {
-        // A further special case of EventData in the above test case, where there is no Name key inside the Data tag as shown below.
+        // A further special case of EventData beyond the above test case, where there is no Name
+        // key inside the Data tag as shown below.
         // For this reason, only the EventData key receives special handling in the rule file.
         // Currently, this case has only been confirmed with the downgrade_attack.yml rule.
         let rule_str = r"
@@ -862,7 +911,8 @@ mod tests {
 
     #[test]
     fn test_notdetect_special_eventdata() {
-        // A further special case of EventData in the above test case, where there is no Name key inside the Data tag as shown below.
+        // A further special case of EventData beyond the above test case, where there is no Name
+        // key inside the Data tag as shown below.
         // For this reason, only the EventData key receives special handling in the rule file.
         // Currently, this case has only been confirmed with the downgrade_attack.yml rule.
         let rule_str = r"
@@ -916,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_use_strfeature_in_or_node() {
-        // Test that startswith can be used within an orNode.
+        // Test that startswith can also be used within an OR node (a list of values).
         let rule_str = r#"
         enabled: true
         detection:
@@ -975,7 +1025,7 @@ mod tests {
 
     #[test]
     fn test_detect_not_defined_selection() {
-        // Test that a warning is issued when an unknown string option is written in a rule.
+        // Test that an error is returned when the detection node has no content.
         let rule_str = r#"
         enabled: true
         detection:
@@ -992,7 +1042,7 @@ mod tests {
 
     #[test]
     fn test_use_allfeature_() {
-        // Test that when "all" is included via pipe, the items below are treated as AND conditions.
+        // Test that when the |all modifier is given, the listed values are combined with AND.
         let rule_str = r#"
         enabled: true
         detection:
@@ -1023,7 +1073,8 @@ mod tests {
           }
         }"#;
 
-        // case of
+        // A record that should not match: param2 contains "aut" but not "star", so contains|all
+        // fails.
         let record_json_str2 = r#"
         {
           "Event": {
@@ -1045,7 +1096,7 @@ mod tests {
         check_select(rule_str, record_json_str2, false);
     }
 
-    /// Test function to verify numbers for count.
+    /// Test helper that verifies the number of records accumulated for the count aggregation.
     fn _check_count(rule_str: &str, record_str: &str, key: &str, expect_count: i32) {
         let mut rule_yaml = YamlLoader::load_from_str(rule_str).unwrap().into_iter();
         let test = rule_yaml.next().unwrap();

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -7,27 +7,34 @@ use yaml_rust2::Yaml;
 
 use super::matchers::{self, DefaultMatcher};
 
-// Nodes under detection-selection in a Rule file implement this trait.
+/// Trait implemented by every node under the detection-selection section of a rule file.
 pub trait SelectionNode: Downcast + Send + Sync {
-    // Determine whether the event log record specified as an argument matches the condition.
-    // Appropriate determination processing must be written for each struct that implements this trait.
+    /// Determines whether the given event log record matches this node's condition.
+    /// Each struct implementing this trait must provide its own matching logic.
     fn select(&self, event_record: &EvtxRecordInfo, eventkey_alias: &EventKeyAliasConfig) -> bool;
 
-    // Perform initialization processing.
-    // Since errors can be returned as a return value, output an error here when the Rule file is incorrect and a SelectionNode cannot be constructed.
-    // AndSelectionNode and others implement a new() function in addition to init(), but new() is meant to only create an instance without writing overly long processing.
-    // This is done to consolidate error handling for Rule file parsing into the init() function.
+    /// Performs initialization.
+    /// Since this method can return errors, report here when the rule file is invalid and a
+    /// SelectionNode cannot be constructed. AndSelectionNode and the like also implement a new()
+    /// function in addition to init(), but new() is only meant to create an instance and should
+    /// not contain lengthy processing. This keeps the error handling for rule file parsing
+    /// consolidated in init().
     fn init(&mut self) -> Result<(), Vec<String>>;
 
-    // Get child nodes (same meaning as child in graph theory).
-    fn get_childs(&self) -> Vec<&dyn SelectionNode>;
+    /// Gets the child nodes ("child" in the graph-theory sense).
+    fn get_children(&self) -> Vec<&dyn SelectionNode>;
 
-    // Get descendant nodes (same meaning as descendant in graph theory).
+    /// Gets the descendant nodes ("descendant" in the graph-theory sense).
     fn get_descendants(&self) -> Vec<&dyn SelectionNode>;
 }
+// Enable downcasting so callers (e.g. get_detection_keys() in rule/mod.rs) can identify concrete
+// node types such as LeafSelectionNode.
 downcast_rs::impl_downcast!(SelectionNode);
 
-/// Node representing AND conditions under detection-selection.
+/// Node representing an AND condition under detection-selection.
+/// Built from a YAML hash (every key/value pair must match), from a value list whose field key
+/// carries the `|all` modifier, or for `and` operators in condition expressions; matches only
+/// when all child nodes match.
 pub struct AndSelectionNode {
     pub child_nodes: Vec<Box<dyn SelectionNode>>,
 }
@@ -70,7 +77,7 @@ impl SelectionNode for AndSelectionNode {
         }
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         let mut ret = vec![];
         self.child_nodes.iter().for_each(|child_node| {
             ret.push(child_node.as_ref());
@@ -80,7 +87,7 @@ impl SelectionNode for AndSelectionNode {
     }
 
     fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = self.get_childs();
+        let mut ret = self.get_children();
 
         self.child_nodes
             .iter()
@@ -93,7 +100,8 @@ impl SelectionNode for AndSelectionNode {
     }
 }
 
-/// Node representing All conditions under detection-selection.
+/// Node for the keyless `|all` modifier under detection-selection: every keyword in the value
+/// list must match. Matching behaves like AndSelectionNode, but it is kept as a distinct type.
 pub struct AllSelectionNode {
     pub child_nodes: Vec<Box<dyn SelectionNode>>,
 }
@@ -136,7 +144,7 @@ impl SelectionNode for AllSelectionNode {
         }
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         let mut ret = vec![];
         self.child_nodes.iter().for_each(|child_node| {
             ret.push(child_node.as_ref());
@@ -146,7 +154,7 @@ impl SelectionNode for AllSelectionNode {
     }
 
     fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = self.get_childs();
+        let mut ret = self.get_children();
 
         self.child_nodes
             .iter()
@@ -159,7 +167,9 @@ impl SelectionNode for AllSelectionNode {
     }
 }
 
-/// Node representing OR conditions under detection-selection.
+/// Node representing an OR condition under detection-selection.
+/// Built from a YAML array of values, for `or` operators in condition expressions, or when the
+/// correlation parser merges referenced rules; matches when any child node matches.
 pub struct OrSelectionNode {
     pub child_nodes: Vec<Box<dyn SelectionNode>>,
 }
@@ -202,7 +212,7 @@ impl SelectionNode for OrSelectionNode {
         }
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         let mut ret = vec![];
         self.child_nodes.iter().for_each(|child_node| {
             ret.push(child_node.as_ref());
@@ -212,7 +222,7 @@ impl SelectionNode for OrSelectionNode {
     }
 
     fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = self.get_childs();
+        let mut ret = self.get_children();
 
         self.child_nodes
             .iter()
@@ -225,7 +235,7 @@ impl SelectionNode for OrSelectionNode {
     }
 }
 
-/// Node representing Not in condition.
+/// Node representing a `not` in the condition expression; inverts the result of the wrapped node.
 pub struct NotSelectionNode {
     node: Box<dyn SelectionNode>,
 }
@@ -242,23 +252,25 @@ impl SelectionNode for NotSelectionNode {
     }
 
     fn init(&mut self) -> Result<(), Vec<String>> {
+        // Nothing to initialize: this node is created when the condition expression is compiled,
+        // which happens after all named selections have already been initialized.
         Result::Ok(())
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         vec![]
     }
 
     fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        self.get_childs()
+        self.get_children()
     }
 }
 
-/// Used to reference conditions defined in detection from condition.
+/// Used to reference a named selection defined under detection from the condition expression.
 pub struct RefSelectionNode {
-    // selection_node is owned by name_2_node of DetectionNode, so ownership cannot be given to selection_node of RefSelectionNode.
-    // Therefore, Arc is used so that ownership is shared between name_2_node of DetectionNode and selection_node of RefSelectionNode.
-    // Arc is used instead of Rc for multi-thread support.
+    // selection_node is owned by DetectionNode's name_to_selection map, so RefSelectionNode cannot
+    // take ownership of it. Arc is used so that ownership is shared between name_to_selection and
+    // this field. Arc is used instead of Rc for multi-thread support.
     selection_node: Arc<Box<dyn SelectionNode>>,
 }
 
@@ -276,19 +288,24 @@ impl SelectionNode for RefSelectionNode {
     }
 
     fn init(&mut self) -> Result<(), Vec<String>> {
+        // Nothing to initialize: the referenced selection is initialized by DetectionNode before
+        // the condition expression is compiled.
         Result::Ok(())
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         vec![self.selection_node.as_ref().as_ref()]
     }
 
     fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        self.get_childs()
+        self.get_children()
     }
 }
 
-/// Leaf node under detection-selection.
+/// Leaf node under detection-selection: a single field/value pair.
+/// key_list holds the chain of YAML keys leading to the value (e.g. `["CommandLine|contains"]` or
+/// `["field", "min_length"]`), key holds the field name with any pipe modifiers stripped, and the
+/// actual comparison is delegated to the LeafMatcher chosen during init().
 pub struct LeafSelectionNode {
     key: String,
     key_list: Nested<String>,
@@ -310,6 +327,9 @@ impl LeafSelectionNode {
         &self.key
     }
 
+    /// Returns the event keys this leaf refers to: the leaf's own field key plus, for field
+    /// comparison modifiers such as `equalsfield`/`fieldref`, the key of the field being compared
+    /// against. Used to decide which values to extract from each record up front.
     pub fn get_keys(&self) -> Vec<&String> {
         let mut keys = vec![];
         if !self.key.is_empty() {
@@ -328,6 +348,8 @@ impl LeafSelectionNode {
         keys
     }
 
+    /// Derives the field name from key_list: the first element with any pipe modifiers
+    /// (e.g. "|contains") stripped off.
     fn _create_key(&self) -> String {
         if self.key_list.is_empty() {
             return String::default();
@@ -337,9 +359,10 @@ impl LeafSelectionNode {
         topkey.split('|').next().unwrap_or_default().to_string()
     }
 
-    /// Function to get a value from EventJSON in JSON format. Aliases are also considered.
+    /// Gets the value for this leaf's key from the event record JSON.
+    /// Event key aliases are also taken into account.
     fn get_event_value<'a>(&self, record: &'a EvtxRecordInfo) -> Option<&'a String> {
-        // If no key is specified, get the record data as-is.
+        // If no key is specified (a keyword-style rule), match against the whole record string.
         if self.key_list.is_empty() {
             return Option::Some(&record.data_string);
         }
@@ -347,8 +370,9 @@ impl LeafSelectionNode {
         record.get_value(self.get_key())
     }
 
-    /// Gets the list of matchers::LeafMatchers.
-    /// Examine in order from the top, and the first matching Matcher is applied.
+    /// Gets the list of candidate matchers::LeafMatcher implementations.
+    /// They are examined in order from the top, and the first matcher whose is_target_key()
+    /// returns true is applied, so the most permissive matcher (DefaultMatcher) must stay last.
     fn get_matchers(&self) -> Vec<Box<dyn matchers::LeafMatcher>> {
         vec![
             Box::new(matchers::MinlengthMatcher::new()),
@@ -361,12 +385,13 @@ impl LeafSelectionNode {
 
 impl SelectionNode for LeafSelectionNode {
     fn select(&self, event_record: &EvtxRecordInfo, eventkey_alias: &EventKeyAliasConfig) -> bool {
+        // The matcher is set in init(); if init() failed, this node never matches.
         if self.matcher.is_none() {
             return false;
         }
 
-        // EventData requires special handling because XML is in a special format.
-        //// The original XML is in the following format.
+        // EventData requires special handling because its XML has a special format.
+        // The original XML looks like this:
         /*
             <EventData>
             <Data>Available</Data>
@@ -374,8 +399,9 @@ impl SelectionNode for LeafSelectionNode {
             <Data>NewEngineState=Available PreviousEngineState=None SequenceNumber=9 HostName=ConsoleHost HostVersion=2.0 HostId=5cbb33bf-acf7-47cc-9242-141cd0ba9f0c EngineVersion=2.0 RunspaceId=c6e94dca-0daf-418c-860a-f751a9f2cbe1 PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine=</Data>
             </EventData>
         */
-        //// When XML is parsed to JSON, it is in the following format.
-        //// Rules that would result in JSON being an array cannot currently be written.
+        // When the XML is parsed into JSON, it takes the following format.
+        // Rules that target the case where the JSON becomes an array like this cannot currently
+        // be written.
         /*     "EventData": {
                     "Binary": null,
                     "Data": [
@@ -399,9 +425,9 @@ impl SelectionNode for LeafSelectionNode {
                     .is_match(Option::None, event_record);
             }
 
-            // For strings or numbers (not arrays), compare normally.
             let eventdata_data = values.unwrap();
             match eventdata_data {
+                // For strings or numbers (not arrays), compare normally.
                 Value::Bool(_) | Value::Number(_) | Value::String(_) => {
                     let event_value = event_record.get_value(self.get_key());
                     return self
@@ -410,6 +436,7 @@ impl SelectionNode for LeafSelectionNode {
                         .unwrap()
                         .is_match(event_value, event_record);
                 }
+                // For arrays, the leaf matches if any element matches.
                 Value::Array(_) => {
                     return eventdata_data
                         .as_array()
@@ -440,9 +467,11 @@ impl SelectionNode for LeafSelectionNode {
             && !self.key_list[0].contains("|")
             && let Some(event_id) = self.select_value.as_i64()
         {
-            // Regex is heavy, so for numeric EventIDs, use exact string matching.
+            // Regex matching is heavy, so when the rule specifies EventID as a plain integer
+            // (no pipe modifiers), use exact string comparison instead.
             return event_value.unwrap_or(&String::default()) == &event_id.to_string();
         }
+        // For the keyless `|all` modifier, match against the entire record JSON string.
         if !self.key_list.is_empty() && self.key_list[0].eq("|all") {
             event_value = Some(&event_record.data_string);
         }
@@ -458,7 +487,7 @@ impl SelectionNode for LeafSelectionNode {
             .into_iter()
             .find(|matcher| matcher.is_target_key(&self.key_list));
 
-        // Error: no matching matcher found.
+        // Error: no matcher accepted this key.
         if self.matcher.is_none() {
             return Result::Err(vec![format!(
                 "Found unknown key. key:{}",
@@ -466,6 +495,7 @@ impl SelectionNode for LeafSelectionNode {
             )]);
         }
 
+        // Error: the YAML value could not be parsed.
         if self.select_value.is_badvalue() {
             return Result::Err(vec![format!(
                 "Cannot parse yml file. key:{}",
@@ -480,7 +510,7 @@ impl SelectionNode for LeafSelectionNode {
             .init(&self.key_list, &self.select_value)
     }
 
-    fn get_childs(&self) -> Vec<&dyn SelectionNode> {
+    fn get_children(&self) -> Vec<&dyn SelectionNode> {
         vec![]
     }
 
@@ -512,6 +542,8 @@ mod tests {
         }))
     }
 
+    // Parses the rule, wraps the JSON record, and asserts that rule_node.select() returns
+    // expect_select.
     fn check_select(rule_str: &str, record_str: &str, expect_select: bool) {
         let mut rule_node = parse_rule_from_str(rule_str);
         let dummy_stored_static = create_dummy_stored_static();
@@ -540,7 +572,7 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_mutiple_regex_and() {
+    fn test_detect_multiple_regex_and() {
         // Verify that AND conditions are correctly detected.
         let rule_str = r#"
         enabled: true
@@ -561,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_notdetect_mutiple_regex_and() {
+    fn test_notdetect_multiple_regex_and() {
         // Verify that if even one condition in an AND condition does not match, it is not detected.
         // In this example, the Computer value is different.
         let rule_str = r#"
@@ -628,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_notdetect_or() {
-        // Verify that OR conditions are correctly detected.
+        // Verify that an OR condition does not match when none of the listed values match.
         let rule_str = r#"
         enabled: true
         detection:

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -36,11 +36,15 @@ use super::detection::EvtxRecordInfo;
 use super::message::{AlertMessage, ERROR_LOG_STACK};
 use rust_embed::Embed;
 
+/// Embedded copy of config/default_profile_name.txt, used as a fallback when the file does not
+/// exist on disk.
 #[derive(Embed)]
 #[folder = "config"]
 #[include = "default_profile_name.txt"]
 pub struct DefaultProfileName;
 
+/// Builds a human-readable path into a rule's detection section, e.g.
+/// "detection -> selection -> key1 -> key2", for use in rule parse error messages.
 pub fn concat_selection_key(key_list: &Nested<String>) -> String {
     key_list
         .iter()
@@ -50,6 +54,7 @@ pub fn concat_selection_key(key_list: &Nested<String>) -> String {
         })
 }
 
+/// Returns true if the string matches any of the given regexes.
 pub fn check_regex(string: &str, regex_list: &[Regex]) -> bool {
     for regex in regex_list {
         if !regex.is_match(string) {
@@ -62,6 +67,7 @@ pub fn check_regex(string: &str, regex_list: &[Regex]) -> bool {
     false
 }
 
+/// Returns true if the target matches any of the allowlist regexes.
 pub fn check_allowlist(target: &str, regexes: &[Regex]) -> bool {
     for regex in regexes {
         if regex.is_match(target) {
@@ -72,6 +78,8 @@ pub fn check_allowlist(target: &str, regexes: &[Regex]) -> bool {
     false
 }
 
+/// Converts a scalar JSON value (bool/number/string) to a trimmed string. Returns None for
+/// null, arrays and objects.
 pub fn value_to_string(value: &Value) -> Option<String> {
     match value {
         Value::Null => Option::None,
@@ -83,6 +91,8 @@ pub fn value_to_string(value: &Value) -> Option<String> {
     }
 }
 
+/// Reads a text file into its lines. If the file is part of the all-in-one config bundle
+/// (ONE_CONFIG_MAP), the embedded content is used instead of reading from disk.
 pub fn read_txt(filename: &str) -> Result<Nested<String>, String> {
     let filepath = if filename.starts_with("./") {
         check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), filename, true)
@@ -115,7 +125,9 @@ pub fn read_txt(filename: &str) -> Result<Nested<String>, String> {
     ))
 }
 
-/// convert jsonl fmt string to serde_json Value iterator
+/// Converts a JSONL-format file into an iterator of serde_json Values, wrapping each line's
+/// object in {"Event": {"EventData": ...}} so that it has the same shape as an evtx-derived
+/// record.
 pub fn read_jsonl_to_value(path: &str) -> Result<Box<dyn Iterator<Item = Value>>, String> {
     let f = File::open(path);
     if f.is_err() {
@@ -141,7 +153,9 @@ pub fn read_jsonl_to_value(path: &str) -> Result<Box<dyn Iterator<Item = Value>>
     Err("Conversion failed because it is not in JSONL format.".to_string())
 }
 
-/// convert json fmt string to serde_json Value iterator
+/// Converts a JSON-format file (either a JSON array, or concatenated objects as produced by
+/// `jq -c`) into an iterator of serde_json Values, wrapping each record in
+/// {"Event": {"EventData": ...}} so that it has the same shape as an evtx-derived record.
 pub fn read_json_to_value(path: &str) -> Result<Box<dyn Iterator<Item = Value>>, String> {
     let f = fs::read_to_string(path);
     if f.is_err() {
@@ -177,6 +191,8 @@ pub fn read_json_to_value(path: &str) -> Result<Box<dyn Iterator<Item = Value>>,
     }
 }
 
+/// Reads a CSV config file into rows, preferring the all-in-one config bundle (ONE_CONFIG_MAP)
+/// over the file on disk.
 pub fn read_csv(filename: &str) -> Result<Nested<Vec<String>>, String> {
     let re = Regex::new(r".*/").unwrap();
     let one_config_path = &re.replace(filename, "").to_string();
@@ -198,6 +214,8 @@ pub fn read_csv(filename: &str) -> Result<Nested<Vec<String>>, String> {
     Ok(csv_res)
 }
 
+/// Parses CSV contents into rows of column strings. The first row is treated as a header and is
+/// not included in the result; unparsable rows are skipped silently.
 pub fn parse_csv(file_contents: &str) -> Nested<Vec<String>> {
     let mut ret = Nested::<Vec<String>>::new();
     let mut rdr = csv::ReaderBuilder::new().from_reader(file_contents.as_bytes());
@@ -219,6 +237,8 @@ pub fn get_event_id_key() -> String {
     "Event.System.EventID".to_string()
 }
 
+/// Parses an RFC 3339 timestamp string (e.g. an evtx SystemTime value) into a UTC DateTime.
+/// Returns None for empty or unparsable input.
 pub fn str_time_to_datetime(system_time_str: &str) -> Option<DateTime<Utc>> {
     if system_time_str.is_empty() {
         return Option::None;
@@ -232,7 +252,10 @@ pub fn str_time_to_datetime(system_time_str: &str) -> Option<DateTime<Utc>> {
         .single()
 }
 
-/// Checks the type of serde::Value and returns a string.
+/// Converts a serde_json Value to a string regardless of its underlying type (string, number,
+/// bool). When search_flag is true, objects are also flattened into "key:value ¦ key:value"
+/// form so that the search feature can match against them; otherwise objects and null return
+/// None.
 pub fn get_serde_number_to_string(
     value: &serde_json::Value,
     search_flag: bool,
@@ -251,13 +274,18 @@ pub fn get_serde_number_to_string(
             .join(" ¦ ");
         Some(CompactString::from(val))
     } else if value.is_null() || (value.is_object() && !search_flag) {
-        // Object type is not specified record value.
+        // Objects are not expected as record values (they are only stringified for the search
+        // feature above), so return None.
         Option::None
     } else {
         Some(CompactString::from(value.to_string()))
     }
 }
 
+/// Looks up a value in the event record by key. The key is first resolved through
+/// eventkey_alias.txt (e.g. "Computer" -> "Event.System.Computer"); keys without an alias are
+/// treated as dot-separated JSON paths, and keys containing no dot are assumed to live under
+/// "Event.EventData".
 pub fn get_event_value<'a>(
     key: &str,
     event_value: &'a Value,
@@ -270,9 +298,12 @@ pub fn get_event_value<'a>(
     let event_key = eventkey_alias.get_event_key(key);
     let mut ret: &Value = event_value;
     if let Some(event_key) = event_key {
-        // Since it is not possible to get_event_key without also being able to get_event_key_split, the unwrap check is not performed.
+        // get_event_key_split always has an entry whenever get_event_key succeeded, so the
+        // unwrap below is not checked.
         let splits = eventkey_alias.get_event_key_split(key);
         let mut start_idx = 0;
+        // splits holds the length of each dot-separated segment of the resolved event key, so
+        // the JSON path can be walked by slicing the key string instead of re-splitting it.
         for key in splits.unwrap() {
             if !ret.is_object() {
                 return Option::None;
@@ -302,6 +333,8 @@ pub fn get_event_value<'a>(
     }
 }
 
+/// Returns the number of worker threads to use: the user-specified value if given, otherwise
+/// the number of available CPU cores.
 pub fn get_thread_num(thread_number: Option<usize>) -> usize {
     let cpu_num = available_parallelism().unwrap();
     thread_number.unwrap_or(cpu_num.into())
@@ -315,7 +348,7 @@ pub fn create_tokio_runtime(thread_number: Option<usize>) -> Runtime {
         .unwrap()
 }
 
-// Creates EvtxRecordInfo.
+/// Creates an EvtxRecordInfo from a parsed event record.
 pub fn create_rec_info(
     mut data: Value,
     path: String,
@@ -325,11 +358,14 @@ pub fn create_rec_info(
 ) -> EvtxRecordInfo {
     // Processing for performance optimization.
 
-    // For example, to get the value of "Event.System.EventID" from a Value type, it would require 3 accesses like value["Event"]["System"]["EventID"].
-    // To speed up this processing, set the value with the key "Event.System.EventID" in a hashmap called rec.key_2_value.
-    // With this, the value can be retrieved by specifying the key "Event.System.EventID" only once, which should improve performance.
-    // Also, retrieving values from serde_json Value like value["Event"] is somehow slow, so this might also help.
-    // Also, serde_json internally uses the standard library hashmap, but using hashbrown is reportedly faster. Since the standard library adopted hashbrown, serde_json has also been sped up.
+    // For example, getting the value of "Event.System.EventID" from a serde_json Value requires
+    // three accesses: value["Event"]["System"]["EventID"]. To speed this up, the value is stored
+    // in the rec.key_2_value hashmap under the flat key "Event.System.EventID", so it can later
+    // be retrieved with a single lookup, which should improve performance. Also, retrieving
+    // values from a serde_json Value like value["Event"] is somehow slow, so this might help
+    // there too. In addition, serde_json internally uses the standard library hashmap, but using
+    // hashbrown is reportedly faster; since the standard library adopted hashbrown, serde_json
+    // has also been sped up.
     let mut key_2_values = HashMap::new();
 
     let binding = STORED_EKEY_ALIAS.read().unwrap();
@@ -374,7 +410,8 @@ pub fn create_rec_info(
 }
 
 /**
- * Function that changes the color output setting of standard output to the specified value and outputs to screen.
+ * Writes the string to the given buffer writer with the specified foreground color and prints
+ * it to the screen.
  */
 pub fn write_color_buffer(
     wtr: &BufferWriter,
@@ -392,7 +429,8 @@ pub fn write_color_buffer(
     wtr.print(&buf)
 }
 
-/// Function that checks whether the no-color option is specified, returning None if it is, and returning the Color specified as an argument wrapped in Some if it is not.
+/// Checks whether the no-color option is specified: returns None if it is, otherwise the color
+/// given as an argument.
 pub fn get_writable_color(color: Option<Color>, no_color: bool) -> Option<Color> {
     if no_color { None } else { color }
 }
@@ -453,7 +491,7 @@ fn _collect_recordinfo<'a>(
     org_value: &'a Value,
     cur_value: &'a Value,
     output: &mut HashSet<(String, String)>,
-    filed_data_converter: (&Option<FieldDataMap>, &FieldDataMapKey),
+    field_data_converter: (&Option<FieldDataMap>, &FieldDataMapKey),
 ) {
     match cur_value {
         Value::Array(ary) => {
@@ -465,12 +503,14 @@ fn _collect_recordinfo<'a>(
                     org_value,
                     sub_value,
                     output,
-                    filed_data_converter,
+                    field_data_converter,
                 );
             }
         }
         Value::Object(obj) => {
-            // The implementation is a bit unusual due to lifetime constraints.
+            // The implementation is a bit unusual due to lifetime constraints: parent keys are
+            // pushed/popped on a shared Vec of borrowed &strs instead of building owned path
+            // strings.
             if !parent_key.is_empty() {
                 keys.push(parent_key);
             }
@@ -490,7 +530,7 @@ fn _collect_recordinfo<'a>(
                     org_value,
                     value,
                     output,
-                    filed_data_converter,
+                    field_data_converter,
                 );
             }
             if !parent_key.is_empty() {
@@ -502,6 +542,8 @@ fn _collect_recordinfo<'a>(
             // Only collect the values of the innermost child elements.
             let strval = value_to_string(cur_value);
             if let Some(strval) = strval {
+                // Replace control characters and whitespace with plain spaces, except for
+                // \r, \n and \t, which are handled later by remove_sp_char.
                 let mut strval = strval.chars().fold(String::default(), |mut acc, c| {
                     if (c.is_control() || c.is_ascii_whitespace())
                         && !['\r', '\n', '\t'].contains(&c)
@@ -512,8 +554,9 @@ fn _collect_recordinfo<'a>(
                     };
                     acc
                 });
+                // Array elements are output with 1-based indices, e.g. "Data[1]", "Data[2]".
                 let key = if arr_index >= 0 {
-                    let (field_data_map, field_data_map_key) = filed_data_converter;
+                    let (field_data_map, field_data_map_key) = field_data_converter;
                     let i = arr_index + 1;
                     let field = format!("{parent_key}[{i}]").to_lowercase();
                     if let Some(map) = field_data_map {
@@ -555,7 +598,10 @@ pub fn make_ascii_titlecase(s: &str) -> CompactString {
     }
 }
 
-/// Function that checks whether base_path/path exists and returns a path referencing the current directory if it does not.
+/// Resolves a config file path: returns the path as-is if it is part of the all-in-one config
+/// bundle (ONE_CONFIG_MAP), otherwise base_path/path if that exists. If neither applies, returns
+/// the path unchanged (interpreted relative to the current directory) when ignore_err is set,
+/// or None otherwise.
 pub fn check_setting_path(base_path: &Path, path: &str, ignore_err: bool) -> Option<PathBuf> {
     let re = Regex::new(r".*/").unwrap();
     if ONE_CONFIG_MAP.contains_key(&re.replace(path, "").to_string()) {
@@ -571,7 +617,7 @@ pub fn check_setting_path(base_path: &Path, path: &str, ignore_err: bool) -> Opt
 
 /// Function to verify the location of rule config files.
 pub fn check_rule_config(config_path: &PathBuf) -> Result<(), String> {
-    // Check various files.
+    // Rule config files that must be present.
     let files = vec![
         "channel_abbreviations.txt",
         "target_event_IDs.txt",
@@ -611,7 +657,8 @@ pub fn check_rule_config(config_path: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
-/// Function to get information adjusted for the timezone.
+/// Formats a UTC timestamp for output, converting it to the local timezone unless the UTC or
+/// ISO 8601 output option is specified.
 pub fn format_time(
     time: &DateTime<Utc>,
     date_only: bool,
@@ -624,7 +671,8 @@ pub fn format_time(
     }
 }
 
-/// return rfc time format string by option
+/// Formats the time according to the selected time format option (RFC 2822, RFC 3339, US,
+/// US military, European or ISO 8601 style, defaulting to "YYYY-MM-DD hh:mm:ss.fff +-hh:mm").
 fn format_rfc<Tz: TimeZone>(
     time: &DateTime<Tz>,
     date_only: bool,
@@ -677,7 +725,8 @@ where
     }
 }
 
-/// Check file path exist. If path is existed, output alert message.
+/// Checks whether the file path already exists; if it does, prints the given alert message and
+/// returns true.
 pub fn check_file_expect_not_exist(path: &Path, exist_alert_str: String) -> bool {
     let ret = path.exists();
     if ret {
@@ -686,6 +735,8 @@ pub fn check_file_expect_not_exist(path: &Path, exist_alert_str: String) -> bool
     ret
 }
 
+/// Accumulates the given output line into the specified section of the HTML report when the
+/// --html-report option is enabled.
 pub fn output_and_data_stack_for_html(
     output_str: &str,
     section_name: &str,
@@ -698,14 +749,19 @@ pub fn output_and_data_stack_for_html(
     }
 }
 
+/// Returns true if `input` contains `check` as a substring. Uses memchr::memmem, which is
+/// faster than the standard str::contains.
 pub fn contains_str(input: &str, check: &str) -> bool {
     memmem::find(input.as_bytes(), check.as_bytes()).is_some()
 }
 
+/// Outputs the active output profile name, either to the terminal or to the HTML report
+/// depending on the stdout argument.
 pub fn output_profile_name(output_option: &Option<OutputOption>, stdout: bool, no_color: bool) {
     // output profile name
     if let Some(profile_opt) = output_option {
-        // default profile name check
+        // Determine the default profile name, preferring config/default_profile_name.txt on
+        // disk and falling back to the embedded copy.
         let default_profile_name = if let Ok(name) = read_to_string(
             check_setting_path(
                 &CURRENT_EXE_PATH.to_path_buf(),
@@ -724,7 +780,7 @@ pub fn output_profile_name(output_option: &Option<OutputOption>, stdout: bool, n
                 .to_string()
         };
 
-        // user input profile option
+        // Use the profile specified by the user, or the default profile name.
         let profile_name = profile_opt
             .profile
             .as_ref()
@@ -746,7 +802,9 @@ pub fn output_profile_name(output_option: &Option<OutputOption>, stdout: bool, n
             .ok();
         }
         let output_saved_str = format!("Output profile: {profile_name}");
-        // Since the display position in the profile and the HTML output order differ, this is managed by arguments.
+        // The profile name appears at a different position in the terminal output than in the
+        // HTML report, so the stdout argument controls which of the two this call produces (the
+        // function is called once for each).
         if !stdout && profile_opt.html_report.is_some() {
             htmlreport::add_md_data(
                 "General Overview {#general_overview}",
@@ -756,7 +814,8 @@ pub fn output_profile_name(output_option: &Option<OutputOption>, stdout: bool, n
     }
 }
 
-/// Function to determine whether a computer name is subject to filtering.
+/// Determines whether a record should be filtered out based on its Computer field and the
+/// include_computer/exclude_computer options. Returns true when the record should be skipped.
 pub fn is_filtered_by_computer_name(
     record: Option<&Value>,
     (include_computer, exclude_computer): (&HashSet<CompactString>, &HashSet<CompactString>),
@@ -772,7 +831,9 @@ pub fn is_filtered_by_computer_name(
     false
 }
 
-/// Function to create an output string from the specified number of seconds and milliseconds. Calculates from the absolute value of seconds and outputs in hh:mm:ss.fff format.
+/// Creates an output string in hh:mm:ss.fff format from the given seconds and milliseconds.
+/// Both components are negated only when the seconds component is negative; a negative
+/// milliseconds value with a zero seconds component is not normalized.
 pub fn output_duration((mut s, mut ms): (i64, i64)) -> String {
     if s < 0 {
         s = -s;
@@ -785,6 +846,10 @@ pub fn output_duration((mut s, mut ms): (i64, i64)) -> String {
     format!("{h:02}:{m:02}:{s:02}.{ms:03}")
 }
 
+/// Sanitizes a field value for single-line output: \n, \r and \t are replaced with the "🛂n",
+/// "🛂r" and "🛂t" placeholders (restored or stripped later by the output code in afterfact.rs),
+/// runs of spaces are collapsed into one, all remaining control characters are removed, and the
+/// result is trimmed.
 pub fn remove_sp_char(record_value: CompactString) -> CompactString {
     let mut newline_replaced_cs: String = record_value
         .replace('\n', "🛂n")
@@ -801,6 +866,8 @@ pub fn remove_sp_char(record_value: CompactString) -> CompactString {
     newline_replaced_cs.trim().into()
 }
 
+/// Returns the size of the file in bytes, or 0 if its metadata cannot be read (in which case a
+/// warning is shown and/or stacked depending on the verbose and quiet-errors flags).
 pub fn get_file_size(file_path: &Path, verbose_flag: bool, quiet_errors_flag: bool) -> u64 {
     match fs::metadata(file_path) {
         Ok(res) => res.len(),
@@ -855,7 +922,8 @@ mod tests {
         match serde_json::from_str(record_json_str) {
             Ok(record) => {
                 let ret = utils::create_recordinfos(&record, &FieldDataMapKey::default(), &None);
-                // System is excluded / attributes (_attributes are also excluded) / sorted by key.
+                // Event.System is excluded, xmlns keys are excluded (which removes the
+                // *_attributes objects here), and the output is sorted by key.
                 let expected = "AccessMask: %%1369 ¦ Process: lsass.exe ¦ User: u1".to_string();
                 assert_eq!(ret.join(" ¦ "), expected);
             }
@@ -889,7 +957,8 @@ mod tests {
         match serde_json::from_str(record_json_str) {
             Ok(record) => {
                 let ret = utils::create_recordinfos(&record, &FieldDataMapKey::default(), &None);
-                // System is excluded / attributes (_attributes are also excluded) / sorted by key.
+                // Event.System is excluded, xmlns keys are excluded (which removes the
+                // *_attributes objects here), and the output is sorted by key.
                 let expected = "Binary: hogehoge ¦ Data[1]: Data1 ¦ Data[2]: DataData2 ¦ Data[3]:  ¦ Data[4]: DataDataData3"
                     .to_string();
                 assert_eq!(ret.join(" ¦ "), expected);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -17,6 +17,9 @@ pub struct DataFilterRule {
     pub replace_str: String,
 }
 
+/// Rule IDs to filter out at rule-loading time, mapped to the filter file (noisy_rules.txt or
+/// exclude_rules.txt) each ID came from. IDs from exclude_rules.txt are always skipped; IDs from
+/// noisy_rules.txt are skipped unless --enable-noisy-rules is set.
 #[derive(Clone, Debug)]
 pub struct RuleExclude {
     pub no_use_rule: HashMap<String, String>,
@@ -36,6 +39,8 @@ impl Default for RuleExclude {
     }
 }
 
+/// Loads the rule IDs listed in noisy_rules.txt and exclude_rules.txt under the config directory
+/// so that the corresponding detection rules can be skipped at rule-loading time.
 pub fn exclude_ids(stored_static: &StoredStatic) -> RuleExclude {
     let mut exclude_ids = RuleExclude::default();
     exclude_ids.insert_ids(
@@ -59,6 +64,9 @@ pub fn exclude_ids(stored_static: &StoredStatic) -> RuleExclude {
 
 impl RuleExclude {
     fn insert_ids(&mut self, filename: &str, stored_static: &StoredStatic) {
+        // ONE_CONFIG_MAP (the all-in-one config bundle) is keyed by bare file name, so strip the
+        // directory part. If the file is bundled there, read the ID list from the bundle instead
+        // of from disk.
         let re = Regex::new(r".*/").unwrap();
         let one_config_path = &re.replace(filename, "").to_string();
         let lines: Vec<String> = if ONE_CONFIG_MAP.contains_key(one_config_path) {
@@ -86,9 +94,10 @@ impl RuleExclude {
             reader.lines().map_while(Result::ok).collect()
         };
         for v in lines {
+            // Strip inline comments: everything after the first '#' is ignored.
             let v = v.split('#').collect::<Vec<&str>>()[0].trim().to_string();
             if v.is_empty() || !configs::IDS_REGEX.is_match(&v) {
-                // Ignore empty lines. Validate ID.
+                // Skip blank lines and entries that are not UUID-formatted rule IDs.
                 continue;
             }
             self.no_use_rule.insert(v, filename.to_owned());
@@ -96,6 +105,10 @@ impl RuleExclude {
     }
 }
 
+/// Reads only the first record of each evtx file to determine which channel the file holds, and
+/// groups the file paths by channel name. This assumes all records in a file share the channel of
+/// its first record. Files that fail to open are logged unless quiet_errors_flag is set; files
+/// whose first record cannot be parsed are skipped silently.
 fn peek_channel_from_evtx_first_record(
     evtx_files: &Vec<PathBuf>,
     quiet_errors_flag: bool,
@@ -133,10 +146,15 @@ fn peek_channel_from_evtx_first_record(
     channels
 }
 
+/// Matches the Channel values referenced by each rule against the channels actually present in
+/// the loaded evtx files. Returns the paths of the rules whose Channel matches at least one evtx
+/// channel, together with the matched channel names.
 fn extract_channel_from_rules(
     rule_files: &Vec<RuleNode>,
     evtx_channels: &HashSet<String>,
 ) -> (Vec<String>, Vec<String>) {
+    // Recursively walks a rule's YAML tree and records every evtx channel matched by any
+    // "Channel:" value found in it.
     fn visit_value(
         key: &str,
         value: &Yaml,
@@ -146,7 +164,9 @@ fn extract_channel_from_rules(
         match *value {
             Yaml::String(ref s) if key == "Channel" => {
                 if s.contains('*') {
-                    // When a wildcard is used for Channel in a Sigma rule
+                    // The rule uses a wildcard in its Channel value: strip the leading/trailing
+                    // wildcards and treat the remainder as a substring match against each evtx
+                    // channel name.
                     for ch in evtx_channels {
                         if ch.contains(s.trim_matches('*')) {
                             intersection_channels.push(ch.to_string());
@@ -170,19 +190,23 @@ fn extract_channel_from_rules(
         }
     }
     let mut intersection_channels = vec![];
-    let mut filtered_rulespathes = vec![];
+    let mut filtered_rule_paths = vec![];
     for rule in rule_files {
         let before_visit_len = intersection_channels.len();
         visit_value("", &rule.yaml, evtx_channels, &mut intersection_channels);
+        // If the visit added any channel, this rule targets at least one loaded evtx channel.
         if before_visit_len < intersection_channels.len() {
-            filtered_rulespathes.push(rule.rulepath.to_string());
+            filtered_rule_paths.push(rule.rulepath.to_string());
         }
     }
-    (filtered_rulespathes, intersection_channels)
+    (filtered_rule_paths, intersection_channels)
 }
 
+/// Result of matching rule Channel values against the channels found in the loaded evtx files.
+/// Used to skip evtx files that no loaded rule targets, and rules that no loaded evtx file can
+/// trigger.
 pub struct ChannelFilter {
-    pub rulepathes: Vec<String>,
+    pub rule_paths: Vec<String>, // paths of rules whose Channel matches some loaded evtx file
     pub intersec_channels: HashSet<String>, // intersection of evtx and rule channels
     pub evtx_channels_map: HashMap<String, Vec<PathBuf>>, // key=channel, val=list of evtx paths
 }
@@ -190,15 +214,17 @@ pub struct ChannelFilter {
 impl ChannelFilter {
     pub fn new() -> ChannelFilter {
         ChannelFilter {
-            rulepathes: vec![],
+            rule_paths: vec![],
             intersec_channels: HashSet::new(),
             evtx_channels_map: HashMap::new(),
         }
     }
 
-    pub fn scanable_rule_exists(&mut self, path: &PathBuf) -> bool {
-        for (channel, rulepathes) in &self.evtx_channels_map {
-            if rulepathes.contains(path) && self.intersec_channels.contains(channel) {
+    /// Returns true when the given evtx file holds a channel that at least one loaded rule
+    /// targets, i.e. scanning the file can possibly produce a detection.
+    pub fn scannable_rule_exists(&mut self, path: &PathBuf) -> bool {
+        for (channel, evtx_paths) in &self.evtx_channels_map {
+            if evtx_paths.contains(path) && self.intersec_channels.contains(channel) {
                 return true;
             }
         }
@@ -212,6 +238,9 @@ impl Default for ChannelFilter {
     }
 }
 
+/// Builds a ChannelFilter by peeking at the channel of each evtx file and intersecting those
+/// channels with the Channel values referenced by the loaded rules. Returns an empty filter when
+/// no channel could be read from any evtx file.
 pub fn create_channel_filter(
     evtx_files: &Vec<PathBuf>,
     rule_nodes: &Vec<RuleNode>,
@@ -221,7 +250,7 @@ pub fn create_channel_filter(
     if !channels.is_empty() {
         let (x, y) = extract_channel_from_rules(rule_nodes, &channels.keys().cloned().collect());
         ChannelFilter {
-            rulepathes: x,
+            rule_paths: x,
             intersec_channels: y.into_iter().collect(),
             evtx_channels_map: channels,
         }
@@ -230,6 +259,8 @@ pub fn create_channel_filter(
     }
 }
 
+/// Narrows down the evtx files to load according to the --include-channel/--exclude-channel and
+/// --include-filename/--exclude-filename command line options.
 pub fn filter_evtx_files(
     mut evtx_files: Vec<PathBuf>,
     include_channel: &Option<Vec<String>>,
@@ -243,6 +274,9 @@ pub fn filter_evtx_files(
     apply_filename_filter(evtx_files, exclude_filename, true)
 }
 
+/// Filters evtx files by the channel recorded in their first event. Builds a minimal synthetic
+/// rule that lists the requested channels and reuses the rule-vs-evtx channel matching logic
+/// (create_channel_filter) to decide which files match.
 fn apply_channel_filter(
     mut evtx_files: Vec<PathBuf>,
     channels: &Option<Vec<String>>,
@@ -264,15 +298,20 @@ detection:
         let yaml_data = YamlLoader::load_from_str(yaml_str.as_str());
         let maybe_doc = yaml_data.ok().and_then(|docs| docs.into_iter().next());
         if let Some(doc) = maybe_doc {
+            // The rule path label ("log-metrics") is arbitrary: only channel matching matters
+            // here, so the synthetic rule never surfaces to the user.
             let node = RuleNode::new("log-metrics".to_string(), doc);
             let node = vec![node];
             let mut channel_filter = create_channel_filter(&evtx_files, &node, false);
-            evtx_files.retain(|e| channel_filter.scanable_rule_exists(e) != is_exclude);
+            // Keep the files whose match result differs from is_exclude: matching files for an
+            // include filter, non-matching files for an exclude filter.
+            evtx_files.retain(|e| channel_filter.scannable_rule_exists(e) != is_exclude);
         }
     }
     evtx_files
 }
 
+/// Filters evtx files by file name using case-insensitive wildcard patterns (e.g. "*.evtx").
 fn apply_filename_filter(
     mut evtx_files: Vec<PathBuf>,
     patterns: &Option<Vec<String>>,
@@ -301,7 +340,7 @@ mod tests {
     use yaml_rust2::YamlLoader;
 
     #[test]
-    fn test_channel_filter_scanable_rule_exists() {
+    fn test_channel_filter_scannable_rule_exists() {
         let mut channel_filter = ChannelFilter::new();
         channel_filter
             .evtx_channels_map
@@ -310,8 +349,8 @@ mod tests {
             .intersec_channels
             .insert("channel1".to_string());
 
-        assert!(channel_filter.scanable_rule_exists(&PathBuf::from("path1")));
-        assert!(!channel_filter.scanable_rule_exists(&PathBuf::from("path2")));
+        assert!(channel_filter.scannable_rule_exists(&PathBuf::from("path1")));
+        assert!(!channel_filter.scannable_rule_exists(&PathBuf::from("path2")));
     }
 
     #[test]
@@ -421,6 +460,6 @@ mod tests {
         let rule = RuleNode::new("test_files/evtx/test1.evtx".to_string(), test_yaml_data);
         let rule_nodes = vec![rule];
         let result = create_channel_filter(&evtx_files, &rule_nodes, false);
-        assert_eq!(result.rulepathes.len(), 0);
+        assert_eq!(result.rule_paths.len(), 0);
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -7,6 +7,8 @@ use hashbrown::{HashMap, HashSet};
 use lazy_static::lazy_static;
 use rust_embed::Embed;
 lazy_static! {
+    // Computer names listed in config/critical_systems.txt. Alerts for these hosts get their
+    // level raised by one step (see LEVEL::convert). Missing file means an empty set.
     static ref CRITICAL_SYSTEM: HashSet<String> = {
         let current = CURRENT_EXE_PATH.to_path_buf();
         let path = current.join("config/critical_systems.txt");
@@ -23,11 +25,15 @@ use strum::EnumIter;
 
 use termcolor::Color;
 
+/// Embedded copy of config/level_color.txt, used as a fallback when the file cannot be read
+/// from disk.
 #[derive(Embed)]
 #[folder = "config"]
 #[include = "level_color.txt"]
 struct LevelColor;
 
+/// Rule severity level. Variants are declared from lowest to highest severity; use index() for
+/// numeric comparison (e.g. minimum-level filtering).
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, Default, Hash)]
 pub enum LEVEL {
     #[default]
@@ -41,6 +47,8 @@ pub enum LEVEL {
 }
 
 impl LEVEL {
+    /// Parses a full level name (case-insensitive). Abbreviations such as "info" are not
+    /// accepted; any unrecognized string maps to UNDEFINED.
     pub fn from(s: &str) -> Self {
         let s = s.to_lowercase();
         let s = s.as_str();
@@ -78,6 +86,8 @@ impl LEVEL {
         }
     }
 
+    /// Numeric severity rank (higher = more severe), used for sorting detections and for
+    /// minimum-level filtering.
     pub fn index(&self) -> usize {
         match *self {
             LEVEL::UNDEFINED => 0,
@@ -90,6 +100,11 @@ impl LEVEL {
         }
     }
 
+    /// Raises the level by one step when any of the computer names is listed in
+    /// config/critical_systems.txt; otherwise returns the level unchanged. `computer` may
+    /// contain several names joined with " ¦ " (count/correlation results combine the computer
+    /// names of all contributing records).
+    /// INFORMATIONAL stays INFORMATIONAL and EMERGENCY is already the maximum.
     pub fn convert(&self, computer: &str) -> &LEVEL {
         // If the computer is included in CRITICAL_SYSTEM, raise the level.
         let computers = computer.split(" ¦ ");
@@ -116,7 +131,9 @@ impl PartialEq<str> for LEVEL {
     }
 }
 
-/// Reads the level_color.txt file and returns the corresponding text color mapping.
+/// Reads the level_color.txt file and returns the level-to-text-color mapping. Falls back to
+/// the embedded copy when the file cannot be read from disk, and returns an empty map (no
+/// coloring) when the no_color flag is set.
 pub fn create_output_color_map(no_color_flag: bool) -> HashMap<LEVEL, Colors> {
     let path = utils::check_setting_path(Path::new("."), "config/level_color.txt", false)
         .unwrap_or_else(|| {
@@ -147,7 +164,8 @@ pub fn create_output_color_map(no_color_flag: bool) -> HashMap<LEVEL, Colors> {
     let color_map_contents = match read_result {
         Ok(c) => c,
         Err(e) => {
-            // If there is no color information, only the normal white output will appear and it will not affect behavior, so it is treated as a warning.
+            // Missing color information only means output falls back to the default uncolored
+            // text and does not affect behavior, so it is treated as a warning, not an error.
             AlertMessage::warn(&e).ok();
             return color_map;
         }
@@ -210,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    /// To confirm that empty character color mapping data is returned when the no_color flag is given.
+    /// Confirms that an empty color map is returned when the no_color flag is given.
     fn test_set_output_color_no_color_flag() {
         let expect: HashMap<LEVEL, Colors> = HashMap::new();
         check_hashmap_data(create_output_color_map(true), expect);

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,8 @@ struct Contributors;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-// The number of records to load and scan at one time.
-// The number of records to load and scan at a time. 1000 gave the fastest results and lowest memory usage in test benchmarks.
+// The number of records to load and scan at a time. In test benchmarks, 1000 gave the fastest
+// results and the lowest memory usage.
 const MAX_DETECT_RECORDS: usize = 1000;
 
 fn main() {
@@ -106,6 +106,10 @@ fn main() {
     app.rt.shutdown_background();
 }
 
+/// RAII guard that disables WOW64 filesystem redirection while it is alive and restores the
+/// previous state on drop. Without this, a 32-bit binary running on 64-bit Windows would have
+/// paths like C:\Windows\System32\winevt\Logs silently redirected to SysWOW64 and could not read
+/// the real event logs. On non-Windows targets this is a no-op.
 struct Wow64RedirectionGuard {
     #[cfg(target_os = "windows")]
     old_state: *mut c_void,
@@ -142,6 +146,8 @@ impl Drop for Wow64RedirectionGuard {
     }
 }
 
+/// Application driver: owns the Tokio runtime used for record processing and the union of event
+/// field keys referenced by the loaded detection rules.
 pub struct App {
     rt: Runtime,
     rule_keys: Nested<String>,
@@ -155,6 +161,8 @@ impl App {
         }
     }
 
+    /// Dispatch and run the subcommand selected on the command line, then print the closing
+    /// summary output (elapsed time, error log, HTML report, etc.).
     fn exec(&mut self, app: &mut Command, stored_static: &mut StoredStatic) {
         if stored_static.profiles.is_none() {
             return;
@@ -191,7 +199,7 @@ impl App {
             return;
         }
 
-        // Show usage when no arguments.
+        // Show usage when no arguments are provided.
         if stored_static.config.action.is_none() {
             if !stored_static.common_options.quiet {
                 self.output_logo(stored_static);
@@ -224,7 +232,9 @@ impl App {
             return;
         }
 
-        // Prevent errors when running from a directory other than the current directory without the rules-config option.
+        // If the rules-config option was not specified (the path is still the default
+        // ./rules/config), resolve it relative to the executable's directory so that running
+        // Hayabusa from a different current directory does not cause errors.
         if stored_static.config_path == Path::new("./rules/config") {
             stored_static.config_path =
                 check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), "rules/config", true).unwrap();
@@ -338,11 +348,11 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                         checked_item_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                         picked_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
                         values_style: Style::new().color256(46), // green
-                        prompt_prefix: Style::new().color256(160).apply_to("?".to_string()), // orange
-                        prompt_suffix: Style::new().color256(15).apply_to("›".to_string()),  // cyan
-                        prompt_style: Style::new().color256(160).bold(),                     // red
-                        defaults_style: Style::new().color256(51),                           // cyan
-                        hint_style: Style::new().color256(214), // orange
+                        prompt_prefix: Style::new().color256(160).apply_to("?".to_string()), // red
+                        prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // white
+                        prompt_style: Style::new().color256(160).bold(), // red
+                        defaults_style: Style::new().color256(51), // cyan
+                        hint_style: Style::new().color256(214),  // orange
                         success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
                         success_suffix: Style::new().color256(15).apply_to("·".to_string()), // white
                         ..Default::default()
@@ -429,7 +439,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
 
         match &stored_static.config.action.as_ref().unwrap() {
             Action::CsvTimeline(_) | Action::JsonTimeline(_) => {
-                // Prevent errors when running from a directory other than the current directory without the rules option.
+                // If the rules option was not specified (the path is still the default ./rules),
+                // resolve it relative to the executable's directory so that running Hayabusa from
+                // a different current directory does not cause errors.
                 if stored_static.output_option.as_ref().unwrap().rules == Path::new("./rules") {
                     if Path::new("./encoded_rules.yml").exists() {
                         stored_static.output_option.as_mut().unwrap().rules = check_setting_path(
@@ -454,7 +466,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 }
                 if let Some(html_path) = &stored_static.output_option.as_ref().unwrap().html_report
                 {
-                    // if already exists same html report file. output alert message and exit
+                    // If an HTML report file with the same name already exists, output an alert message and exit.
                     if !stored_static.output_option.as_ref().unwrap().clobber
                         && utils::check_file_expect_not_exist(
                             html_path.as_path(),
@@ -697,7 +709,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                     _ => None,
                 };
                 println!();
-                // If an error occurs, do not output errors because there may be issues such as no internet connection.
+                // If an error occurs (e.g. no internet connection), ignore it and do not output
+                // an error message.
                 let latest_version_data = Update::get_latest_hayabusa_version().unwrap_or_default();
                 let now_version = &format!("v{}", env!("CARGO_PKG_VERSION"));
                 stored_static.include_status.insert("*".into());
@@ -965,7 +978,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 } else {
                     &opt.rules
                 };
-                // Check the rule config folder and files, and terminate if there are errors.
+                // Terminate with an alert if the rules directory does not exist.
                 if !rule_dir.exists() {
                     AlertMessage::alert(
                         "The rules directory does not exist. Please check the path.",
@@ -1143,6 +1156,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         }
     }
 
+    /// Determine the input source (live analysis, directory tree, or single file), collect the
+    /// target files, and start the analysis.
     fn analysis_start(
         &mut self,
         target_extensions: &HashSet<String>,
@@ -1267,6 +1282,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         }
     }
 
+    /// Recursively collect files under `dir_path` whose extension is one of `target_extensions`,
+    /// skipping hidden files (names starting with a dot).
     fn collect_evtxfiles(
         dir_path: &str,
         target_extensions: &HashSet<String>,
@@ -1345,6 +1362,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         .ok();
     }
 
+    /// Run the scan over the collected files: show the rule-set wizard if enabled, load and
+    /// filter the detection rules, apply channel filters, analyze each file, and emit the
+    /// results.
     fn analysis_files(
         &mut self,
         mut evtx_files: Vec<PathBuf>,
@@ -1416,7 +1436,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 .lock()
                 .as_mut()
                 .unwrap()
-                .rap_checkpoint("Rule Parse Processing Time");
+                .lap_checkpoint("Rule Parse Processing Time");
             let mut rule_counter_wizard_map = HashMap::new();
             yaml::count_rules(
                 &stored_static.output_option.as_ref().unwrap().rules,
@@ -1432,7 +1452,13 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 true,
             )
             .ok();
-            let calcurate_wizard_rule_count = |exclude_noisytarget_flag: bool,
+            // Count the loadable rules per status (or per tag when target_tags is non-empty) at
+            // or above min_level, based on rule_counter_wizard_map, which is keyed as
+            // status -> level -> tag -> count. When exclude_noisytarget_flag is set, only the
+            // statuses in exclude_noisy_status are counted (used for the deprecated/unsupported/
+            // noisy prompts); otherwise those statuses are skipped, unless target_status contains
+            // "*", in which case all statuses (including the noisy/deprecated ones) are counted.
+            let calculate_wizard_rule_count = |exclude_noisytarget_flag: bool,
                                                exclude_noisy_status: Vec<&str>,
                                                min_level: &str,
                                                target_status: Vec<&str>,
@@ -1517,7 +1543,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             let sections_rule_cnt = selections_status
                 .iter()
                 .map(|(_, (status, min_level))| {
-                    calcurate_wizard_rule_count(
+                    calculate_wizard_rule_count(
                         false,
                         ["excluded", "deprecated", "unsupported", "noisy"].to_vec(),
                         min_level,
@@ -1602,7 +1628,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                     picked_item_prefix: Style::new().color256(214).apply_to("❯".to_string()), // orange
                     values_style: Style::new().color256(46), // green
                     prompt_prefix: Style::new().color256(214).apply_to("?".to_string()), // orange
-                    prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // cyan
+                    prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // white
                     defaults_style: Style::new().color256(51), // cyan
                     hint_style: Style::new().color256(214),  // orange
                     success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
@@ -1624,7 +1650,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             stored_static.output_option.as_mut().unwrap().min_level =
                 selections_status[selected_index].1.1.into();
 
-            let exclude_noisy_cnt = calcurate_wizard_rule_count(
+            let exclude_noisy_cnt = calculate_wizard_rule_count(
                 true,
                 ["excluded", "noisy", "deprecated", "unsupported"].to_vec(),
                 selections_status[selected_index].1.1,
@@ -1642,7 +1668,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
 
             let mut output_option = stored_static.output_option.clone().unwrap();
             let exclude_tags = output_option.exclude_tag.get_or_insert_with(Vec::new);
-            let tags_cnt = calcurate_wizard_rule_count(
+            let tags_cnt = calculate_wizard_rule_count(
                 false,
                 [].to_vec(),
                 selections_status[selected_index].1.1,
@@ -1691,7 +1717,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             } else {
                 // If "4. All alert rules" or "5. All event and alert rules" was selected, ask questions about deprecated and unsupported rules.
                 if let Some(dep_cnt) = exclude_noisy_cnt.get("deprecated") {
-                    // deprecated rules load prompt
+                    // Prompt whether to load deprecated rules.
                     let prompt_fmt = format!(
                         "Include deprecated rules? ({} rules)",
                         dep_cnt.to_formatted_string(&Locale::en)
@@ -1711,7 +1737,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                     }
                 }
                 if let Some(unsup_cnt) = exclude_noisy_cnt.get("unsupported") {
-                    // unsupported rules load prompt
+                    // Prompt whether to load unsupported rules.
                     let prompt_fmt = format!(
                         "Include unsupported rules? ({} rules)",
                         unsup_cnt.to_formatted_string(&Locale::en)
@@ -1739,7 +1765,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 .set_checkpoint(Local::now());
 
             if let Some(noisy_cnt) = exclude_noisy_cnt.get("noisy") {
-                // noisy rules load prompt
+                // Prompt whether to load noisy rules.
                 let prompt_fmt = format!(
                     "Include noisy rules? ({} rules)",
                     noisy_cnt.to_formatted_string(&Locale::en)
@@ -1867,7 +1893,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 .lock()
                 .as_mut()
                 .unwrap()
-                .rap_checkpoint("Rule Parse Processing Time");
+                .lap_checkpoint("Rule Parse Processing Time");
             CHECKPOINT
                 .lock()
                 .as_mut()
@@ -1901,7 +1927,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                     stored_static.quiet_errors_flag,
                 );
                 if !stored_static.scan_all_evtx_files {
-                    evtx_files.retain(|e| channel_filter.scanable_rule_exists(e));
+                    evtx_files.retain(|e| channel_filter.scannable_rule_exists(e));
                     write_color_buffer(
                         &BufferWriter::stdout(ColorChoice::Always),
                         get_writable_color(
@@ -1922,7 +1948,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 }
                 if !stored_static.enable_all_rules {
                     rule_files.retain(|r| {
-                        channel_filter.rulepathes.contains(&r.rulepath)
+                        channel_filter.rule_paths.contains(&r.rulepath)
                             || !r.yaml["correlation"].is_badvalue()
                     });
                     let rules_after_channel_filter =
@@ -1984,7 +2010,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             let rule_files = vec![node];
             let mut channel_filter =
                 create_channel_filter(&evtx_files, &rule_files, stored_static.quiet_errors_flag);
-            evtx_files.retain(|e| channel_filter.scanable_rule_exists(e));
+            evtx_files.retain(|e| channel_filter.scannable_rule_exists(e));
         }
 
         if matches!(
@@ -2005,7 +2031,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             let rule_files = vec![node];
             let mut channel_filter =
                 create_channel_filter(&evtx_files, &rule_files, stored_static.quiet_errors_flag);
-            evtx_files.retain(|e| channel_filter.scanable_rule_exists(e));
+            evtx_files.retain(|e| channel_filter.scannable_rule_exists(e));
         }
 
         if let Some(Action::LogMetrics(opt)) = &stored_static.config.action {
@@ -2018,6 +2044,10 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             );
         }
 
+        // Build the indicatif progress bar template. In the colored branch, the doubled braces
+        // in the format! call are escapes that produce literal braces, so the indicatif
+        // placeholders like {elapsed_precise} survive intact while the spinner and bar are
+        // wrapped in green truecolor escape sequences.
         let template = if stored_static.common_options.no_color {
             "[{elapsed_precise}] {human_pos} / {human_len} {spinner} [{bar:40}] {percent}%\n\n{msg}"
                 .to_string()
@@ -2029,7 +2059,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             )
         };
 
-        let progress_style = ProgressStyle::with_template(&template) // Pass `&template` here
+        let progress_style = ProgressStyle::with_template(&template)
             .unwrap()
             .progress_chars("=> ");
 
@@ -2124,7 +2154,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             .lock()
             .as_mut()
             .unwrap()
-            .rap_checkpoint("Analysis Processing Time");
+            .lap_checkpoint("Analysis Processing Time");
         CHECKPOINT
             .lock()
             .as_mut()
@@ -2149,7 +2179,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             tl.config_critical_systems_dsp_msg(stored_static.common_options.no_color);
         }
         if is_timeline_cmd {
-            let mut log_records = detection.add_aggcondition_msges(&self.rt, stored_static);
+            let mut log_records = detection.add_aggcondition_msgs(&self.rt, stored_static);
             if stored_static.is_low_memory {
                 let empty_ids = HashSet::new();
                 afterfact::emit_csv(
@@ -2180,7 +2210,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             } else {
                 style("Scanning finished.\n").color256(214).to_string()
             };
-            // Convert the ColoredString to a String before passing it
+            // The styled message was converted to a plain String above because
+            // finish_with_message requires a string type.
             if is_show_progress {
                 pb.finish_with_message(msg);
             } else {
@@ -2196,7 +2227,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 .ok();
             }
 
-            // output afterfact
+            // Output the post-detection results (afterfact processing).
             if stored_static.is_low_memory {
                 afterfact::output_additional_afterfact(
                     stored_static,
@@ -2224,7 +2255,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             .lock()
             .as_mut()
             .unwrap()
-            .rap_checkpoint("Output Processing Time");
+            .lap_checkpoint("Output Processing Time");
         CHECKPOINT
             .lock()
             .as_mut()
@@ -2232,7 +2263,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             .set_checkpoint(Local::now());
     }
 
-    // Analyze one Windows event log file.
+    /// Analyze one Windows .evtx event log file: iterate its records in chunks of
+    /// MAX_DETECT_RECORDS, apply the computer/EventID/channel/time filters, and run timeline
+    /// processing and rule detection on the surviving records.
     fn analysis_file(
         &self,
         (evtx_filepath, time_filter, target_event_ids, stored_static): (
@@ -2369,7 +2402,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             ));
             tl.start(&records_per_detect, stored_static);
             if need_rule {
-                // detect event record by rule file
+                // Run the loaded detection rules against this batch of records.
                 let (detection_tmp, mut log_records) =
                     detection.start(&self.rt, records_per_detect);
 
@@ -2406,7 +2439,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         (detection, record_cnt, tl, recover_records_cnt, detect_infos)
     }
 
-    // Perform filtering by time and channel, and return true if filtered.
+    /// Apply the computer, EventID, channel, and timestamp filters to a JSON record. Returns
+    /// true if the record should be filtered out (skipped).
     fn is_filtered_record(
         &self,
         (path, time_filter, target_event_ids, stored_static): (
@@ -2429,7 +2463,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             return true;
         }
 
-        // EventIDがinclude_eidで指定されたものに合致しないまたはexclude_eidで指定されたものに合致した場合、EventID Filter optionが指定されていないかつtarget_eventids.txtで指定されたEventIDではない場合はフィルタリングする。
+        // Filter if the EventID does not match one specified in include_eid or matches one
+        // specified in exclude_eid, or if the EventID filter option is specified and the EventID
+        // is not one specified in target_eventids.txt.
         if self.is_filtered_by_eid(
             data,
             &stored_static.eventkey_alias,
@@ -2506,7 +2542,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         false
     }
 
-    // Analyze one JSON-format event log file.
+    /// Analyze one JSON-format event log file (JSONL, JSON array, or Splunk exports): normalize
+    /// each record so it looks like an evtx-converted record (Event.System, Event.EventData,
+    /// etc.), then apply the filters and run timeline processing and rule detection.
     fn analysis_json_file(
         &self,
         (filepath, time_filter, target_event_ids, stored_static): (
@@ -2561,7 +2599,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         loop {
             let mut records_per_detect = vec![];
             while records_per_detect.len() < MAX_DETECT_RECORDS {
-                // If parsing fails, output an error message.
+                // Read the next record; stop this chunk when the iterator is exhausted.
                 let next_rec = records.next();
                 if next_rec.is_none() {
                     break;
@@ -2569,7 +2607,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 let mut data = next_rec.unwrap();
                 let is_splunk_json = data["Event"]["EventData"]["result"].is_object();
                 is_splunk_api_json = !data["Event"]["EventData"]["rows"].is_null();
-                // Data such as Channel must exist in Event -> System, but considering other processing, the data from Event -> EventData is inserted as-is. clone is used because serde_json::Value does not implement the Copy trait.
+                // Data such as Channel must exist in Event -> System, but to keep the rest of
+                // the processing simple, the data from Event -> EventData is inserted as-is.
+                // clone() is used because serde_json::Value does not implement the Copy trait.
                 if is_splunk_api_json {
                     let tmp_data = data["Event"]["EventData"]["rows"].clone();
                     let tmp_data_value = data["Event"]["EventData"]["fields"].clone();
@@ -2581,7 +2621,11 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                         let mut splunk_api_record = Value::Null;
                         for (v_idx, row_name) in fields_key.iter().enumerate() {
                             if let Some(row) = row_name.as_str() {
-                                // splunk api jsonの場合はrowsとfieldsのデータをEventDataに投入する。rawデータがはレコード情報がそのまま入っているのでその情報を投入したうえでsplunk api json関連のレコード類を投入する
+                                // For Splunk API JSON, the record comes as parallel "rows"
+                                // (values) and "fields" (names) arrays. Insert each value under
+                                // both Event.System and Event.EventData keyed by its field name:
+                                // later processing expects System fields (e.g. Channel, EventID)
+                                // under Event.System and reads field data from Event.EventData.
                                 splunk_api_record["Event"]["System"][row.to_string()] =
                                     splunk_api_rec[v_idx].clone();
                                 splunk_api_record["Event"]["EventData"][row.to_string()] =
@@ -2650,7 +2694,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                         splunk_api_record["Event"]["System"]["Provider_attributes"]["Name"] =
                             splunk_api_record["Event"]["EventData"]["Name"].clone();
                         if stored_static.computer_metrics_flag {
-                            // The computer-metrics command does not perform detection, so only count and check the next record.
+                            // The computer-metrics command does not perform detection, so only
+                            // count the event by computer name.
                             countup_event_by_computer(
                                 &splunk_api_record,
                                 &stored_static.eventkey_alias,
@@ -2725,7 +2770,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 } else {
                     data["Event"]["System"]["Provider_attributes"]["Name"] =
                         data["Event"]["EventData"]["SourceName"].clone();
-                    // Since the content corresponding to the Computer name was found to be Hostname, clone and insert the data.
+                    // The field corresponding to the Computer name turned out to be Hostname, so
+                    // clone that value into System.Computer.
                     data["Event"]["System"]["Computer"] =
                         data["Event"]["EventData"]["Hostname"].clone();
                 }
@@ -2790,6 +2836,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         (detection, record_cnt, tl, recover_records_cnt, detect_infos)
     }
 
+    /// Convert a chunk of raw JSON records into EvtxRecordInfo structs in parallel on the Tokio
+    /// runtime (one task per record).
     async fn create_rec_infos(
         records_per_detect: Vec<(Value, bool)>,
         path: &dyn Display,
@@ -2827,6 +2875,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         ret
     }
 
+    /// Collect the deduplicated set of event field keys referenced by the detection sections of
+    /// all loaded rules.
     fn get_all_keys(&self, rules: &[RuleNode]) -> Nested<String> {
         let mut key_set = HashSet::new();
         for rule in rules {
@@ -2873,6 +2923,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         }
     }
 
+    /// Returns true if the record should be filtered out based on its EventID (the include/
+    /// exclude EID options and the target_eventids.txt filter).
     fn is_filtered_by_eid(
         &self,
         data: &Value,
@@ -2901,6 +2953,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             || (eid_filter && !self._is_target_event_id(data, target_event_ids, eventkey_alias))
     }
 
+    /// Open an .evtx file and return an EvtxParser configured for JSON output. Returns None
+    /// (after logging the error) if the file cannot be opened.
     fn evtx_to_jsons(
         &self,
         evtx_filepath: &PathBuf,
@@ -2938,7 +2992,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         }
     }
 
-    /// output logo
+    /// Output the Hayabusa ASCII art logo.
     fn output_logo(&self, stored_static: &StoredStatic) {
         let logo = Arts::get("logo.txt").unwrap();
         let content = std::str::from_utf8(logo.data.as_ref()).unwrap_or_default();
@@ -2956,7 +3010,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         .ok();
     }
 
-    /// output easter egg arts
+    /// Output seasonal easter egg ASCII art when the run date matches a special day.
     fn output_eggs(&self, exec_datestr: &str) {
         let mut eggs: HashMap<&str, (&str, Color)> = HashMap::new();
         eggs.insert("01/01", ("happynewyear.txt", Color::Rgb(255, 0, 0))); // Red
@@ -2983,6 +3037,8 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         }
     }
 
+    /// Print a random line from the given messages file (rules/config/opening_messages.txt or
+    /// closing_messages.txt), unless quiet mode is enabled.
     fn output_open_close_message(
         &self,
         file_path: &str,
@@ -3035,7 +3091,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         Ok(())
     }
 
-    /// check architecture
+    /// Check whether this binary's architecture matches the OS architecture. Returns false for a
+    /// 32-bit binary running on 64-bit Windows (WOW64), in which case filesystem redirection
+    /// must be disabled so the real System32 event logs can be read.
     fn is_matched_architecture_and_binary(&self) -> bool {
         if cfg!(target_os = "windows") {
             let is_processor_arch_32bit = env::var_os("PROCESSOR_ARCHITECTURE")
@@ -3051,6 +3109,9 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
         true
     }
 
+    /// Returns false when a subcommand that requires arguments was invoked with none (i.e. argv
+    /// only contains the program name and the subcommand), so that its help can be printed
+    /// instead of running.
     fn check_is_valid_args_num(&self, action: Option<&Action>) -> bool {
         // Under `cargo test`, `env::args()` is the test harness's argv (e.g. it
         // contains `--test-threads=1` or a test-name filter), not hayabusa's own
@@ -3256,7 +3317,7 @@ mod tests {
         // TODO add check
         // assert_eq!(MESSAGES.len(), 0);
 
-        // Create the test file.
+        // Delete the test file.
         remove_file("overwrite_csv_exit.csv").ok();
     }
 
@@ -3296,7 +3357,7 @@ mod tests {
         app.exec(&mut config_reader.app, &mut stored_static);
         // TODO add check
         // assert_ne!(MESSAGES.len(), 0);
-        // Create the test file.
+        // Delete the test file.
         remove_file("overwrite_csv_clobber.csv").ok();
     }
 
@@ -3337,7 +3398,7 @@ mod tests {
         // TODO add check
         // assert_eq!(MESSAGES.len(), 0);
 
-        // Create the test file.
+        // Delete the test file.
         remove_file("overwrite_json_exit.json").ok();
     }
 

--- a/src/options/expand_list.rs
+++ b/src/options/expand_list.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use yaml_rust2::YamlLoader;
 use yaml_rust2::yaml::Hash;
 
+/// Recursively collects the paths of all `.yml` files under `dir`.
 fn list_yml_files<P: AsRef<Path>>(dir: P) -> Vec<String> {
     let mut yml_files = Vec::new();
     if let Ok(entries) = fs::read_dir(dir) {
@@ -22,6 +23,10 @@ fn list_yml_files<P: AsRef<Path>>(dir: P) -> Vec<String> {
     yml_files
 }
 
+/// Walks a rule's detection section and records every key that uses the `|expand` modifier,
+/// mapping the key (e.g. `CommandLine|expand`) to its string value, which is the placeholder
+/// (e.g. `%Admins_Workstations%`). Only string values are recorded; nested mappings are searched
+/// recursively, but list values are not descended into.
 fn extract_expand_keys_recursive(hash: &Hash, expand_keys: &mut HashMap<String, String>) {
     for (key, value) in hash {
         if let Some(key_str) = key.as_str() {
@@ -42,6 +47,10 @@ fn extract_expand_keys(detection: &Hash) -> HashMap<String, String> {
     expand_keys
 }
 
+/// Returns the set of placeholder strings (e.g. `%Admins_Workstations%`) referenced by `|expand`
+/// field modifiers in the detection sections of all `.yml` rules under `dir`. This backs the
+/// `expand-list` command, which shows users which placeholders they need to define in
+/// `config/expand`.
 pub fn expand_list(dir: &PathBuf) -> HashSet<String> {
     let yml_files = list_yml_files(dir);
     let mut result = HashSet::new();

--- a/src/options/geoip_search.rs
+++ b/src/options/geoip_search.rs
@@ -9,8 +9,13 @@ use std::sync::Mutex;
 use std::{net::IpAddr, str::FromStr};
 
 lazy_static! {
+    // Cache of IP address -> formatted geo data ("ASN🦅Country🦅City"), so each address is only
+    // looked up in the MaxMind databases once.
     pub static ref IP_MAP: Mutex<HashMap<IpAddr, CompactString>> = Mutex::new(HashMap::new());
 }
+
+/// Wraps the three MaxMind GeoLite2 database readers (ASN, Country, City) used to enrich IP
+/// addresses found in event records when the GeoIP option is enabled.
 pub struct GeoIPSearch {
     pub asn_reader: Reader<Vec<u8>>,
     pub country_reader: Reader<Vec<u8>>,
@@ -18,6 +23,8 @@ pub struct GeoIPSearch {
 }
 
 impl GeoIPSearch {
+    /// Opens the three .mmdb databases. `asn_country_city_filename` must list the ASN, Country
+    /// and City database file names in that order.
     pub fn new(path: &Path, asn_country_city_filename: Vec<&str>) -> GeoIPSearch {
         GeoIPSearch {
             asn_reader: maxminddb::Reader::open_readfile(path.join(asn_country_city_filename[0]))
@@ -31,7 +38,9 @@ impl GeoIPSearch {
         }
     }
 
-    /// check existence files in specified path by GeoIP option.
+    /// Checks that all .mmdb files required by the GeoIP option exist under the given
+    /// directory. Returns Ok(None) when the option was not specified, and an error listing
+    /// every missing file otherwise.
     pub fn check_exist_geo_ip_files(
         geo_ip_dir_path: &Option<PathBuf>,
         check_files: Vec<&str>,
@@ -56,7 +65,10 @@ impl GeoIPSearch {
         }
     }
 
-    /// check target_ip in private IP range.
+    /// Checks whether target_ip falls within one of the CIDR ranges below, which are excluded
+    /// from GeoIP lookup and reported as "Private". Note that the IPv6 list includes 2000::/3
+    /// (global unicast), so effectively all IPv6 addresses except loopback are treated as
+    /// private.
     fn check_in_private_ip_range(&self, target_ip: &IpAddr) -> bool {
         let private_cidr = if target_ip.is_ipv4() {
             vec![
@@ -82,11 +94,16 @@ impl GeoIPSearch {
         false
     }
 
-    /// convert IP address string to geo data
+    /// Resolves an IP address string to geo data in the form "ASN🦅Country🦅City" (the caller
+    /// splits on '🦅' to fill the SrcASN/SrcCountry/SrcCity etc. profile fields). Local and
+    /// private addresses get placeholder values without a database lookup.
     pub fn convert_ip_to_geo(&self, target_ip: &str) -> Result<String, MaxMindDbError> {
+        // Some events (e.g. RDP logons) record the literal string "LOCAL" instead of an IP
+        // address; the first literal checked below is the Japanese-localized equivalent.
         if target_ip == "ローカル" || target_ip == "LOCAL" {
             return Ok("Local🦅-🦅-".to_string());
         }
+        // Strip the IPv4-mapped IPv6 prefix so the address is handled as plain IPv4.
         let target = if target_ip.starts_with("::ffff:") {
             target_ip.replace("::ffff:", "")
         } else {
@@ -108,7 +125,8 @@ impl GeoIPSearch {
             return Ok("Private🦅-🦅-".to_string());
         }
 
-        // If the IP address is the same, the result obtained is the same, so the lookup process is omitted by obtaining the result of a hit from the cache.
+        // The same IP address always resolves to the same geo data, so return the cached result
+        // when available and skip the database lookups.
         if let Some(cached_data) = IP_MAP.lock().unwrap().get(&addr) {
             return Ok(cached_data.to_string());
         }
@@ -229,9 +247,10 @@ mod tests {
         let test_path = Path::new("test_files/mmdb").to_path_buf();
 
         // Test files from https://github.com/maxmind/MaxMind-DB/tree/a8ae5b4ac0aa730e2783f708cdaa208aca20e9ec/test-data
-        // GeoLite2-ASN.mmdb -> GeoLite2.ASN-Test.mmdb
-        // GeoLite2-Country.mmdb -> GeoLite2.Country-Test.mmdb
-        // GeoLite2-City.mmdb -> GeoLite2.City-Test.mmdb
+        // The upstream files were renamed locally as follows:
+        //   GeoLite2-ASN-Test.mmdb     -> GeoLite2-ASN.mmdb
+        //   GeoLite2-Country-Test.mmdb -> GeoLite2-Country.mmdb
+        //   GeoLite2-City-Test.mmdb    -> GeoLite2-City.mmdb
         let target_files = vec![
             "GeoLite2-ASN.mmdb",
             "GeoLite2-Country.mmdb",

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -15,11 +15,15 @@ use std::path::Path;
 use std::sync::RwLock;
 use termcolor::{BufferWriter, Color, ColorChoice};
 
+/// Static assets for the HTML report (CSS, logo, favicon) embedded into the binary at compile
+/// time from config/html_report/.
 #[derive(Embed)]
 #[folder = "config/html_report/"]
 struct HtmlReportsConfig;
 
 lazy_static! {
+    /// Global accumulator for the HTML report contents. Sections are filled in while the analysis
+    /// runs and rendered to HTML at the end.
     pub static ref HTML_REPORTER: RwLock<HtmlReporter> = RwLock::new(HtmlReporter::new());
 }
 
@@ -29,9 +33,12 @@ lazy_static! {
 #[cfg(test)]
 pub(crate) static HTML_REPORTER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Accumulates the markdown fragments that make up the HTML report.
 #[derive(Clone)]
 pub struct HtmlReporter {
+    /// Section names in the order they should appear in the report.
     pub section_order: Nested<String>,
+    /// Markdown lines per section name.
     pub md_datas: HashMap<String, Nested<String>>,
 }
 
@@ -44,7 +51,8 @@ impl HtmlReporter {
         }
     }
 
-    /// return converted String from md_data(markdown fmt string).
+    /// Renders the accumulated markdown data of every section (in section_order) into a single
+    /// HTML string.
     pub fn create_html(self) -> String {
         let mut options = Options::empty();
         options.insert(Options::ENABLE_TABLES);
@@ -77,6 +85,8 @@ impl Default for HtmlReporter {
     }
 }
 
+/// Returns true when the csv-timeline or json-timeline action was invoked with the
+/// -H/--HTML-report option.
 pub fn check_html_flag(config: &Config) -> bool {
     if config.action.as_ref().is_none() {
         return false;
@@ -88,7 +98,8 @@ pub fn check_html_flag(config: &Config) -> bool {
     }
 }
 
-/// get html report section data in HashMap
+/// Builds the initial section order and the empty per-section markdown map. The `{#id}` suffixes
+/// in the section names become HTML heading ids via the heading-attributes markdown extension.
 fn get_init_md_data_map() -> (Nested<String>, HashMap<String, Nested<String>>) {
     let mut ret = HashMap::new();
     let mut section_order = Nested::<String>::new();
@@ -103,6 +114,7 @@ fn get_init_md_data_map() -> (Nested<String>, HashMap<String, Nested<String>>) {
     (section_order, ret)
 }
 
+/// Appends markdown lines to the given section of the global HTML_REPORTER.
 pub fn add_md_data(section_name: &str, data: Nested<String>) {
     let mut md_with_section_data = HTML_REPORTER.write().unwrap().md_datas.to_owned();
     for c in data.iter() {
@@ -114,7 +126,8 @@ pub fn add_md_data(section_name: &str, data: Nested<String>) {
     HTML_REPORTER.write().unwrap().md_datas = md_with_section_data;
 }
 
-/// create html file
+/// Writes the HTML report to `path_str`, inlining the embedded CSS and embedding the logo and
+/// favicon images as base64 data URIs, then prints the output path to stdout.
 pub fn create_html_file(input_html: String, path_str: &str, no_color: bool) {
     let path = Path::new(path_str);
     if !path.parent().unwrap().exists() {
@@ -171,6 +184,8 @@ pub fn create_html_file(input_html: String, path_str: &str, no_color: bool) {
     .ok();
 }
 
+/// Determines the image type from the file's magic-number prefix (the hex encoding of its first
+/// bytes). Returns an empty string for unsupported types.
 fn get_file_type(hex: &str) -> &str {
     if hex.starts_with("ffd8ffe0") {
         return "jpeg";
@@ -182,6 +197,8 @@ fn get_file_type(hex: &str) -> &str {
     ""
 }
 
+/// Encodes an embedded image file as a `data:image/...;base64,` URI. Returns an empty string if
+/// the file is missing or not a supported image type.
 fn img_to_base64(path: &str) -> String {
     if let Some(file) = HtmlReportsConfig::get(path) {
         let vec = file.data.as_ref();

--- a/src/options/level_tuning.rs
+++ b/src/options/level_tuning.rs
@@ -11,6 +11,8 @@ use termcolor::{BufferWriter, ColorChoice};
 pub struct LevelTuning {}
 
 impl LevelTuning {
+    /// Rewrites the `level:` line of every rule file whose `id` appears in the level tuning
+    /// CSV (rows of `id,new_level`), letting users persistently adjust rule severities.
     pub fn run(
         level_tuning_config_path: &str,
         rules_path: &str,
@@ -21,15 +23,20 @@ impl LevelTuning {
             Err(e) => return Result::Err(e.to_string()),
         };
 
-        // Read Tuning files
+        // Read the tuning file into a rule-id -> new-level map.
         let mut tuning_map: HashMap<String, String> = HashMap::new();
         read_result.iter().try_for_each(|line| -> Result<(), String> {
-            // If the first element also does not exist, it is skipped at the read_csv stage, so get(0) will not be None.
+            // Rows without any columns are already dropped at the read_csv stage, so first()
+            // is never None.
             let id = line.first().unwrap();
             if !configs::IDS_REGEX.is_match(id) {
                 return Result::Err(format!("Failed to read level tuning file. {id} is not correct id format, fix it."));
             }
 
+            // The level column accepts "info" as an abbreviation of "informational" and may
+            // carry a trailing inline comment after '#'
+            // (e.g. "high # 'Rule title' - Originally critical"); only the part before '#'
+            // is kept.
             let level = match line.get(1) {
                 Some(_level) => {
                     if _level.starts_with("informational")
@@ -45,16 +52,18 @@ impl LevelTuning {
                             return Result::Err("level tuning file's level must in informational, low, medium, high, critical".to_string())
                         }
                     }
-                // This error occurs when the header does not have two or more columns.
+                // This only happens when the CSV header row has fewer than two columns: the csv
+                // reader drops any row whose column count differs from the header's.
                 _ => return Result::Err("Failed to read level...".to_string())
             };
             tuning_map.insert(id.to_string(), level);
             Ok(())
         })?;
 
-        // Read Rule files
+        // Read the rule files.
         let mut rulefile_loader = ParseYaml::new(stored_static);
-        //noisy rules and exclude rules treats as update target
+        // An empty RuleExclude is passed so that noisy and excluded rules are also treated as
+        // update targets.
         let result_readdir = rulefile_loader.read_dir(
             rules_path,
             "informational",
@@ -66,7 +75,8 @@ impl LevelTuning {
             return Result::Err(format!("{}", e));
         }
 
-        // Convert rule files
+        // Rewrite the level of every loaded rule whose id appears in the tuning map, by plain
+        // string replacement of the "level: <old>" text in the rule file.
         for (path, rule) in rulefile_loader.files {
             if let Some(new_level) = tuning_map.get(rule["id"].as_str().unwrap()) {
                 write_color_buffer(

--- a/src/options/pivot.rs
+++ b/src/options/pivot.rs
@@ -11,13 +11,20 @@ use crate::detections::utils::{
 
 use crate::detections::configs::{EventKeyAliasConfig, StoredStatic};
 
+/// One pivot keyword category (e.g. "Ip Addresses" or "Users") defined in the pivot keywords
+/// config file.
 #[derive(Debug)]
 pub struct PivotKeyword {
+    /// Unique field values harvested from the scanned records.
     pub keywords: IndexSet<String>,
+    /// Event field names (eventkey aliases) whose values should be collected for this category.
     pub fields: IndexSet<String>,
 }
 
 lazy_static! {
+    /// Global map of pivot keyword category name -> PivotKeyword. The categories and their fields
+    /// are loaded from the pivot keywords config file, and the keyword values are filled in while
+    /// scanning records.
     pub static ref PIVOT_KEYWORD: RwLock<IndexMap<String, PivotKeyword>> =
         RwLock::new(IndexMap::new());
 }
@@ -43,8 +50,8 @@ impl PivotKeyword {
     }
 }
 
-/// For records with a level greater than low, if a keyword is found in the record,
-/// insert it into PIVOT_KEYWORD.keywords.
+/// For records with a level of low or higher, collects the values of every configured pivot
+/// field found in the record into PIVOT_KEYWORD.keywords.
 pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAliasConfig) {
     if let Some(record_level) = get_event_value("Event.System.Level", event_record, eventkey_alias)
     {
@@ -63,12 +70,17 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
         return;
     }
 
+    // For every pivot category, resolve each configured field against the record and collect its
+    // value.
     let mut pivots = PIVOT_KEYWORD.write().unwrap();
     pivots.iter_mut().for_each(|(_, pivot)| {
         for field in &pivot.fields {
             if let Some(array_str) = eventkey_alias.get_event_key(&String::from(field)) {
                 let mut is_exist_event_key = false;
                 let mut tmp_event_record: &Value = event_record;
+                // Walk the dot-separated event key path as far as it matches the record. If the
+                // walk stops on a JSON object (i.e. the full path did not resolve to a scalar),
+                // get_serde_number_to_string below returns None and the field is skipped.
                 for s in array_str.split('.') {
                     if let Some(record) = tmp_event_record.get(s) {
                         is_exist_event_key = true;
@@ -79,6 +91,8 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
                     let hash_value = get_serde_number_to_string(tmp_event_record, false);
 
                     if let Some(value) = hash_value {
+                        // Skip placeholder ("-") and localhost values, which are useless as pivot
+                        // keywords.
                         if value == "-" || value == "127.0.0.1" || value == "::1" {
                             continue;
                         }
@@ -90,7 +104,10 @@ pub fn insert_pivot_keyword(event_record: &Value, eventkey_alias: &EventKeyAlias
     });
 }
 
-// Functions related to standard output of pivot_keywords, etc.
+/// Formats one pivot keyword section for output. When `place` is "standard" the section is
+/// printed directly to stdout (with a colored header) and an empty string is returned; otherwise
+/// ("file") the formatted section is appended to `output` and returned so the caller can write it
+/// to a file.
 pub fn create_output(
     mut output: String,
     key: &String,
@@ -99,7 +116,7 @@ pub fn create_output(
     stored_static: &StoredStatic,
 ) -> String {
     if place == "standard" {
-        //headers
+        // Print the section header (category name and its fields) in green.
         let output = String::default();
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),
@@ -109,7 +126,7 @@ pub fn create_output(
         )
         .ok();
 
-        //keywords_results
+        // Print the collected keyword values.
         let output = String::default();
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),
@@ -125,12 +142,14 @@ pub fn create_output(
     }
 }
 
+/// Appends the section header, e.g. `Ip Addresses: ( %IpAddress% ):`, to `output`.
 pub fn fmt_headers(mut output: String, key: &String, pivot_keyword: &PivotKeyword) -> String {
     write!(output, "{key}: ( ").ok();
     for i in pivot_keyword.fields.iter() {
         write!(output, "%{i}% ").ok();
     }
 
+    // Only add a trailing newline when keyword values will follow the header.
     if pivot_keyword.keywords.is_empty() {
         write!(output, "):").ok();
     } else {
@@ -140,6 +159,7 @@ pub fn fmt_headers(mut output: String, key: &String, pivot_keyword: &PivotKeywor
     output
 }
 
+/// Appends each collected keyword value on its own line to `output`.
 pub fn fmt_keywords_results(mut output: String, pivot_keyword: &PivotKeyword) -> String {
     for i in pivot_keyword.keywords.iter() {
         writeln!(output, "{i}").ok();

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -18,11 +18,17 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 use yaml_rust2::{Yaml, YamlEmitter, YamlLoader};
 
+// Embeds all config/*.yaml files into the binary at build time so the standard profile files can
+// still be loaded when the config folder is missing on disk (see read_profile_data()).
 #[derive(Embed)]
 #[folder = "config/"]
 #[include = "*.yaml"]
 struct DefaultProfile;
 
+/// One output column of a timeline profile. Each variant corresponds to a `%Alias%` placeholder
+/// usable in profiles.yaml and identifies which piece of detection data fills the column. The
+/// inner `Cow` carries the column's data: empty when first parsed from profiles.yaml, later
+/// replaced via `convert()` with the value rendered for each detection.
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub enum Profile {
     Timestamp(Cow<'static, str>),
@@ -58,6 +64,7 @@ pub enum Profile {
 }
 
 impl Profile {
+    /// Returns the inner value regardless of variant.
     pub fn to_value(&self) -> String {
         match &self {
             Timestamp(v) | Computer(v) | Channel(v) | Level(v) | EventID(v) | RecordID(v)
@@ -71,6 +78,8 @@ impl Profile {
         }
     }
 
+    /// Returns a copy of this variant carrying `converted_string` as its value. Used to fill a
+    /// profile column with the value rendered for the record currently being output.
     pub fn convert(&self, converted_string: &CompactString) -> Self {
         match self {
             Timestamp(_) => Timestamp(converted_string.to_owned().into()),
@@ -102,11 +111,14 @@ impl Profile {
             RecoveredRecord(_) => RecoveredRecord(converted_string.to_owned().into()),
             Details(_) => Details(converted_string.to_owned().into()),
             AllFieldInfo(_) => AllFieldInfo(converted_string.to_owned().into()),
+            // Literal is the only variant left: fixed strings are never converted per record.
             p => p.to_owned(),
         }
     }
 }
 
+/// Maps a `%Alias%` placeholder from profiles.yaml to its `Profile` variant. Any string that is
+/// not a known alias becomes a `Literal` and is output verbatim.
 impl From<&str> for Profile {
     fn from(alias: &str) -> Self {
         match alias {
@@ -138,7 +150,8 @@ impl From<&str> for Profile {
     }
 }
 
-// Process to load the profile at the specified path.
+// Loads the profile YAML at the specified path, falling back to the copy embedded in the binary
+// (see DefaultProfile) when the file does not exist on disk.
 fn read_profile_data(profile_path: &str) -> Result<Vec<Yaml>, String> {
     let profile_path_buf = Path::new(profile_path).to_path_buf();
     if let Ok(loaded_profile) = yaml::ParseYaml::read_file(&profile_path_buf) {
@@ -154,7 +167,8 @@ fn read_profile_data(profile_path: &str) -> Result<Vec<Yaml>, String> {
                 .to_str()
                 .unwrap_or_default(),
         );
-        // When loading a normal profile file.
+        // The file was not found on disk, but its file name matches one of the profile files
+        // bundled into the binary, so load the embedded copy instead.
         if let Some(path) = default_profile_name_path {
             match YamlLoader::load_from_str(
                 std::str::from_utf8(path.data.as_ref()).unwrap_or_default(),
@@ -170,7 +184,12 @@ fn read_profile_data(profile_path: &str) -> Result<Vec<Yaml>, String> {
     }
 }
 
-/// Function to load profile information.
+/// Loads the output profile as an ordered list of (column name, field kind) pairs. The profile
+/// named by the --profile option is used if one was given; otherwise the default profile is
+/// loaded. Reserved GeoIP columns are appended when a GeoIP database has been loaded, and a
+/// RecoveredRecord column is appended when record recovery is enabled. Returns None if
+/// `opt_stored_static` is None or the profile cannot be loaded (in the latter case an alert has
+/// already been printed).
 pub fn load_profile(
     default_profile_path: &str,
     profile_path: &str,
@@ -201,13 +220,16 @@ pub fn load_profile(
         }
     };
 
-    // If no results are returned after loading the profile, an Alert is issued, so output None to terminate the program.
+    // If loading the profile yielded no documents, an alert was already printed above, so return
+    // None to make the caller terminate the program.
     if profile_all.is_empty() {
         return None;
     }
     let profile_data = &profile_all[0];
     let mut ret: Vec<(CompactString, Profile)> = vec![];
 
+    // yaml-rust2 hashes preserve insertion order, so the output columns keep the order in which
+    // they are written in the profile file.
     if let Some(profile_name) = profile {
         let target_data = &profile_data[profile_name.as_str()];
         if !target_data.is_badvalue() {
@@ -247,7 +269,8 @@ pub fn load_profile(
                 ));
             });
     }
-    // insert preserved keyword when get-ip option specified.
+    // Append the reserved GeoIP output columns when the GeoIP option was specified (i.e. a GeoIP
+    // database has been loaded).
     if GEOIP_DB_PARSER.read().unwrap().is_some() {
         ret.push((CompactString::from("SrcASN"), SrcASN(Cow::default())));
         ret.push((
@@ -273,7 +296,9 @@ pub fn load_profile(
     Some(ret)
 }
 
-/// Function to set the default profile.
+/// Handles the set-default-profile action: overwrites the default profile file with the contents
+/// of the profile selected by --profile, and records the chosen profile name in
+/// default_profile_name.txt next to it.
 pub fn set_default_profile(
     default_profile_path: &str,
     profile_path: &str,
@@ -355,7 +380,8 @@ pub fn set_default_profile(
     }
 }
 
-/// Get profile name and tag list in yaml file.
+/// Returns one row per profile in the YAML file: the profile name followed by a comma-joined
+/// list of its column placeholders. Backs the list-profiles command.
 pub fn get_profile_list(profile_path: &str) -> Nested<Vec<String>> {
     let ymls = match read_profile_data(
         check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), profile_path, true)
@@ -411,7 +437,8 @@ mod tests {
     }
 
     #[test]
-    /// Process tests sequentially because option settings prevent guaranteed idempotency of values.
+    /// Run these sub-tests sequentially: they set global option state (e.g. GEOIP_DB_PARSER), so
+    /// the results would not be deterministic if the tests ran in parallel.
     fn test_load_profile() {
         test_load_profile_without_profile_option();
         test_load_profile_no_exist_profile_files();

--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -15,7 +15,9 @@ use termcolor::{BufferWriter, Color, ColorChoice};
 pub struct Update {}
 
 impl Update {
-    /// get latest hayabusa version number.
+    /// Gets the latest Hayabusa version number (release tag name) from the GitHub Releases API.
+    /// Note that the returned tag name keeps its JSON string quotes (Value::to_string), which the
+    /// caller strips.
     pub fn get_latest_hayabusa_version() -> Result<Option<String>, Box<dyn std::error::Error>> {
         let text =
             ureq::get("https://api.github.com/repos/Yamato-Security/hayabusa/releases/latest")
@@ -33,10 +35,11 @@ impl Update {
         }
     }
 
-    /// update rules(hayabusa-rules subrepository)
+    /// Updates the detection rules (the hayabusa-rules repository, checked out in the rules
+    /// folder or referenced as a git submodule), then prints which rule files changed.
     pub fn update_rules(
         rule_path: &str,
-        stored_staic: &StoredStatic,
+        stored_static: &StoredStatic,
     ) -> Result<String, git2::Error> {
         let mut result;
         let mut prev_modified_rules: HashMap<String, String> = HashMap::default();
@@ -50,17 +53,20 @@ impl Update {
                 true,
             )
             .ok();
-            // execution git clone of hayabusa-rules repository when failed open hayabusa repository.
+            // Neither the hayabusa repository nor the rules repository could be opened, so git
+            // clone the hayabusa-rules repository from scratch.
             result = Update::clone_rules(Path::new(rule_path));
         } else if hayabusa_rule_repo.is_ok() {
-            // case of exist hayabusa-rules repository
+            // The hayabusa-rules repository already exists: hard reset it to local main, then
+            // pull. If fetching origin/main fails here, no git clone fallback is attempted, so a
+            // failure most likely means a network error.
             Update::_repo_main_reset_hard(hayabusa_rule_repo.as_ref().unwrap())?;
-            // case of failed fetching origin/main, git clone is not executed so network error has occurred possibly.
-            prev_modified_rules = Update::get_updated_rules(rule_path, stored_staic);
+            prev_modified_rules = Update::get_updated_rules(rule_path, stored_static);
             result = Update::pull_repository(&hayabusa_rule_repo.unwrap());
         } else {
-            // case of no exist hayabusa-rules repository in rules.
-            // execute update because submodule information exists if hayabusa repository exists submodule information.
+            // The rules folder is not a git repository, but the hayabusa repository itself could
+            // be opened. If the hayabusa repository has submodule information (i.e. it is a
+            // source checkout), update the rules through the submodule.
 
             let rules_path = Path::new(rule_path);
             if !rules_path.exists() {
@@ -70,7 +76,8 @@ impl Update {
                 let hayabusa_repo = hayabusa_repo.unwrap();
                 let submodules = hayabusa_repo.submodules()?;
                 let mut is_success_submodule_update = true;
-                // submodule rules erase path is hard coding to avoid unintentional remove folder.
+                // The stale submodule metadata path to delete is hardcoded so that no unintended
+                // folder can be removed.
                 fs::remove_dir_all(".git/.submodule/rules").ok();
                 for mut submodule in submodules {
                     submodule.update(true, None)?;
@@ -93,22 +100,24 @@ impl Update {
                     true,
                 )
                 .ok();
-                // execution git clone of hayabusa-rules repository when failed open hayabusa repository.
+                // A custom rules path is not managed as a submodule, so git clone the
+                // hayabusa-rules repository into it instead.
                 result = Update::clone_rules(rules_path);
             }
         }
         if result.is_ok() {
-            let updated_modified_rules = Update::get_updated_rules(rule_path, stored_staic);
+            let updated_modified_rules = Update::get_updated_rules(rule_path, stored_static);
             result = Update::print_diff_modified_rule_dates(
                 prev_modified_rules,
                 updated_modified_rules,
-                stored_staic.common_options.no_color,
+                stored_static.common_options.no_color,
             );
         }
         result
     }
 
-    /// hard reset in main branch
+    /// Hard resets the repository to the head of its local main branch, discarding any local
+    /// changes.
     fn _repo_main_reset_hard(input_repo: &Repository) -> Result<(), git2::Error> {
         let branch = input_repo
             .find_branch("main", git2::BranchType::Local)
@@ -121,7 +130,8 @@ impl Update {
         }
     }
 
-    /// Pull(fetch and fast-forward merge) repositoryto input_repo.
+    /// Pulls (fetches and fast-forward merges) the remote main branch into input_repo. Only
+    /// fast-forward merges are supported; any other merge state is reported as an error.
     fn pull_repository(input_repo: &Repository) -> Result<String, git2::Error> {
         match input_repo
             .find_remote("origin")?
@@ -181,20 +191,24 @@ impl Update {
         }
     }
 
-    /// Create rules folder files Hashset. Format is "[rule title in yaml]|[filepath]|[filemodified date]|[rule type in yaml]"
+    /// Collects the current rule files into a map of file path ->
+    /// "[title]|[modified field, falling back to the date field]|[file path]|[rule type]|[parsed yaml]", used to diff
+    /// the rule set before and after an update. The full parsed YAML is included so that any
+    /// content change is detected even when the modified date stays the same.
     fn get_updated_rules(
         rule_folder_path: &str,
-        stored_staic: &StoredStatic,
+        stored_static: &StoredStatic,
     ) -> HashMap<String, String> {
-        let mut rulefile_loader = ParseYaml::new(stored_staic);
-        // level in read_dir is hard code to check all rules.
+        let mut rulefile_loader = ParseYaml::new(stored_static);
+        // The level passed to read_dir is hardcoded to INFORMATIONAL so that every rule is
+        // loaded.
         rulefile_loader
             .read_dir(
                 rule_folder_path,
                 "INFORMATIONAL",
                 "",
                 &filter::RuleExclude::new(),
-                stored_staic,
+                stored_static,
             )
             .ok();
 
@@ -214,7 +228,8 @@ impl Update {
         }))
     }
 
-    /// print updated rule files.
+    /// Prints the rule files that were added or changed by the update, followed by per-rule-type
+    /// update counts. Returns a message describing whether anything was updated.
     fn print_diff_modified_rule_dates(
         prev_sets: HashMap<String, String>,
         updated_sets: HashMap<String, String>,

--- a/src/timeline/computer_metrics.rs
+++ b/src/timeline/computer_metrics.rs
@@ -17,6 +17,13 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
 
+/// Aggregates a single record into the per-computer statistics used by the computer-metrics
+/// command. Every record increments the event count for its `Computer` name. In addition,
+/// System-channel events are mined for host details:
+/// - EID 6009 (logged at every boot): OS version and build number, resolved to a product name.
+/// - EID 6013 (system uptime): the host's timezone.
+/// - EID 12 / 6005 / 6009 (all logged at startup): the most recent boot time, from which the
+///   uptime is later derived as (newest event timestamp - boot time).
 pub fn countup_event_by_computer(
     record: &Value,
     eventkey_alias: &EventKeyAliasConfig,
@@ -25,6 +32,7 @@ pub fn countup_event_by_computer(
     if let Some(computer_name) =
         utils::get_event_value("Event.System.Computer", record, eventkey_alias)
     {
+        // Tuple fields: (OS info, boot time, timezone, last event timestamp, event count).
         let val = tl
             .stats
             .stats_computer
@@ -43,18 +51,27 @@ pub fn countup_event_by_computer(
             let os_name = &mut val.0;
             if id == 6009 && os_name.is_empty() && !WIN_VERSIONS.is_empty() {
                 if let Some(arr) = record["Event"]["EventData"]["Data"].as_array() {
+                    // EID 6009 stores the OS version in the first Data element (e.g. "6.01.")
+                    // and the build number in the second (arr[0]/arr[1]). Zero-padded minor
+                    // versions are normalized (e.g. "6.01"
+                    // -> "6.1") to match the (version, build) keys loaded from
+                    // windows_versions.csv into WIN_VERSIONS.
                     let ver = arr[0].as_str().unwrap_or_default().trim_matches('.');
                     let ver = ver.replace(".01", ".1").replace(".00", ".0");
                     let bui = arr[1].as_str().unwrap_or_default().to_string();
                     if let Some((win, data)) = WIN_VERSIONS.get(&(ver.clone(), bui.clone())) {
                         *os_name = format!("Windows {win} ({data})").into();
                     } else {
+                        // Unknown combination: fall back to showing the raw version and build.
                         *os_name = format!("Version: {ver} Build: {bui}").into();
                     }
                 }
             } else if id == 6013 {
                 let timezone = &mut val.2;
                 if let Some(arr) = record["Event"]["EventData"]["Data"].as_array() {
+                    // EID 6013 stores the timezone in the seventh Data element (arr[6]) as
+                    // "<UTC offset in minutes> <timezone name>" (e.g. "540 Tokyo Standard Time");
+                    // drop the numeric offset prefix and keep only the name.
                     let tz = arr[6].as_str().unwrap_or_default();
                     let tz = match tz.find(' ') {
                         Some(index) => &tz[index + 1..],
@@ -67,6 +84,10 @@ pub fn countup_event_by_computer(
             let evt_time =
                 record["Event"]["System"]["TimeCreated_attributes"]["SystemTime"].to_string();
             let evt_time = evt_time.trim_matches('"').to_string();
+            // EIDs 12 (the OS started), 6005 (the event log service started) and 6009 are all
+            // logged at boot, so the newest of their timestamps is the last boot time. Timestamps
+            // are ISO 8601 strings in a common format, so lexicographic comparison matches
+            // chronological order.
             if id == 12 || id == 6005 || id == 6009 {
                 let uptime = &mut val.1;
                 let evt_time = evt_time.as_str();
@@ -74,6 +95,8 @@ pub fn countup_event_by_computer(
                     *uptime = evt_time.into();
                 }
             }
+            // Also track the newest System-channel event timestamp; the uptime shown to the user
+            // is calculated later as (last timestamp - boot time).
             let last_timestamp = &mut val.3;
             let evt_time = evt_time.as_str();
             if evt_time > last_timestamp.as_str() {
@@ -85,6 +108,9 @@ pub fn countup_event_by_computer(
     }
 }
 
+/// Returns the elapsed time between the last boot (`uptime`) and the newest event
+/// (`last_timestamp`) as a human-readable string, or an empty string if either timestamp is
+/// missing or unparsable, or the difference is not positive.
 fn calc_elapsed_seconds(uptime: &str, last_timestamp: &str) -> String {
     if uptime.is_empty() || last_timestamp.is_empty() {
         return "".to_string();
@@ -104,6 +130,8 @@ fn calc_elapsed_seconds(uptime: &str, last_timestamp: &str) -> String {
     }
 }
 
+/// Formats a duration in seconds as "1Y 2M 3d 4h 5m 6s", approximating a year as 365 days and a
+/// month as 30 days.
 fn format_uptime(seconds: i64) -> String {
     let years = seconds / 31_536_000;
     let months = (seconds % 31_536_000) / 2_592_000;
@@ -114,7 +142,9 @@ fn format_uptime(seconds: i64) -> String {
     format!("{years}Y {months}M {days}d {hours}h {minutes}m {seconds}s")
 }
 
-/// Function that outputs computer names in a record in descending order to the screen or CSV.
+/// Outputs the per-computer metrics (OS information, uptime, timezone and event count) sorted by
+/// event count in descending order, either as a table on the terminal or to a CSV file when an
+/// output path is given.
 pub fn computer_metrics_dsp_msg(
     result_list: &HashMap<
         CompactString,
@@ -161,6 +191,8 @@ pub fn computer_metrics_dsp_msg(
     // Write contents
     for (computer_name, (os_info, uptime, timezone, last_timestamp, count)) in
         result_list.into_iter().sorted_unstable_by(|a, b| {
+            // Sort by event count in descending order (compare negated counts), breaking ties by
+            // computer name in ascending order.
             let count_cmp = Ord::cmp(
                 &-i64::from_usize(a.1.4).unwrap_or_default(),
                 &-i64::from_usize(b.1.4).unwrap_or_default(),
@@ -172,6 +204,7 @@ pub fn computer_metrics_dsp_msg(
             a.0.cmp(b.0)
         })
     {
+        // CSV output gets the plain number; terminal output gets thousands separators.
         let count_str = if output.is_some() {
             format!("{count}")
         } else {

--- a/src/timeline/config_critical_systems.rs
+++ b/src/timeline/config_critical_systems.rs
@@ -14,6 +14,8 @@ use strum::{EnumIter, IntoEnumIterator};
 use termcolor::{BufferWriter, Color, ColorChoice};
 
 static CONFIG_CRITICAL_SYSTEMS: &str = "config/critical_systems.txt";
+
+// Categories of critical systems that can be detected from event logs.
 #[derive(Eq, Hash, PartialEq, Debug, Clone, EnumIter)]
 enum ComputerType {
     DomainController,
@@ -29,6 +31,10 @@ impl ComputerType {
     }
 }
 
+/// Implements the config-critical-systems command: scans Security-channel events for computers
+/// that appear to be domain controllers or file servers, and interactively offers to append their
+/// names to config/critical_systems.txt. Alerts for hosts listed in that file later get their
+/// severity level raised by one (see level.rs).
 #[derive(Clone, Debug)]
 pub struct ConfigCriticalSystems {
     computers: HashMap<ComputerType, HashSet<String>>,
@@ -60,12 +66,16 @@ impl ConfigCriticalSystems {
         }
     }
 
+    /// Classifies the computer that recorded the event as a domain controller or file server
+    /// based on Security-channel event IDs that only those roles log.
     fn find_critical_computers(&mut self, data: &Value) {
         if let Some(ch) = data["Event"]["System"]["Channel"].as_str()
             && let Some(id) = data["Event"]["System"]["EventID"].as_i64()
             && ch == "Security"
         {
             if id == 4768 {
+                // EID 4768 (a Kerberos authentication ticket (TGT) was requested) is only logged
+                // on domain controllers, so the recording computer must be a DC.
                 let v = data["Event"]["System"]["Computer"]
                     .as_str()
                     .unwrap_or_default()
@@ -75,6 +85,10 @@ impl ConfigCriticalSystems {
                     .or_default()
                     .insert(v);
             } else if id == 5145 {
+                // EID 5145 (a network share object was checked for access) indicates the
+                // recording computer is serving file shares. Ignore accesses to the IPC$
+                // named-pipe share, since every Windows host exposes it and it does not mean the
+                // host is a file server.
                 let share = data["Event"]["EventData"]["ShareName"]
                     .as_str()
                     .unwrap_or_default();
@@ -93,6 +107,9 @@ impl ConfigCriticalSystems {
         }
     }
 
+    /// For each computer type, prints the discovered host names and interactively asks the user
+    /// whether to append them to the critical systems config file. Appended entries are then
+    /// deduplicated and sorted together with any pre-existing ones.
     pub fn output_computers(&mut self, no_color: bool) {
         for computer_type in ComputerType::iter() {
             match self.computers.get(&computer_type) {
@@ -116,6 +133,8 @@ impl ConfigCriticalSystems {
                         .ok();
                     }
                     println!();
+                    // Theme for the dialoguer confirmation prompt: plain styles when --no-color
+                    // is set, otherwise Hayabusa's usual color scheme.
                     let color_theme = if no_color {
                         ColorfulTheme {
                             defaults_style: Style::new().for_stderr(),
@@ -151,7 +170,7 @@ impl ConfigCriticalSystems {
                             active_item_style: Style::new().color256(51), // cyan
                             values_style: Style::new().color256(46),      // green
                             prompt_prefix: Style::new().color256(214).apply_to("?".to_string()), // orange
-                            prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // cyan
+                            prompt_suffix: Style::new().color256(15).apply_to("›".to_string()), // white
                             defaults_style: Style::new().color256(51), // cyan
                             hint_style: Style::new().color256(214),    // orange
                             success_prefix: Style::new().color256(46).apply_to("✔".to_string()), // green
@@ -206,6 +225,7 @@ impl ConfigCriticalSystems {
     }
 }
 
+/// Rewrites the given file with its lines deduplicated and sorted alphabetically.
 fn sort_and_dedup_file(file_path: &Path) -> io::Result<()> {
     let file = fs::File::open(file_path)?;
     let reader = BufReader::new(file);

--- a/src/timeline/extract_base64.rs
+++ b/src/timeline/extract_base64.rs
@@ -20,9 +20,15 @@ use std::sync::LazyLock;
 use std::{fmt, str};
 use termcolor::{BufferWriter, Color, ColorChoice};
 
+// Matches runs of characters that can appear in a base64 token. \w also allows '_', which is not
+// valid base64, but every candidate token is verified by actually decoding it. Note that the '='
+// padding is not part of the token; see BASE64_PAD below.
 static TOKEN_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[\w+/]+").unwrap());
+// Matches the <Base64String> placeholder followed by leftover '=' padding so that the padding can
+// be folded into the placeholder.
 static BASE64_PAD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<Base64String>(=*)").unwrap());
 
+/// Metadata of the event record that a candidate base64 string was extracted from.
 struct EvtxInfo {
     ts: String,
     computer: String,
@@ -49,6 +55,7 @@ impl EvtxInfo {
     }
 }
 
+/// The channel/event ID combinations whose fields are scanned for base64-encoded payloads.
 #[derive(Clone)]
 enum Event {
     Sec4688,
@@ -72,6 +79,9 @@ impl fmt::Display for Event {
     }
 }
 
+/// A successfully decoded base64 token, classified by the encoding of its payload. Every variant
+/// carries the original base64 token; the text variants also carry the decoded string, and Binary
+/// carries the raw bytes together with the inferred file type.
 enum Base64Data {
     Utf8(String, String),
     Utf16Le(String, String),
@@ -82,6 +92,8 @@ enum Base64Data {
 
 impl Base64Data {
     fn new(token: &str, payload: &[u8]) -> Self {
+        // Check UTF-16 before UTF-8: ASCII text encoded as UTF-16 contains NUL bytes that would
+        // still pass the ASCII-oriented UTF-8 check, so testing UTF-8 first would misclassify it.
         if is_utf16_le(payload) {
             let s = utf16_le_to_string(payload).unwrap();
             return Base64Data::Utf16Le(token.to_string(), s);
@@ -110,6 +122,8 @@ impl Base64Data {
         }
     }
 
+    /// Returns the decoded text with control characters removed (so that multi-line payloads stay
+    /// on a single line in the output); empty for binary/unknown payloads.
     fn decoded_str(&self) -> String {
         match self {
             Base64Data::Utf8(_, s) | Base64Data::Utf16Le(_, s) | Base64Data::Utf16Be(_, s) => {
@@ -151,6 +165,9 @@ impl Base64Data {
         }
     }
 
+    /// Returns "Y" if the decoded text itself contains another plausible base64 token (i.e. the
+    /// payload was base64-encoded twice), using the same skip heuristics as
+    /// create_base64_extracted_record().
     fn is_double_encoding(&self) -> String {
         for token in tokenize(self.decoded_str().as_str()) {
             if is_base64(token) {
@@ -192,6 +209,10 @@ fn is_base64(s: &str) -> bool {
     }
 }
 
+// The three checks below classify a decoded payload as text. They are heuristics: payloads
+// shorter than 5 bytes are considered too ambiguous to classify, and only byte sequences that
+// decode to pure ASCII are accepted (so despite its name, is_utf8() rejects non-ASCII UTF-8 text
+// such as Japanese).
 fn is_utf8(bytes: &[u8]) -> bool {
     if bytes.is_empty() {
         return false;
@@ -222,6 +243,9 @@ fn is_utf16_be(bytes: &[u8]) -> bool {
     UTF_16BE.decode_without_bom_handling(bytes).0.is_ascii()
 }
 
+/// Returns the field values (paired with their event type) that commonly carry base64-encoded
+/// payloads: process creation command lines (Security 4688, Sysmon 1), service image paths
+/// (System 7045) and PowerShell script/payload fields (4103, 4104 and classic 400).
 fn extract_payload(data: &Value) -> Vec<(Value, Event)> {
     let ch = data["Event"]["System"]["Channel"].as_str();
     let id = data["Event"]["System"]["EventID"].as_i64();
@@ -264,6 +288,7 @@ fn extract_payload(data: &Value) -> Vec<(Value, Event)> {
         .collect()
 }
 
+/// Splits a field value into candidate base64 tokens.
 fn tokenize(payload_str: &str) -> Vec<&str> {
     TOKEN_REGEX
         .find_iter(payload_str)
@@ -271,6 +296,9 @@ fn tokenize(payload_str: &str) -> Vec<&str> {
         .collect()
 }
 
+// Note: chunks(2) assumes an even byte count; an odd-length slice would panic on chunk[1]. In
+// practice is_utf16_le()/is_utf16_be() reject odd-length data because the trailing lone byte
+// decodes to a non-ASCII replacement character.
 fn utf16_le_to_string(bytes: &[u8]) -> Result<String, FromUtf16Error> {
     let utf16_data: Vec<u16> = bytes
         .chunks(2)
@@ -287,6 +315,9 @@ fn utf16_be_to_string(bytes: &[u8]) -> Result<String, FromUtf16Error> {
     String::from_utf16(&utf16_data)
 }
 
+/// Builds one output row per valid base64 token found in the given field value, containing the
+/// record metadata, the token, its decoded form, the field value with the token replaced by a
+/// <Base64String> placeholder, and the classification columns.
 fn create_base64_extracted_record(
     file: &Path,
     possible_base64: &str,
@@ -299,9 +330,11 @@ fn create_base64_extracted_record(
     for token in tokenize(possible_base64) {
         if is_base64(token) {
             if token.len() < 10 || token.chars().all(|c| c.is_alphabetic()) {
-                // Skip short tokens and all alphabetic tokens
+                // Skip tokens that are too short or purely alphabetic: they are usually ordinary
+                // words that merely happen to decode as base64.
                 continue;
             }
+            // is_base64() already verified that one of the two decoders succeeds.
             let payload = match BASE64_STANDARD_NO_PAD.decode(token) {
                 Ok(payload) => payload,
                 Err(_) => BASE64_STANDARD.decode(token).unwrap(),
@@ -310,10 +343,14 @@ fn create_base64_extracted_record(
             if matches!(b64, Base64Data::Unknown(_)) {
                 continue;
             }
+            // Replace the token with a placeholder in the original field value, then fold any
+            // trailing '=' padding (which TOKEN_REGEX cannot capture) into the placeholder.
             let original = possible_base64
                 .replace(b64.base64_str().as_str(), "<Base64String>")
                 .to_string();
             let no_pad_original = BASE64_PAD.replace_all(original.as_str(), "<Base64String>");
+            // A token directly preceded by '-' is most likely a fragment of a hyphenated string
+            // (e.g. a GUID) rather than standalone base64, so skip it to avoid false positives.
             if no_pad_original.contains("-<Base64String>") {
                 continue;
             }
@@ -349,6 +386,8 @@ fn process_record(data: &Value, file: &Path, opt: &TimeFormatOptions) -> Vec<Vec
     records
 }
 
+/// Called for each batch of loaded event records when the extract-base64 command runs; returns
+/// the base64 rows extracted from the batch.
 pub fn process_evtx_record_infos(
     records: &[EvtxRecordInfo],
     opt: &TimeFormatOptions,
@@ -362,6 +401,9 @@ pub fn process_evtx_record_infos(
     all_records
 }
 
+/// Outputs the extracted rows as CSV when an output path is given, otherwise prints the first
+/// four columns as a table on the terminal. In both cases the decoded string of binary payloads
+/// is masked with "(Binary Data)".
 pub fn output_all(
     all_records: Vec<Vec<String>>,
     out_path: Option<&PathBuf>,
@@ -397,6 +439,7 @@ pub fn output_all(
         ];
         wtr.write_record(csv_header)?;
         for row in all_records.clone().iter_mut() {
+            // row[6] is the Binary column; row[3] (the decoded string) is not printable then.
             let binary = row[6].as_str();
             if binary == "Y" {
                 row[3] = "(Binary Data)".to_string();

--- a/src/timeline/log_metrics.rs
+++ b/src/timeline/log_metrics.rs
@@ -5,6 +5,9 @@ use crate::detections::utils;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use std::collections::HashSet;
 
+/// Per-log-file summary statistics collected for the log-metrics command: file path/name/size,
+/// event count, first/last event timestamps, and the distinct computer names, channels and
+/// providers seen in the file.
 #[derive(Default, Debug, Clone)]
 pub struct LogMetrics {
     pub filepath: String,
@@ -27,6 +30,9 @@ impl LogMetrics {
             ..Default::default()
         }
     }
+    /// Folds a batch of records from this log file into the metrics: widens the first/last
+    /// timestamp range, collects each record's computer, channel and provider, and increments the
+    /// event count.
     pub fn update(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         for record in records {
             if let Some(evttime) = utils::get_event_value(
@@ -36,6 +42,7 @@ impl LogMetrics {
             )
             .map(|evt_value| evt_value.to_string().replace("\\\"", "").replace('"', ""))
             {
+                // Timestamps normally use the evtx UTC format, e.g. "2021-12-23T00:00:00.000Z".
                 let timestamp = match NaiveDateTime::parse_from_str(
                     evttime.as_str(),
                     "%Y-%m-%dT%H:%M:%S%.fZ",
@@ -44,6 +51,10 @@ impl LogMetrics {
                         DateTime::<Utc>::from_naive_utc_and_offset(without_timezone_datetime, Utc),
                     ),
                     Err(_) => {
+                        // Fall back to the format used by Splunk JSON exports, which carries an
+                        // explicit UTC offset (e.g. "2021-12-23T00:00:00.000+09:00"). Note that
+                        // NaiveDateTime parsing validates but discards the offset, so the local
+                        // time is stored as if it were UTC.
                         match NaiveDateTime::parse_from_str(
                             evttime.as_str(),
                             "%Y-%m-%dT%H:%M:%S%.3f%:z",

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -14,6 +14,9 @@ use compact_str::CompactString;
 use hashbrown::{HashMap, HashSet};
 use std::path::Path;
 
+/// Grouping key for the logon-summary command. Logon events whose fields below all match are
+/// aggregated into a single row. The `dst_*` fields identify the account/computer that was logged
+/// on to, and the `src_*`/`source_*` fields identify where the logon came from.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct LoginEvent {
     pub channel: CompactString,
@@ -27,12 +30,21 @@ pub struct LoginEvent {
     pub source_ip: CompactString,
 }
 
+/// Accumulates statistics over all scanned records. Depending on the command being run, only some
+/// of the fields are populated: eid-metrics fills `stats_list`, logon-summary fills
+/// `stats_login_list`, computer-metrics fills `stats_computer` (from `computer_metrics.rs`),
+/// log-metrics fills `stats_logfile`, and csv-timeline/json-timeline only use the record count and
+/// time range kept in `total`/`start_time`/`end_time`.
 #[derive(Debug, Clone, Default)]
 pub struct EventMetrics {
+    // Total number of records scanned.
     pub total: usize,
+    // Path of the log file currently being aggregated.
     pub filepath: CompactString,
+    // Timestamps of the oldest and newest events seen so far.
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
+    // eid-metrics: record count keyed by (EventID, Channel), both lowercased.
     pub stats_list: HashMap<(CompactString, CompactString), usize>,
     pub stats_computer: HashMap<
         CompactString, // ComputerName
@@ -44,21 +56,28 @@ pub struct EventMetrics {
             usize,
         ),
     >,
+    // logon-summary: [successful, failed] logon counts per LoginEvent grouping key.
     pub stats_login_list: HashMap<LoginEvent, [usize; 2]>,
+    // log-metrics: per-log-file metrics (file size, event count, time range, computers, etc.).
     pub stats_logfile: Vec<LogMetrics>,
+    // (EventRecordID, timestamp) pairs that have already been counted. Used by the
+    // -X/--remove-duplicate-records option to skip duplicate records.
     pub counted_rec: HashSet<(String, String)>,
 }
 /**
 * Outputs statistics for Windows Event Logs.
 */
 impl EventMetrics {
+    /// Aggregation entry point for the eid-metrics command: updates the overall record count/time
+    /// range and counts records per (EventID, Channel).
     pub fn evt_stats_start(
         &mut self,
         records: &[EvtxRecordInfo],
         stored_static: &StoredStatic,
         (include_computer, exclude_computer): (&HashSet<CompactString>, &HashSet<CompactString>),
     ) {
-        // Get the timestamp of the first record, the timestamp of the last record, and the total number of records from records.
+        // Get the timestamps of the first and last records and the total number of records in
+        // this batch.
         self.stats_time_cnt(records, stored_static);
 
         // Only output statistics when the metrics option is specified as an argument.
@@ -70,6 +89,8 @@ impl EventMetrics {
         self.stats_eventid(records, stored_static, (include_computer, exclude_computer));
     }
 
+    /// Aggregation entry point for the logon-summary command: updates the overall record
+    /// count/time range and counts successful/failed logon events.
     pub fn logon_stats_start(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         // Only output statistics when the logon-summary option is specified as an argument.
         if !stored_static.logon_summary_flag {
@@ -79,6 +100,9 @@ impl EventMetrics {
         self.stats_login_eventid(records, stored_static);
     }
 
+    /// Aggregation entry point for the log-metrics command. Records arrive in batches: if an
+    /// entry for the same file that already contains the computer name of the batch's first
+    /// record exists, the batch is merged into it; otherwise a new per-file entry is created.
     pub fn logfile_stats_start(
         &mut self,
         records: &[EvtxRecordInfo],
@@ -122,17 +146,23 @@ impl EventMetrics {
         }
     }
 
+    /// Updates the total record count and widens the overall start/end time range based on the
+    /// given batch of records. Used by all commands that report the scanned time range.
     pub fn stats_time_cnt(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         if records.is_empty() {
             return;
         }
         self.filepath = CompactString::from(records[0].evtx_filepath.as_str());
+        // The evtx format was introduced with Windows Vista, released on 2007/1/30. Any timestamp
+        // older than that is treated as invalid data (see below).
         let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2007, 1, 30)
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap();
         let evtx_service_released_date = Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
         let mut check_start_end_time = |evttime: &str| {
+            // Try the standard evtx UTC format first, then fall back to the timezone-offset
+            // format used by Splunk JSON exports.
             let timestamp = match NaiveDateTime::parse_from_str(evttime, "%Y-%m-%dT%H:%M:%S%.fZ") {
                 Ok(without_timezone_datetime) => Some(DateTime::<Utc>::from_naive_utc_and_offset(
                     without_timezone_datetime,
@@ -179,6 +209,8 @@ impl EventMetrics {
                 self.end_time = timestamp;
             }
         };
+        // Records are assumed to be in roughly chronological order, so only the first and last
+        // record of the batch are examined instead of every record.
         let first = records.first();
         let last = records.last();
         let rec = [first, last];
@@ -204,7 +236,8 @@ impl EventMetrics {
         self.total += records.len();
     }
 
-    /// Aggregate by EventID
+    /// Counts each record per (EventID, Channel) pair, honoring the computer include/exclude
+    /// filters and optional duplicate-record removal.
     fn stats_eventid(
         &mut self,
         records: &[EvtxRecordInfo],
@@ -232,6 +265,8 @@ impl EventMetrics {
             if let Some(idnum) =
                 utils::get_event_value("EventID", &record.record, &stored_static.eventkey_alias)
             {
+                // With -X/--remove-duplicate-records, skip records whose
+                // (EventRecordID, timestamp) pair has already been counted.
                 if stored_static.metrics_remove_duplication {
                     let event = &record.record["Event"]["System"];
                     let rec_id = event["EventRecordID"].to_string();
@@ -254,8 +289,11 @@ impl EventMetrics {
             };
         }
     }
-    // Login event
+    /// Counts logon events for the logon-summary command: Security 4624 (successful logon),
+    /// Security 4625 (failed logon), RDS LocalSessionManager 21 and RDS Gateway 302 (both
+    /// counted as successful logons).
     fn stats_login_eventid(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
+        // Maps the LogonType number to a human-readable label for display.
         let logontype_map: HashMap<&str, &str> = HashMap::from([
             ("0", "0 - System"),
             ("2", "2 - Interactive"),
@@ -315,6 +353,8 @@ impl EventMetrics {
                         RdsLsm => CompactString::from("RDS-LSM 21"),
                         RdsGtw => CompactString::from("RDS-GTW 302"),
                     };
+                    // The RDS events store the account as a single "DOMAIN\user" field, so the
+                    // user and domain parts are split out of it below.
                     let dst_user = match channel {
                         Sec => get_event_value_as_string(
                             "TargetUserName",
@@ -414,6 +454,8 @@ impl EventMetrics {
                             &stored_static.eventkey_alias,
                         ),
                     };
+                    // With -X/--remove-duplicate-records, skip records whose
+                    // (EventRecordID, timestamp) pair has already been counted.
                     if stored_static.metrics_remove_duplication {
                         let event = &record.record["Event"]["System"];
                         let rec_id = event["EventRecordID"].to_string();
@@ -426,7 +468,9 @@ impl EventMetrics {
                     }
 
                     let countlist: [usize; 2] = [0, 0];
-                    // At this point the EventID is either 4624 or 4625, so obtain the corresponding counter here.
+                    // Fetch (or initialize) the [successful, failed] counters for this logon
+                    // event. At this point the EventID is 4624, 4625, 21 or 302; 4625 counts as a
+                    // failed logon and the others as successful logons.
                     let count: &mut [usize; 2] = self
                         .stats_login_list
                         .entry(LoginEvent {
@@ -456,6 +500,8 @@ impl EventMetrics {
     }
 }
 
+/// Looks up `key` in the record (resolving it through eventkey_alias.txt) and returns the value
+/// as a string with all double/single quote characters removed, or "-" if the field is missing.
 fn get_event_value_as_string(
     key: &str,
     record: &serde_json::Value,
@@ -471,12 +517,15 @@ fn get_event_value_as_string(
     )
 }
 
+/// Event log channels that contain the logon events tracked by the logon-summary command.
 enum Channel {
-    Sec,
-    RdsLsm,
-    RdsGtw,
+    Sec,    // Security
+    RdsLsm, // Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
+    RdsGtw, // Microsoft-Windows-TerminalServices-Gateway/Operational
 }
 
+/// Returns which channel the record's logon event belongs to if its (EventID, Channel) pair is
+/// one that the logon summary tracks, or None if the record is not a target logon event.
 fn is_target_event(idnum: i64, channel: &str) -> Option<Channel> {
     if (idnum == 4624 || idnum == 4625) && channel == "Security" {
         return Some(Sec);

--- a/src/timeline/search.rs
+++ b/src/timeline/search.rs
@@ -26,6 +26,7 @@ use std::io::BufWriter;
 use termcolor::{BufferWriter, Color, ColorChoice};
 use wildmatch::WildMatch;
 
+// Column headers for the search output (CSV header row / terminal column names).
 const OUTPUT_HEADERS: [&str; 8] = [
     "Timestamp",
     "EventTitle",
@@ -37,9 +38,14 @@ const OUTPUT_HEADERS: [&str; 8] = [
     "EvtxFile",
 ];
 
+/// Runs the `search` command: checks event records against the given keywords or regex and either
+/// collects the hits for sorted output or writes them out on the fly.
 #[derive(Debug, Clone)]
 pub struct EventSearch {
+    // Path of the evtx file that the record currently being processed came from.
     pub filepath: CompactString,
+    // Hit records collected for later sorting when the sort_events option is set. Tuple layout:
+    // (timestamp, hostname, channel, event ID, record ID, all field info, evtx file path).
     pub search_result: HashSet<(
         CompactString,
         CompactString,
@@ -49,6 +55,7 @@ pub struct EventSearch {
         CompactString,
         CompactString,
     )>,
+    // Total number of hits, counted even when records are written on the fly instead of collected.
     pub search_result_cnt: u64,
 }
 
@@ -72,7 +79,8 @@ impl EventSearch {
         }
     }
 
-    /// Function that calls the search process. Does not perform a search if keywords is empty.
+    /// Entry point of the search process. Runs the keyword search when keywords were given and
+    /// the regex search when a regex was given; otherwise does nothing.
     pub fn search_start(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         let search_option = stored_static.search_option.as_ref().unwrap();
         let default_details_abbr = self.get_default_details_mapping_table(stored_static);
@@ -93,7 +101,9 @@ impl EventSearch {
         }
     }
 
-    /// Function that returns whether information set in the filter exists within the event record.
+    /// Returns whether the event record satisfies every filter condition. For each filtered
+    /// field, all of its wildcard patterns must match the field value, which is resolved through
+    /// the event key aliases first and the raw EventData fields second.
     fn filter_record(
         &mut self,
         record: &EvtxRecordInfo,
@@ -128,6 +138,9 @@ impl EventSearch {
         })
     }
 
+    /// Builds a per-"Provider_EventID" table that maps full field names to their abbreviations
+    /// (e.g. "CommandLine" -> "Cmdline"), parsed from the default_details.txt templates of the
+    /// form "Cmdline: %CommandLine% ¦ Proc: %Image% ...". Used to shorten the AllFieldInfo output.
     fn get_default_details_mapping_table(
         &self,
         stored_static: &StoredStatic,
@@ -149,7 +162,8 @@ impl EventSearch {
         ret
     }
 
-    // check if a record contains the keywords specified in a search command option or not.
+    /// Checks each record against the keywords given in the search command options and collects
+    /// or outputs the matching records.
     fn search_keyword(
         &mut self,
         records: &[EvtxRecordInfo],
@@ -176,12 +190,13 @@ impl EventSearch {
         };
 
         for record in records.iter() {
-            // filtering
+            // Skip records that do not satisfy the filter conditions.
             if !self.filter_record(record, &filter_rule, &stored_static.eventkey_alias) {
                 continue;
             }
 
-            // check if the record contains keywords or not.
+            // Check whether the record contains the keywords (all of them when the and_logic
+            // option is set, otherwise any of them).
             let search_target = if case_insensitive_flag {
                 record.data_string.to_lowercase()
             } else {
@@ -214,13 +229,14 @@ impl EventSearch {
                 continue;
             }
 
-            // collect the hit record or output it on the fly
+            // Collect the hit record, or output it on the fly.
             let (timestamp, hostname, channel, eventid, recordid, allfieldinfo) =
                 extract_search_event_info(
                     record,
                     &stored_static.eventkey_alias,
                     stored_static.output_option.as_ref().unwrap(),
                 );
+            // Look up the field-name abbreviation table for this record's provider and event ID.
             let target_allfieldinfo_abbr_table = allfield_replace_table.get(
                 format!(
                     "{}_{}",
@@ -231,6 +247,9 @@ impl EventSearch {
                 )
                 .as_str(),
             );
+            // Replace the 🛂r/🛂n/🛂t placeholders (substituted for \r, \n and \t by
+            // utils::remove_sp_char) with a 🦅 sentinel, re-join the pieces with single spaces,
+            // and shorten full field names to their abbreviations.
             let allfieldinfo_newline_split = self.replace_all_field_info_abbr(
                 ALLFIELDINFO_SPECIAL_CHARS
                     .replace_all(&allfieldinfo, &["🦅", "🦅", "🦅"])
@@ -242,7 +261,8 @@ impl EventSearch {
             );
 
             if search_option.sort_events {
-                // we cannot sort all the records unless we get all the records; so we just collect the hit record at this code and we'll sort them later.
+                // We cannot sort the results until every record has been processed, so we just
+                // collect the hit records here and sort them later.
                 self.search_result.insert((
                     timestamp,
                     hostname,
@@ -254,8 +274,9 @@ impl EventSearch {
                 ));
                 self.search_result_cnt += 1;
             } else {
-                // sort_events option is false, the hit record is output on the fly.
-                // We don't want to collect the hit record into the memory, if possible, in order to reduce memory usage.
+                // The sort_events option is false, so the hit record is output on the fly.
+                // We avoid collecting hit records in memory whenever possible in order to reduce
+                // memory usage.
                 let hit_record = (
                     timestamp,
                     hostname,
@@ -276,7 +297,8 @@ impl EventSearch {
         }
     }
 
-    // check if a record matches the regex specified in a search command option or not.
+    /// Checks each record against the regex given in the search command options and collects or
+    /// outputs the matching records.
     fn search_regex(
         &mut self,
         records: &[EvtxRecordInfo],
@@ -295,24 +317,25 @@ impl EventSearch {
         let filter_rule = create_filter_rule(&search_option.filter);
         let mut wtr = ResultWriter::new(search_option);
         for record in records.iter() {
-            // we will skip this record if the record is filterd.
+            // Skip this record if it does not satisfy the filter conditions.
             if !self.filter_record(record, &filter_rule, &stored_static.eventkey_alias) {
                 continue;
             }
 
-            // check if the regex matches the record or not.
+            // Check whether the regex matches the record.
             self.filepath = CompactString::from(record.evtx_filepath.as_str());
             if !re.is_match(&record.data_string) {
                 continue;
             }
 
-            // collect the hit record or output it on the fly
+            // Collect the hit record, or output it on the fly.
             let (timestamp, hostname, channel, eventid, recordid, allfieldinfo) =
                 extract_search_event_info(
                     record,
                     &stored_static.eventkey_alias,
                     stored_static.output_option.as_ref().unwrap(),
                 );
+            // Look up the field-name abbreviation table for this record's provider and event ID.
             let target_allfieldinfo_abbr_table = allfield_replace_table.get(
                 format!(
                     "{}_{}",
@@ -323,6 +346,9 @@ impl EventSearch {
                 )
                 .as_str(),
             );
+            // Replace the 🛂r/🛂n/🛂t placeholders (substituted for \r, \n and \t by
+            // utils::remove_sp_char) with a 🦅 sentinel, re-join the pieces with single spaces,
+            // and shorten full field names to their abbreviations.
             let allfieldinfo_newline_split = self.replace_all_field_info_abbr(
                 ALLFIELDINFO_SPECIAL_CHARS
                     .replace_all(&allfieldinfo, &["🦅", "🦅", "🦅"])
@@ -334,7 +360,8 @@ impl EventSearch {
             );
 
             if search_option.sort_events {
-                // we cannot sort all the records unless we get all the records; so we just collect the hit record at this code and we'll sort them later.
+                // We cannot sort the results until every record has been processed, so we just
+                // collect the hit records here and sort them later.
                 self.search_result.insert((
                     timestamp,
                     hostname,
@@ -346,8 +373,9 @@ impl EventSearch {
                 ));
                 self.search_result_cnt += 1;
             } else {
-                // sort_events option is false, the hit record is output on the fly.
-                // We don't want to collect the hit record into the memory, if possible, in order to reduce memory usage.
+                // The sort_events option is false, so the hit record is output on the fly.
+                // We avoid collecting hit records in memory whenever possible in order to reduce
+                // memory usage.
                 let hit_record = (
                     timestamp,
                     hostname,
@@ -368,7 +396,9 @@ impl EventSearch {
         }
     }
 
-    /// Replace all the field info abbreviations in the given value with their full names.
+    /// Replaces full field names in the given AllFieldInfo string with their abbreviations from
+    /// default_details.txt (e.g. "CommandLine" -> "Cmdline"). Replacement is applied in ascending
+    /// order of field-name length.
     fn replace_all_field_info_abbr(
         &self,
         value: &str,
@@ -391,8 +421,12 @@ impl EventSearch {
     }
 }
 
+/// Writes search results either to the terminal (colored) or to a CSV/JSON/JSONL file, depending
+/// on the search options.
 pub struct ResultWriter {
+    // Terminal writer; Some only when no output file was specified.
     pub disp_wtr: Option<BufferWriter>,
+    // File writer; Some only when an output file was specified.
     pub file_wtr: Option<Writer<BufWriter<File>>>,
     written_record_num: u64,
 }
@@ -401,7 +435,7 @@ impl ResultWriter {
     pub fn new(search_option: &SearchOption) -> ResultWriter {
         let mut file_wtr = Option::None;
         if let Some(path) = &search_option.output {
-            // create new file if not exist and append if exist.
+            // Create the file if it does not exist, and append to it if it does.
             match OpenOptions::new().append(true).create(true).open(path) {
                 Ok(file) => {
                     if search_option.json_output || search_option.jsonl_output {
@@ -441,7 +475,9 @@ impl ResultWriter {
         }
     }
 
-    fn write_headder(&mut self, search_option: &SearchOption) {
+    /// Writes the output header: the CSV header row for file output, or the column names for
+    /// terminal output. JSON/JSONL output has no header.
+    fn write_header(&mut self, search_option: &SearchOption) {
         if search_option.output.is_some()
             && !search_option.json_output
             && !search_option.jsonl_output
@@ -463,6 +499,9 @@ impl ResultWriter {
         }
     }
 
+    /// Writes one search hit in the configured format: CSV or JSON/JSONL when writing to a file,
+    /// or a colored " · "-separated line when writing to the terminal. The header is written
+    /// first when is_write_header is true (i.e. for the first hit).
     pub fn write_record(
         &mut self,
         (timestamp, hostname, channel, event_id, record_id, all_field_info, evtx_file): (
@@ -479,7 +518,7 @@ impl ResultWriter {
         is_write_header: bool,
     ) {
         if is_write_header {
-            self.write_headder(search_option);
+            self.write_header(search_option);
         }
         self.written_record_num += 1;
 
@@ -508,6 +547,8 @@ impl ResultWriter {
         };
 
         let fmted_all_field_info = all_field_info.split_whitespace().join(" ");
+        // Depending on the output options, the " ¦ " separator between fields is replaced with a
+        // newline (multiline file output) or a tab.
         let all_field_info = if search_option.output.is_some() && stored_static.multiline_flag {
             fmted_all_field_info.replace(" ¦ ", "\r\n")
         } else if stored_static.tab_separator_flag {
@@ -537,6 +578,8 @@ impl ResultWriter {
         } else if search_option.output.is_some()
             && (search_option.json_output || search_option.jsonl_output)
         {
+            // For JSON/JSONL file output, wrap the fields produced by output_json_str() in curly
+            // braces.
             let file_wtr = self.file_wtr.as_mut().unwrap();
             file_wtr.write_field("{").ok();
             let mut detail_infos: HashMap<CompactString, Vec<CompactString>> = HashMap::default();
@@ -596,7 +639,8 @@ impl ResultWriter {
             for (record_field_idx, record_field_data) in record_data.iter().enumerate() {
                 let newline_flag = record_field_idx == record_data.len() - 1;
                 if record_field_idx == 6 {
-                    // Output the AllFieldInfo column.
+                    // Output the AllFieldInfo column: print each "name: value" pair in two
+                    // colors, with " ¦ " between pairs.
                     let all_field_sep_info = all_field_info.split('¦').collect::<Vec<&str>>();
                     for (field_idx, fields) in all_field_sep_info.iter().enumerate() {
                         let mut separated_fields_data =
@@ -661,7 +705,9 @@ impl ResultWriter {
     }
 }
 
-/// Function that creates filter conditions from filters.
+/// Parses the filter conditions ("FieldName:value" strings with wildcard support) into a map from
+/// field name to wildcard patterns. Surrounding double quotes are stripped, and conditions
+/// without a colon are ignored.
 fn create_filter_rule(filters: &[String]) -> HashMap<String, Vec<WildMatch>> {
     filters
         .iter()
@@ -669,10 +715,10 @@ fn create_filter_rule(filters: &[String]) -> HashMap<String, Vec<WildMatch>> {
             let prefix_trim_condition = filter_condition
                 .strip_prefix('"')
                 .unwrap_or(filter_condition);
-            let trimed_condition = prefix_trim_condition
+            let trimmed_condition = prefix_trim_condition
                 .strip_suffix('"')
                 .unwrap_or(prefix_trim_condition);
-            let condition = trimed_condition.split(':').map(|x| x.trim()).collect_vec();
+            let condition = trimmed_condition.split(':').map(|x| x.trim()).collect_vec();
             if condition.len() != 1 {
                 let acc_val = acc.entry(condition[0].to_string()).or_insert(vec![]);
                 condition[1..]
@@ -683,7 +729,8 @@ fn create_filter_rule(filters: &[String]) -> HashMap<String, Vec<WildMatch>> {
         })
 }
 
-/// Function that extracts information to output from event records matching the search conditions.
+/// Extracts the output fields (timestamp, hostname, channel, event ID, record ID, AllFieldInfo)
+/// from an event record that matched the search conditions.
 fn extract_search_event_info(
     record: &EvtxRecordInfo,
     eventkey_alias: &EventKeyAliasConfig,
@@ -696,6 +743,7 @@ fn extract_search_event_info(
     CompactString,
     CompactString,
 ) {
+    // Fall back to the UNIX epoch when the record's timestamp cannot be parsed.
     let default_time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
     let timestamp_datetime = message::get_event_time(&record.record, false).unwrap_or(default_time);
 
@@ -753,7 +801,9 @@ fn extract_search_event_info(
     )
 }
 
-/// Function that outputs search results to standard output or a CSV file.
+/// Outputs the collected search results to standard output or a file, followed by the total
+/// number of findings. When the sort_events option is false, the hits were already written on
+/// the fly, so only the summary is printed here.
 pub fn search_result_dsp_msg(
     event_search: &EventSearch,
     search_option: &SearchOption,
@@ -761,6 +811,7 @@ pub fn search_result_dsp_msg(
 ) {
     let mut wtr = ResultWriter::new(search_option);
     if search_option.sort_events {
+        // Sort hits by timestamp, then record ID (string comparison), then evtx file path.
         let hit_records = event_search
             .search_result
             .clone()
@@ -792,7 +843,7 @@ pub fn search_result_dsp_msg(
         }
     }
 
-    // if sort_events option is false, search results should have been already output.
+    // If the sort_events option is false, the search results have already been output on the fly.
     if event_search.search_result_cnt == 0 {
         write_color_buffer(
             &BufferWriter::stdout(ColorChoice::Always),

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -33,6 +33,12 @@ use crate::timeline::log_metrics::LogMetrics;
 use hashbrown::HashSet;
 use itertools::Itertools;
 
+/// Aggregated state for the non-detection commands (eid-metrics, logon-summary, log-metrics,
+/// search, extract-base64, config-critical-systems, computer-metrics). Records are fed in
+/// incrementally via `start()` (except for computer-metrics, which fills `stats.stats_computer`
+/// via `computer_metrics::countup_event_by_computer()`) and the collected results are rendered
+/// later by the `*_dsp_msg` methods. The detection commands csv-timeline/json-timeline also use
+/// this struct to track the total record count and the first/last event timestamps.
 #[derive(Debug, Clone)]
 pub struct Timeline {
     pub total_record_cnt: usize,
@@ -62,6 +68,9 @@ impl Timeline {
         }
     }
 
+    /// Dispatches a batch of loaded event records to the aggregator that matches the currently
+    /// running command. Called once per record chunk while the log files are being read; the
+    /// accumulated results are output afterwards by the corresponding `*_dsp_msg` method.
     pub fn start(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         if stored_static.metrics_flag {
             self.stats.evt_stats_start(
@@ -95,18 +104,19 @@ impl Timeline {
         }
     }
 
+    /// Output the computers found by the config-critical-systems command, grouped by system type.
     pub fn config_critical_systems_dsp_msg(&mut self, no_color: bool) {
         self.config_critical_systems.output_computers(no_color);
     }
 
-    /// Function to output the statistics message for the metrics command.
+    /// Function to output the statistics message for the eid-metrics command.
     pub fn tm_stats_dsp_msg(
         &mut self,
         event_timeline_config: &EventInfoConfig,
         stored_static: &StoredStatic,
     ) {
         // Create the output message.
-        let mut sammsges: Nested<String> = Nested::new();
+        let mut summary_msgs: Nested<String> = Nested::new();
         let total_event_record = format!(
             "\n\nTotal Event Records: {}\n",
             self.total_record_cnt.to_formatted_string(&Locale::en)
@@ -117,11 +127,11 @@ impl Timeline {
         match &stored_static.config.action.as_ref().unwrap() {
             Action::EidMetrics(option) => {
                 if option.input_args.filepath.is_some() {
-                    sammsges.push(format!("Evtx File Path: {}", self.stats.filepath));
+                    summary_msgs.push(format!("Evtx File Path: {}", self.stats.filepath));
                 }
-                sammsges.push(total_event_record);
+                summary_msgs.push(total_event_record);
                 if let Some(start_time) = self.stats.start_time {
-                    sammsges.push(format!(
+                    summary_msgs.push(format!(
                         "First Timestamp: {}",
                         utils::format_time(
                             &start_time,
@@ -135,7 +145,7 @@ impl Timeline {
                     ));
                 }
                 if let Some(end_time) = self.stats.end_time {
-                    sammsges.push(format!(
+                    summary_msgs.push(format!(
                         "Last Timestamp: {}\n",
                         utils::format_time(
                             &end_time,
@@ -149,7 +159,7 @@ impl Timeline {
                     ));
                 }
                 wtr = if let Some(csv_path) = option.output.as_ref() {
-                    // output to file
+                    // Output to file.
                     match File::create(csv_path) {
                         Ok(file) => {
                             target = Box::new(BufWriter::new(file));
@@ -185,15 +195,15 @@ impl Timeline {
 
         stats_tb.set_header(header_cells);
 
-        // Sort by aggregated count.
+        // Sort by aggregated count in descending order.
         let mut mapsorted: Vec<_> = self.stats.stats_list.iter().collect();
         mapsorted.sort_by(|x, y| y.1.cmp(x.1));
 
         // Generate an output message for each Event ID.
-        let stats_msges: Nested<Vec<CompactString>> =
+        let stats_msgs: Nested<Vec<CompactString>> =
             self.tm_stats_set_msg(mapsorted, event_timeline_config, stored_static);
 
-        for msgprint in sammsges.iter() {
+        for msgprint in summary_msgs.iter() {
             let mut parts = msgprint.splitn(2, ':');
             let first_part = parts.next().unwrap_or_default();
             let second_part = format!(": {}", parts.next().unwrap_or_default());
@@ -216,13 +226,13 @@ impl Timeline {
             .ok();
         }
         if wtr.is_some() {
-            for msg in stats_msges.iter() {
+            for msg in stats_msgs.iter() {
                 if let Some(ref mut w) = wtr {
                     w.write_record(msg.iter().map(|x| x.as_str())).ok();
                 }
             }
         }
-        stats_tb.add_rows(stats_msges.iter());
+        stats_tb.add_rows(stats_msgs.iter());
         let terminal_width = match terminal_size() {
             Some((Width(w), _)) => w,
             None => 100,
@@ -247,7 +257,7 @@ impl Timeline {
     /// Function to output the logon statistics message.
     pub fn tm_logon_stats_dsp_msg(&mut self, stored_static: &StoredStatic) {
         // Create the output message.
-        let mut sammsges: Vec<String> = Vec::new();
+        let mut summary_msgs: Vec<String> = Vec::new();
         let total_event_record = format!(
             "\n\nTotal Event Records: {}\n",
             self.total_record_cnt.to_formatted_string(&Locale::en)
@@ -256,12 +266,12 @@ impl Timeline {
             &stored_static.config.action.as_ref().unwrap()
         {
             if logon_summary_option.input_args.filepath.is_some() {
-                sammsges.push(format!("Evtx File Path: {}", self.stats.filepath));
+                summary_msgs.push(format!("Evtx File Path: {}", self.stats.filepath));
             }
-            sammsges.push(total_event_record);
+            summary_msgs.push(total_event_record);
 
             if let Some(start_time) = self.stats.start_time {
-                sammsges.push(format!(
+                summary_msgs.push(format!(
                     "First Timestamp: {}",
                     utils::format_time(
                         &start_time,
@@ -275,7 +285,7 @@ impl Timeline {
                 ));
             }
             if let Some(end_time) = self.stats.end_time {
-                sammsges.push(format!(
+                summary_msgs.push(format!(
                     "Last Timestamp: {}\n",
                     utils::format_time(
                         &end_time,
@@ -289,7 +299,7 @@ impl Timeline {
                 ));
             }
 
-            for msgprint in sammsges.iter() {
+            for msgprint in summary_msgs.iter() {
                 let mut parts = msgprint.splitn(2, ':');
                 let first_part = parts.next().unwrap_or_default();
                 let second_part = format!(": {}", parts.next().unwrap_or_default());
@@ -319,30 +329,31 @@ impl Timeline {
         }
     }
 
-    // Generate an output message for each Event ID.
+    /// Generates one output row per (event ID, channel) pair: count, percentage, abbreviated
+    /// channel, event ID and event title.
     fn tm_stats_set_msg(
         &self,
         mapsorted: Vec<(&(CompactString, CompactString), &usize)>,
         event_timeline_config: &EventInfoConfig,
         stored_static: &StoredStatic,
     ) -> Nested<Vec<CompactString>> {
-        let mut msges: Nested<Vec<CompactString>> = Nested::new();
+        let mut msgs: Nested<Vec<CompactString>> = Nested::new();
 
         for ((event_id, channel), event_cnt) in mapsorted.iter() {
             // Calculate the percentage of counts.
             let rate: f32 = **event_cnt as f32 / self.stats.total as f32;
             let fmted_channel = channel;
 
-            // Get event information (event title, etc.)
-            // Set information for entries registered in channel_eid_info.txt.
-            // Create one line of output message.
+            // Create one line of the output message. The event title is only known for
+            // channel/event-ID pairs registered in channel_eid_info.txt; everything else is
+            // reported as "Unknown".
             let ch = replace_channel_abbr(stored_static, fmted_channel);
 
             if event_timeline_config
                 .get_event_id(fmted_channel, event_id)
                 .is_some()
             {
-                msges.push(vec![
+                msgs.push(vec![
                     CompactString::from(format!("{event_cnt}")),
                     format!("{:.1}%", (rate * 1000.0).round() / 10.0).into(),
                     ch.trim().into(),
@@ -355,7 +366,7 @@ impl Timeline {
                     ),
                 ]);
             } else {
-                msges.push(vec![
+                msgs.push(vec![
                     CompactString::from(format!("{event_cnt}")),
                     format!("{:.1}%", (rate * 1000.0).round() / 10.0).into(),
                     ch.trim().into(),
@@ -364,7 +375,7 @@ impl Timeline {
                 ]);
             }
         }
-        msges
+        msgs
     }
 
     /// Generate output message for login statistics per user.
@@ -380,11 +391,11 @@ impl Timeline {
             write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, "", false).ok();
         }
         if self.stats.stats_login_list.is_empty() {
-            let mut loginmsges: Vec<String> = Vec::new();
-            loginmsges.push("-----------------------------------------".to_string());
-            loginmsges.push("|     No logon events were detected.    |".to_string());
-            loginmsges.push("-----------------------------------------\n".to_string());
-            for msgprint in loginmsges.iter() {
+            let mut login_msgs: Vec<String> = Vec::new();
+            login_msgs.push("-----------------------------------------".to_string());
+            login_msgs.push("|     No logon events were detected.    |".to_string());
+            login_msgs.push("-----------------------------------------\n".to_string());
+            for msgprint in login_msgs.iter() {
                 println!("{msgprint}");
             }
         } else {
@@ -425,7 +436,7 @@ impl Timeline {
         }
         let mut wtr = if let Some(csv_path) = output {
             let file_name = csv_path.as_path().display().to_string() + "-" + logon_res + ".csv";
-            // output to file
+            // Output to file.
             match File::create(file_name) {
                 Ok(file) => {
                     target = Box::new(BufWriter::new(file));
@@ -447,15 +458,17 @@ impl Timeline {
         logins_stats_tb
             .load_preset(UTF8_FULL)
             .apply_modifier(UTF8_ROUND_CORNERS);
+        // The terminal table only shows a subset of the columns (count, event, target account,
+        // target computer, source computer, source IP address); the CSV output has all of them.
         let h = &header;
         logins_stats_tb.set_header([h[0], h[1], h[2], h[4], h[8], h[9]]);
-        // Set the logon results to aggregate.
+        // Index into the per-user [successful, failed] logon count pair.
         let vnum = match logon_res {
             "successful" => 0,
             "failed" => 1,
             &_ => 0,
         };
-        // Sort by aggregated count.
+        // Sort by aggregated count in descending order.
         let mut mapsorted: Vec<_> = self.stats.stats_login_list.iter().collect();
         mapsorted.sort_by(|x, y| y.1[vnum].cmp(&x.1[vnum]));
         for (e, values) in &mapsorted {
@@ -544,6 +557,8 @@ impl Timeline {
         }
     }
 
+    /// Output the log-metrics results (one row per log file) as CSV or as a terminal table,
+    /// sorted by event count in descending order.
     pub fn log_metrics_dsp_msg(&mut self, stored_static: &StoredStatic) {
         if let Action::LogMetrics(opt) = &stored_static.config.action.as_ref().unwrap() {
             let log_metrics = &mut self.stats.stats_logfile;
@@ -596,6 +611,8 @@ impl Timeline {
         }
     }
 
+    /// Output the strings collected by the extract-base64 command. Output failures are reported
+    /// according to the verbose/quiet-errors flags.
     pub fn extract_base64_dsp_msg(&mut self, stored_static: &StoredStatic) {
         match output_all(
             self.extracted_base64_records.clone(),
@@ -618,6 +635,10 @@ impl Timeline {
         }
     }
 
+    /// Builds one log-metrics output row for a single log file. Returns `None` when the file's
+    /// computers are dropped by the --include-computer / --exclude-computer filters. `sep` joins
+    /// multi-value cells (computers, channels, providers) unless overridden by the multiline or
+    /// tab-separator flags.
     fn create_record_array(
         rec: &LogMetrics,
         stored_static: &StoredStatic,
@@ -689,6 +710,9 @@ impl Timeline {
     }
 }
 
+/// Replaces a channel name with its abbreviation from channel_abbreviations.txt (looked up
+/// case-insensitively, falling back to the original name), then shortens generic terms using
+/// the abbreviations defined in generic_abbreviations.txt.
 fn replace_channel_abbr(stored_static: &StoredStatic, fmted_channel: &CompactString) -> String {
     stored_static.disp_abbr_generic.replace_all(
         stored_static
@@ -700,6 +724,9 @@ fn replace_channel_abbr(stored_static: &StoredStatic, fmted_channel: &CompactStr
     )
 }
 
+/// Replaces a provider name with its abbreviation from provider_abbreviations.txt (falling back
+/// to the original name), then shortens generic terms using the abbreviations defined in
+/// generic_abbreviations.txt.
 fn replace_provider_abbr(stored_static: &StoredStatic, fmted_provider: &CompactString) -> String {
     stored_static.disp_abbr_generic.replace_all(
         stored_static
@@ -742,7 +769,7 @@ mod tests {
         }))
     }
 
-    /// Test for statistics aggregation of the metrics command.
+    /// Test for the statistics aggregation of the logon-summary command.
     #[test]
     pub fn test_evt_logon_stats() {
         let mut dummy_stored_static =
@@ -789,7 +816,7 @@ mod tests {
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
         let mut timeline = Timeline::default();
 
-        // Test that stats_time_cnt does nothing when there is no record information.
+        // Test that logon_stats_start does nothing when there is no record information.
         timeline.stats.logon_stats_start(&[], &dummy_stored_static);
 
         // Test 1: When there is no target Timestamp information.
@@ -819,7 +846,7 @@ mod tests {
         assert!(timeline.stats.end_time.is_none());
 
         // Test 2: When Event.System.TimeCreated_attributes.SystemTime contains a timestamp.
-        let tcreated_attribe_record_str = r#"{
+        let tcreated_attrib_record_str = r#"{
             "Event": {
                 "System": {
                     "EventID": "4624",
@@ -839,11 +866,11 @@ mod tests {
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
 
-        let include_tcreated_attribe_record =
-            serde_json::from_str(tcreated_attribe_record_str).unwrap();
+        let include_tcreated_attrib_record =
+            serde_json::from_str(tcreated_attrib_record_str).unwrap();
         input_datas.clear();
         input_datas.push(create_rec_info(
-            include_tcreated_attribe_record,
+            include_tcreated_attrib_record,
             "testpath2".to_string(),
             &Nested::<String>::new(),
             &false,
@@ -851,7 +878,7 @@ mod tests {
         ));
 
         // Test 3: When Event.System.@timestamp contains a timestamp.
-        let timestamp_attribe_record_str = r#"{
+        let timestamp_attrib_record_str = r#"{
             "Event": {
                 "System": {
                     "EventID": 4625,
@@ -866,7 +893,7 @@ mod tests {
             },
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
-        let include_timestamp_record = serde_json::from_str(timestamp_attribe_record_str).unwrap();
+        let include_timestamp_record = serde_json::from_str(timestamp_attrib_record_str).unwrap();
         input_datas.push(create_rec_info(
             include_timestamp_record,
             "testpath2".to_string(),
@@ -976,7 +1003,7 @@ mod tests {
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
         let mut timeline = Timeline::default();
         let mut input_datas = vec![];
-        let timestamp_attribe_record_str = r#"{
+        let timestamp_attrib_record_str = r#"{
             "Event": {
                 "System": {
                     "EventID": 4625,
@@ -991,7 +1018,7 @@ mod tests {
             },
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
-        let include_timestamp_record = serde_json::from_str(timestamp_attribe_record_str).unwrap();
+        let include_timestamp_record = serde_json::from_str(timestamp_attrib_record_str).unwrap();
         input_datas.push(create_rec_info(
             include_timestamp_record,
             "testpath2".to_string(),
@@ -1074,7 +1101,7 @@ mod tests {
         *STORED_EKEY_ALIAS.write().unwrap() = Some(dummy_stored_static.eventkey_alias.clone());
         let mut timeline = Timeline::default();
         let mut input_datas = vec![];
-        let tcreated_attribe_record_str = r#"{
+        let tcreated_attrib_record_str = r#"{
             "Event": {
                 "System": {
                     "EventID": 4624,
@@ -1093,18 +1120,18 @@ mod tests {
             },
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
-        let include_tcreated_attribe_record =
-            serde_json::from_str(tcreated_attribe_record_str).unwrap();
+        let include_tcreated_attrib_record =
+            serde_json::from_str(tcreated_attrib_record_str).unwrap();
         input_datas.clear();
         input_datas.push(create_rec_info(
-            include_tcreated_attribe_record,
+            include_tcreated_attrib_record,
             "testpath2".to_string(),
             &Nested::<String>::new(),
             &false,
             &false,
         ));
 
-        let timestamp_attribe_record_str = r#"{
+        let timestamp_attrib_record_str = r#"{
             "Event": {
                 "System": {
                     "EventID": 4625,
@@ -1119,7 +1146,7 @@ mod tests {
             },
             "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
         }"#;
-        let include_timestamp_record = serde_json::from_str(timestamp_attribe_record_str).unwrap();
+        let include_timestamp_record = serde_json::from_str(timestamp_attrib_record_str).unwrap();
         input_datas.push(create_rec_info(
             include_timestamp_record,
             "testpath2".to_string(),
@@ -1146,7 +1173,7 @@ mod tests {
             "Source IP Address",
         ];
 
-        // Login Successful csv output test
+        // CSV output test for successful logons.
         let expect_success_records = [[
             "1",
             "Sec 4624",
@@ -1173,7 +1200,7 @@ mod tests {
             }
         };
 
-        // Login Failed csv output test
+        // CSV output test for failed logons.
         header[0] = "Failed";
         let expect_failed_records = [[
             "1",

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -23,16 +23,33 @@ lazy_static! {
     static ref DATE_REGEX: Regex = Regex::new(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$").unwrap();
 }
 
+/// Loads detection rule YAML files from disk, applies all rule filtering options
+/// (level, status, category, tags, excluded/noisy rule IDs) and keeps the counters
+/// shown in the rule loading summary at startup.
 pub struct ParseYaml {
+    /// Rules that survived filtering, as (rule file path, parsed YAML document) pairs.
     pub files: Vec<(String, Yaml)>,
+    /// Number of loaded rules per `ruletype` value ("Other" when the key is missing).
     pub rulecounter: HashMap<CompactString, u128>,
+    /// Number of rules that were not loaded, keyed by the reason ("excluded" or "noisy").
     pub rule_load_cnt: HashMap<CompactString, u128>,
+    /// Number of rules per `status` value, including deprecated/unsupported rules that were
+    /// counted but then skipped.
     pub rule_status_cnt: HashMap<CompactString, u128>,
+    /// Number of correlation rules encountered.
     pub rule_cor_cnt: HashMap<CompactString, u128>,
+    /// For each rule ID referenced from a correlation rule's `rules` list, how many times it is
+    /// referenced.
     pub rule_cor_ref_cnt: HashMap<CompactString, u128>,
+    /// Number of rules that use the Sigma `|expand` field modifier.
     pub rule_expand_cnt: u128,
+    /// Number of `|expand` rules whose placeholders had definitions in config/expand and thus
+    /// remained enabled.
     pub rule_expand_enabled_cnt: u128,
+    /// Number of rules that failed to be read, parsed as YAML, or validated against the
+    /// Hayabusa rule format.
     pub errorrule_count: u128,
+    /// Status values to exclude, from the --exclude-status option.
     pub exclude_status: HashSet<String>,
     pub loaded_rule_ids: HashSet<CompactString>,
 }
@@ -62,6 +79,7 @@ impl ParseYaml {
         }
     }
 
+    /// Reads the entire file at `path` into a String.
     pub fn read_file(path: &PathBuf) -> Result<String, String> {
         let mut file_content = String::new();
 
@@ -75,6 +93,8 @@ impl ParseYaml {
         Ok(file_content)
     }
 
+    /// Reads an obfuscated rule file (encoded_rules.yml) and decodes it by XORing every byte
+    /// with 0xAA.
     fn read_encoded_file(path: &PathBuf) -> Result<String, String> {
         let mut fr = fs::File::open(path)
             .map(BufReader::new)
@@ -86,6 +106,8 @@ impl ParseYaml {
         Ok(decode_string)
     }
 
+    /// Counts correlation rules and, for each rule ID listed under a correlation rule's `rules`
+    /// key, how many correlation rules reference it.
     fn update_correlation_counts(&mut self, yaml_docs: &Vec<Yaml>) {
         for doc in yaml_docs {
             if let Some(correlation) = doc["correlation"].as_hash() {
@@ -99,7 +121,7 @@ impl ParseYaml {
                 {
                     for rule in rules_list {
                         if let Some(rule_str) = rule.as_str() {
-                            // Update rules count, storing each unique rule
+                            // Count how many correlation rules reference this rule ID.
                             let rule_entry = self
                                 .rule_cor_ref_cnt
                                 .entry(CompactString::from(rule_str))
@@ -112,6 +134,10 @@ impl ParseYaml {
         }
     }
 
+    /// Recursively loads every .yml rule file under `path` (or the single file itself if `path`
+    /// is a file), applies all rule filtering options (minimum/exact level, status, category,
+    /// tags, excluded/noisy rule IDs) and appends the surviving rules to `self.files`.
+    /// The returned String is always empty; only the io::Result part matters to callers.
     pub fn read_dir<P: AsRef<Path>>(
         &mut self,
         path: P,
@@ -133,6 +159,9 @@ impl ParseYaml {
                 path.as_ref().to_path_buf().display(),
                 err_contents
             );
+            // "(os error 123)" is Windows ERROR_INVALID_NAME (invalid path syntax), which
+            // typically happens when a quoted path ends with a backslash, which escapes the
+            // closing quote and mangles the command-line argument.
             if err_contents.ends_with("123)") {
                 errmsg = format!(
                     "{errmsg}. You may not be able to load evtx files when there are spaces in the directory path. Please enclose the path with double quotes and remove any trailing slash at the end of the path."
@@ -162,7 +191,8 @@ impl ParseYaml {
             {
                 return io::Result::Ok(String::default());
             }
-            // Do not immediately abort when loading individual files.
+            // Do not abort the whole loading process when an individual rule file cannot be read;
+            // just skip that file.
             let mut is_encoded = false;
             let read_content = if path
                 .as_ref()
@@ -198,11 +228,13 @@ impl ParseYaml {
                 }
             };
 
-            // Same here: do not immediately abort when loading individual files.
+            // Likewise, skip files that fail to parse as YAML instead of aborting the whole load.
             match YamlLoader::load_from_str(&read_content) {
                 Ok(contents) => {
                     Self::update_correlation_counts(self, &contents);
                     yaml_docs.extend(contents.into_iter().map(|yaml_content| {
+                        // encoded_rules.yml bundles many rules in one file; each document
+                        // records its original file path in the `rulefile` key.
                         let filepath = if is_encoded {
                             yaml_content["rulefile"]
                                 .as_str()
@@ -259,21 +291,22 @@ impl ParseYaml {
                 }
 
                 let path_str = path.to_str().unwrap();
-                // ignore if yml file in .git folder.
+                // Ignore yml files inside a .git folder.
                 if utils::contains_str(path_str, "/.git/")
                     || utils::contains_str(path_str, "\\.git\\")
                 {
                     return io::Result::Ok(ret);
                 }
 
-                // ignore if tool test yml file in hayabusa-rules.
+                // Ignore the sigmac tool test yml files bundled in the hayabusa-rules repository.
                 if utils::contains_str(path_str, "rules/tools/sigmac/test_files")
                     || utils::contains_str(path_str, "rules\\tools\\sigmac\\test_files")
                 {
                     return io::Result::Ok(ret);
                 }
 
-                // Do not immediately abort when loading individual files.
+                // Do not abort the whole loading process when an individual rule file cannot be read;
+                // just skip that file.
                 let read_content = match Self::read_file(&path) {
                     Ok(content) => content,
                     Err(e) => {
@@ -293,7 +326,7 @@ impl ParseYaml {
                     }
                 };
 
-                // Same here: do not immediately abort when loading individual files.
+                // Likewise, skip files that fail to parse as YAML instead of aborting the whole load.
                 match YamlLoader::load_from_str(&read_content) {
                     Ok(contents) => {
                         Self::update_correlation_counts(self, &contents);
@@ -327,6 +360,10 @@ impl ParseYaml {
         }
         let exist_output_opt = stored_static.output_option.is_some();
         let files = yaml_docs.into_iter().filter_map(|(filepath, yaml_doc)| {
+            // Expand Sigma `|expand` field modifiers using the placeholder definitions found in
+            // config/expand. `expand_found` is set when a rule uses `|expand`;
+            // `expand_enabled_found` is additionally set when at least one placeholder was
+            // actually replaced. Rules whose placeholders have no definitions are skipped.
             let mut expand_found = false;
             let mut expand_enabled_found = false;
             let place_holder_map = expand_map.as_ref().unwrap();
@@ -344,13 +381,15 @@ impl ParseYaml {
                     return Option::None;
                 }
             };
-            // Ignore excluded rules.
+            // Skip rules whose ID is listed in exclude_rules.txt or noisy_rules.txt.
             let rule_id = &yaml_doc["id"].as_str();
             if rule_id.is_some() {
                 if let Some(v) = exclude_ids
                     .no_use_rule
                     .get(&rule_id.unwrap_or(&String::default()).to_string())
                 {
+                    // `v` is the path of the list file that the rule ID came from
+                    // (exclude_rules.txt or noisy_rules.txt).
                     let entry_key = if utils::contains_str(v, "exclude_rule") {
                         "excluded"
                     } else {
@@ -371,6 +410,8 @@ impl ParseYaml {
                         return Option::None;
                     }
                 }
+                // When the -P/--proven-rules option is used, only load rules whose IDs are
+                // listed in proven_rules.txt.
                 if let Some(id) = rule_id
                     && !stored_static.target_ruleids.is_target(id, true)
                 {
@@ -406,7 +447,8 @@ impl ParseYaml {
                 }
             }
 
-            // Ignore rules below the specified level.
+            // Ignore rules below the minimum level and, when an exact target level is given
+            // (--exact-level), rules at any other level.
             let doc_level = &yaml_doc["level"]
                 .as_str()
                 .unwrap_or("informational")
@@ -422,7 +464,8 @@ impl ParseYaml {
             }
             let status = yaml_doc["status"].as_str();
             if let Some(s) = yaml_doc["status"].as_str() {
-                // Exclude rules whose status matches the excluded status option, or does not match the include_status option.
+                // Exclude rules whose status matches the --exclude-status option or does not
+                // match the --include-status option.
                 if self.exclude_status.contains(&s.to_string())
                     || !(is_contained_include_status_all_allowed
                         || stored_static.include_status.contains(s))
@@ -445,11 +488,15 @@ impl ParseYaml {
                                 .unwrap()
                                 .enable_unsupported_rules))
                 {
-                    // If the corresponding enable-xxx-rules option is not specified for deprecated or unsupported status, only count the status and then exclude.
+                    // Deprecated/unsupported rules are only counted, not loaded, unless the
+                    // corresponding --enable-deprecated-rules / --enable-unsupported-rules
+                    // option is given.
                     up_rule_status_cnt(s);
                     return Option::None;
                 }
             } else if !is_contained_include_status_all_allowed {
+                // Rules without a status are excluded for the scan commands unless all statuses
+                // are allowed with the wildcard "*".
                 let need_rules = matches!(
                     stored_static.config.action.as_ref().unwrap(),
                     Action::CsvTimeline(_) | Action::JsonTimeline(_) | Action::PivotKeywordsList(_)
@@ -498,7 +545,7 @@ impl ParseYaml {
                 }
             }
 
-            // Exclude rules that do not have the tags specified by the tags option.
+            // Exclude rules that do not carry any of the tags given by the --include-tag option.
             if exist_output_opt
                 && stored_static
                     .output_option
@@ -529,7 +576,7 @@ impl ParseYaml {
                 }
             }
 
-            // Exclude rules that have the tag specified by the exclude-tag option.
+            // Exclude rules that carry any of the tags given by the --exclude-tag option.
             if let Some(opt) = stored_static.output_option.as_ref()
                 && let Some(exclude_tag) = opt.exclude_tag.as_ref()
             {
@@ -567,6 +614,11 @@ impl ParseYaml {
 }
 
 /// Count rules hierarchically by status/level/tags for display in the scan wizard.
+/// The returned map is keyed by status ("excluded"/"noisy" for filtered rules), then by
+/// uppercased level, then by tag bucket ("detection.emerging_threats",
+/// "detection.threat_hunting", "sysmon", "other", or the "duplicated" adjustment bucket).
+/// Under the "excluded"/"noisy" keys the innermost key is instead the rule's lowercased
+/// status (e.g. "test", "experimental", "undefined") rather than a tag bucket.
 pub fn count_rules<P: AsRef<Path>>(
     path: P,
     exclude_ids: &RuleExclude,
@@ -593,7 +645,8 @@ pub fn count_rules<P: AsRef<Path>>(
             return HashMap::default();
         }
 
-        // Do not immediately abort when loading individual files.
+        // Do not abort the whole loading process when an individual rule file cannot be read;
+        // just skip that file.
         let mut is_encoded = false;
         let read_content = if path
             .as_ref()
@@ -613,13 +666,15 @@ pub fn count_rules<P: AsRef<Path>>(
             Err(_) => return HashMap::default(),
         };
 
-        // Same here: do not immediately abort when loading individual files.
+        // Likewise, skip files that fail to parse as YAML instead of aborting the whole load.
         let yaml_contents = match YamlLoader::load_from_str(&read_content) {
             Ok(contents) => contents,
             Err(_) => return HashMap::default(),
         };
 
         yaml_docs.extend(yaml_contents.into_iter().map(|yaml_content| {
+            // encoded_rules.yml bundles many rules in one file; each document records its
+            // original file path in the `rulefile` key.
             let filepath = if is_encoded {
                 yaml_content["rulefile"]
                     .as_str()
@@ -656,27 +711,28 @@ pub fn count_rules<P: AsRef<Path>>(
                 }
 
                 let path_str = path.to_str().unwrap();
-                // ignore if yml file in .git folder.
+                // Ignore yml files inside a .git folder.
                 if utils::contains_str(path_str, "/.git/")
                     || utils::contains_str(path_str, "\\.git\\")
                 {
                     return io::Result::Ok(ret);
                 }
 
-                // ignore if tool test yml file in hayabusa-rules.
+                // Ignore the sigmac tool test yml files bundled in the hayabusa-rules repository.
                 if utils::contains_str(path_str, "rules/tools/sigmac/test_files")
                     || utils::contains_str(path_str, "rules\\tools\\sigmac\\test_files")
                 {
                     return io::Result::Ok(ret);
                 }
 
-                // Do not immediately abort when loading individual files.
+                // Do not abort the whole loading process when an individual rule file cannot be read;
+                // just skip that file.
                 let read_content = match ParseYaml::read_file(&path) {
                     Ok(content) => content,
                     Err(_) => return io::Result::Ok(ret),
                 };
 
-                // Same here: do not immediately abort when loading individual files.
+                // Likewise, skip files that fail to parse as YAML instead of aborting the whole load.
                 let yaml_contents = match YamlLoader::load_from_str(&read_content) {
                     Ok(contents) => contents,
                     Err(e) => {
@@ -705,10 +761,10 @@ pub fn count_rules<P: AsRef<Path>>(
             .unwrap_or_default();
     }
     yaml_docs.into_iter().for_each(|(_filepath, yaml_doc)| {
-        // Ignore excluded rules.
         let empty = vec![];
         let rule_id = &yaml_doc["id"].as_str();
         let rule_tags_vec = yaml_doc["tags"].as_vec().unwrap_or(&empty);
+        // Collect the wizard-relevant tags that this rule carries.
         let included_target_tag_vec = {
             let target_wizard_tags = [
                 "detection.emerging_threats",
@@ -721,11 +777,15 @@ pub fn count_rules<P: AsRef<Path>>(
                 .filter_map(|s| s.as_str())
                 .collect_vec()
         };
+        // Rules whose ID is listed in exclude_rules.txt / noisy_rules.txt are counted under
+        // "excluded"/"noisy" instead of their own status.
         if rule_id.is_some()
             && let Some(v) = exclude_ids
                 .no_use_rule
                 .get(&rule_id.unwrap_or(&String::default()).to_string())
         {
+            // `v` is the path of the list file that the rule ID came from
+            // (exclude_rules.txt or noisy_rules.txt).
             let entry_key = if utils::contains_str(v, "exclude_rule") {
                 "excluded"
             } else {
@@ -758,7 +818,8 @@ pub fn count_rules<P: AsRef<Path>>(
         }
 
         if let Some(s) = yaml_doc["status"].as_str() {
-            // In the initial counting for the wizard, check the status and level, then skip further processing.
+            // The wizard's initial count only categorizes rules by status, level and wizard
+            // tags; none of the other load-time filters are applied here.
             let counter = result_container.entry(s.into()).or_insert(HashMap::new());
             if included_target_tag_vec.is_empty() {
                 *counter
@@ -773,6 +834,9 @@ pub fn count_rules<P: AsRef<Path>>(
                     .entry("other".into())
                     .or_insert(0) += 1;
             } else {
+                // A rule carrying more than one wizard tag is counted once per tag below, so
+                // record a negative adjustment of -(n-1) in the "duplicated" bucket to keep the
+                // grand total equal to the actual number of rules.
                 if included_target_tag_vec.len() > 1 {
                     *counter
                         .entry(
@@ -805,6 +869,9 @@ pub fn count_rules<P: AsRef<Path>>(
     result_container.to_owned()
 }
 
+/// Validates that a rule contains every key required by the Hayabusa rule format (correlation
+/// rules do not need `logsource`/`detection`) and that the `level`, `status` and `date` values
+/// are valid. On failure, returns all problems joined with " ¦ ".
 pub fn check_hayabusa_rule_fmt(yaml: &Yaml) -> Result<(), String> {
     let mut required_keys = vec![
         "author",
@@ -958,7 +1025,7 @@ mod tests {
     }
 
     #[test]
-    /// no specifed "level" arguments value is adapted default level(informational)
+    /// When no level argument is specified, the default level (informational) should be applied.
     fn test_default_level_read_yaml() {
         let path = Path::new("test_files/rules/level_yaml");
         let dummy_stored_static = create_dummy_stored_static();

--- a/src/yaml_expand.rs
+++ b/src/yaml_expand.rs
@@ -5,6 +5,15 @@ use std::{fs, io};
 use yaml_rust2::Yaml;
 use yaml_rust2::yaml::Hash;
 
+/// Applies placeholder replacement to the value of a `|expand` field.
+///
+/// For a string value, each known `%placeholder%` it contains is substituted independently with
+/// each of that placeholder's configured replacement values (a string containing multiple known
+/// placeholders yields variants in which the other placeholders remain unreplaced), turning the
+/// single string into an array of strings (Sigma treats a list of field values as an OR
+/// condition). A string that contains no known placeholder is returned unchanged. Array values
+/// are processed element by element via `process_yaml`, so only nested `|expand` keys inside
+/// them are expanded.
 fn process_value(
     value: &Yaml,
     replacements: &HashMap<String, Vec<String>>,
@@ -40,6 +49,17 @@ fn process_value(
     }
 }
 
+/// Recursively rewrites a rule YAML document, implementing the Sigma `|expand` field modifier.
+///
+/// Every mapping key that contains `|expand` has the modifier stripped from the key name and any
+/// `%placeholder%` tokens in its value replaced using `replacements` (loaded from
+/// `config/expand/*.txt` by [`read_expand_files`]).
+///
+/// The two out-parameters let the caller decide how to treat the rule:
+/// * `expand_found` is set to true when at least one `|expand` key was encountered.
+/// * `expand_enabled` is set to true when at least one replacement actually changed a value,
+///   i.e. a placeholder definition existed. Rules that use `|expand` but have no matching
+///   placeholder definitions are skipped by the caller (see `yaml.rs`).
 pub fn process_yaml(
     yaml: &Yaml,
     replacements: &HashMap<String, Vec<String>>,
@@ -87,6 +107,10 @@ pub fn process_yaml(
     }
 }
 
+/// Loads placeholder definitions from every `.txt` file directly under `dir` (normally
+/// `config/expand`). The file stem becomes the placeholder name wrapped in percent signs
+/// (e.g. `admins.txt` defines `%admins%`), and each line, trimmed of surrounding whitespace,
+/// becomes one replacement value. Files that contain no lines are ignored.
 pub fn read_expand_files<P: AsRef<Path>>(dir: P) -> io::Result<HashMap<String, Vec<String>>> {
     let mut expand_map = HashMap::new();
     if let Ok(entries) = fs::read_dir(dir) {


### PR DESCRIPTION
Closes #1807

## What Changed

A comments-and-identifiers-only cleanup across all of `src/**/*.rs` (~35k lines, read file by file). **No behavior changes** — no logic, no string literals, no output formats.

- **Translated all remaining Japanese comments to English** (about 19, across `main.rs`, `afterfact.rs`, `matchers.rs`, `base64_match.rs`, `condition_parser.rs`, etc.), preserving the full original meaning including author TODO/self-critique notes kept as refactoring reminders.
- **Repaired 6 half-translated comment artifacts** left over from earlier passes, e.g. `matchers.rs`: `// When it is a wildcard.、"*"は".*"という正規表現に変換し…` is now one coherent English sentence.
- **Cleaned up ~450 existing English comments** (spelling such as `occured`, grammar, clarity), including comments that had drifted from the code — these were rewritten to describe what the code actually does. Examples of comment/code drift fixed:
  - `main.rs` `is_filtered_record`: the old comment said EID filtering applies when the EventID filter option is *not* specified; the code filters when `eid_filter` *is* enabled (and the EventID is not in `target_eventids.txt`).
  - `timeline/search.rs` `replace_all_field_info_abbr`: the old doc said it replaces abbreviations with full names; the code does the reverse (full name → abbreviation).
  - `detections/message.rs` `create_error_log`: the old doc claimed it returns a `BufWriter`; it returns `()` and writes the error log file.
- **Added ~420 comments/doc comments** where the logic is hard to follow: rule-engine internals (selection tree, wildcard→regex conversion, base64offset arithmetic, count/correlation evaluation), output profile handling, and non-obvious invariants and edge cases. Comments explain the *why* and the non-obvious *what*; obvious code was left uncommented.
- **Fixed misspelled identifiers** (internal names only; verified not CLI-visible, not serde/output field names, never inside string literals), e.g.:
  - `AggegationConditionCompiler` → `AggregationConditionCompiler`
  - `CONTROL_CHAT_REPLACE_MAP` → `CONTROL_CHAR_REPLACE_MAP` (it maps control *characters*)
  - `get_childs` → `get_children`, `scanable_rule_exists` → `scannable_rule_exists`
  - `rap_checkpoint` → `lap_checkpoint` (ラップ = lap), `rulepathes` → `rule_paths`
  - `add_aggcondition_msges`/`sammsges`/`err_msges`/`stats_msges`/`loginmsges` → `..._msgs` (whole family)
  - `stored_staic` → `stored_static`, `reducted_*` → `reduced_*`, `write_headder` → `write_header`, `trimed_condition` → `trimmed_condition`, `filed_data_converter` → `field_data_converter`, plus ~40 more of the same kind (misspelled test names, local variables, private helpers).

## Deliberate decisions (for reviewers)

- **String literals are untouched, byte-for-byte** — including the Japanese strings used as UTF-8/UTF-16 test data (`base64_match.rs`, `matchers.rs`, `fast_match.rs`), `"ローカル"` in `geoip_search.rs`, and typos inside user-facing strings (`"occured"`, `"deteciton"`, `"Successed"` — listed in #1807 for a follow-up).
- **Commented-out code blocks were not deleted**, and **author TODOs were kept verbatim** (e.g. `// TODO hach1yon add logic` in `timeline/search.rs`, the `// TODO add check` notes in `main.rs` tests).
- One stale note was dropped rather than translated: the old Japanese comment on `ConditionToken::NotContainer` criticized it for being a `Vec`; the field has since been refactored to `Box`, so only the still-accurate description was kept.
- One rename is semantic rather than a spelling fix: the local loop variable `rulepathes` in `filter.rs::scannable_rule_exists` was renamed to `evtx_paths` because the values it iterates are evtx file paths (per `evtx_channels_map`'s own definition), so the old name was factually wrong.
- Some renamed items are `pub` (the crate has a lib target): `SelectionNode::get_children`, `CONTROL_CHAR_REPLACE_MAP`, `ChannelFilter::rule_paths`, `scannable_rule_exists`, `lap_checkpoint`, `AggregationConditionCompiler`. All in-repo consumers are updated and CI is green; only a hypothetical external consumer of hayabusa-as-a-library would notice.
- The nonstandard plural `datas` identifier family (`datas`, `input_datas`, `md_datas`, `time_datas` — ~76 occurrences across 7 files) was left as-is: it is a consistent project-wide idiom and renaming it would significantly grow this PR. Happy to do it here or in a follow-up if you prefer.

## Evidence

- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `RUST_TEST_THREADS=1 cargo test`: **442/442 tests pass** (425 lib + 17 bin, matching the 442 `#[test]` functions in the tree) ✅
- Diff purity was verified mechanically: after stripping comments, every remaining changed line in `git diff` reduces to one of the identifier renames listed above (token-level comparison), i.e. the diff provably contains only comment changes and renames.
- Each file's changes were reviewed against the code by independent reviewers for translation fidelity and technical accuracy, and the full diff then went through a second adversarial review pass (English quality, comment-vs-code accuracy, diff purity, rename integrity); all confirmed findings were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
