### PR TITLE
fix: logon-summary Target Domain was always "-" for RDS Gateway logons due to alias typo

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -14,6 +14,7 @@
 - HTMLレポートのMarkdownインジェクションの問題を修正した。ユーザー由来の値（コンピュータ名など）はHTMLエスケープされていたがMarkdownエスケープはされておらず、`[x](javascript:alert(1))` のような値がクリック可能な `javascript:` リンクとして描画される可能性があった。ユーザー値内のMarkdownメタ文字もエスケープするようにした。 (#1806) (@YamatoSecurity)
 - null-UUIDのテストルールを除外ルール・ノイジールールの件数から除くための判定が、ルールIDではなく除外リストファイルのパスと比較していたため機能しておらず、テストルールが`Excluded rules`の件数を水増ししていた問題を修正した。 (#1821) (@YamatoSecurity)
 - Results Summary（およびHTMLレポート）のユニーク検知のパーセンテージがレベル間で鏡写しに入れ替わっていた問題を修正した。逆順ループのインデックスでパーセンテージを計算していたため、例えば`critical`の行に`informational`のパーセンテージが表示されていた（正しかったのは中央の`medium`のみ）。 (#1812) (@YamatoSecurity)
+- `logon-summary`コマンドで、RDSゲートウェイのログオン（`Microsoft-Windows-TerminalServices-Gateway/Operational`のEID 302）のTarget Domain列が常に`-`になっていた問題を修正した。`dst_domain`の抽出がイベントキーエイリアス`RdsGtwUsername`をスペルミスの`RdsGtwUserName`で参照していたため、`DOMAIN\user`形式の値からドメインが取得されていなかった。 (#1809) (@YamatoSecurity)
 
 ## 3.9.0 [2026/04/29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fuku
 - Fixed a Markdown-injection issue in the HTML report: user-supplied values (e.g. computer names) were HTML-escaped but not Markdown-escaped, so a value like `[x](javascript:alert(1))` could render as a clickable `javascript:` link. Markdown metacharacters in user values are now escaped as well. (#1806) (@YamatoSecurity)
 - The exemption that keeps the null-UUID test rule out of the excluded/noisy rule counts compared the exclude-list file path instead of the rule ID, so it never applied and test rules inflated the `Excluded rules` count. (#1821) (@YamatoSecurity)
 - Unique detection percentages in the Results Summary (and the HTML report) were mirrored across levels: the percentage was computed with the reversed loop index, so e.g. the `critical` row showed `informational`'s percentage and vice versa (only `medium` was correct). (#1812) (@YamatoSecurity)
+- `logon-summary`: the Target Domain column was always `-` for RDS Gateway logons (EID 302 in `Microsoft-Windows-TerminalServices-Gateway/Operational`) because the `dst_domain` lookup used the misspelled event key alias `RdsGtwUserName` instead of `RdsGtwUsername`, so the domain in `DOMAIN\user` values was silently dropped. (#1809) (@YamatoSecurity)
 
 **Other:**
 

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -409,7 +409,7 @@ impl EventMetrics {
                         }
                         RdsGtw => {
                             let user_with_domain = get_event_value_as_string(
-                                "RdsGtwUserName",
+                                "RdsGtwUsername",
                                 &record.record,
                                 &stored_static.eventkey_alias,
                             );

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -902,7 +902,53 @@ mod tests {
             &false,
         ));
 
+        // Test 4: An RDS Gateway logon (EID 302) whose Username carries a "DOMAIN\user" value.
+        // Both the user and the domain are extracted from Event.UserData.EventInfo.Username via
+        // the RdsGtwUsername alias (regression test for #1809, where the dst_domain arm looked
+        // up the misspelled alias "RdsGtwUserName" and always yielded "-").
+        let rds_gtw_record_str = r#"{
+            "Event": {
+                "System": {
+                    "EventID": 302,
+                    "Channel": "Microsoft-Windows-TerminalServices-Gateway/Operational",
+                    "Computer": "GATEWAY01",
+                    "TimeCreated_attributes": {
+                        "SystemTime": "2022-12-23T00:00:00.000Z"
+                    }
+                },
+                "UserData": {
+                    "EventInfo": {
+                        "Username": "CONTOSO\\alice",
+                        "IpAddress": "10.0.0.5"
+                    }
+                }
+            },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        let rds_gtw_record = serde_json::from_str(rds_gtw_record_str).unwrap();
+        input_datas.push(create_rec_info(
+            rds_gtw_record,
+            "testpath3".to_string(),
+            &Nested::<String>::new(),
+            &false,
+            &false,
+        ));
+
         let mut expect: HashMap<LoginEvent, [usize; 2]> = HashMap::new();
+        expect.insert(
+            LoginEvent {
+                channel: "RDS-GTW 302".into(),
+                dst_user: "alice".into(),
+                dst_domain: "CONTOSO".into(),
+                hostname: "GATEWAY01".into(),
+                logontype: "-".into(),
+                src_user: "-".into(),
+                src_domain: "-".into(),
+                source_computer: "-".into(),
+                source_ip: "10.0.0.5".into(),
+            },
+            [1, 0],
+        );
         expect.insert(
             LoginEvent {
                 channel: "Sec 4624".into(),
@@ -952,7 +998,7 @@ mod tests {
             ))
         );
 
-        assert_eq!(timeline.stats.total, 3);
+        assert_eq!(timeline.stats.total, 4);
 
         for (k, v) in timeline.stats.stats_login_list.iter() {
             assert!(expect.contains_key(k));


### PR DESCRIPTION
## What

Fixes #1809.

In the `logon-summary` command, the `dst_domain` (Target Domain) extraction for RDS Gateway logon events (EID 302 in `Microsoft-Windows-TerminalServices-Gateway/Operational`) looked up the event key alias `RdsGtwUserName` (capital `N`), but the alias defined in `rules/config/eventkey_alias.txt` is `RdsGtwUsername`. The case-sensitive lookup missed, fell back to `Event.EventData.RdsGtwUserName` (which never exists for these records — their fields live under `Event.UserData.EventInfo`), and always returned `-`, silently dropping the domain that was present in the record. The neighboring `dst_user` arm already used the correct spelling and worked.

The fix changes the alias to `RdsGtwUsername`, matching the config and the `dst_user` arm. Also adds a regression test (`test_evt_logon_stats`) with an EID 302 record whose `Username` is `CONTOSO\alice`, asserting `dst_user == "alice"` and `dst_domain == "CONTOSO"`, and CHANGELOG entries (English + Japanese).

## Verification

Ran `logon-summary -J` end-to-end on a crafted EID 302 RDS Gateway record with `Username = CONTOSO\alice`:

Before (current main):
```
Successful,Event,Target Account,Target Domain,Target Computer,...,Source IP Address
1,RDS-GTW 302,alice,-,GATEWAY01.contoso.com,...,10.0.0.5
```

After:
```
Successful,Event,Target Account,Target Domain,Target Computer,...,Source IP Address
1,RDS-GTW 302,alice,CONTOSO,GATEWAY01.contoso.com,...,10.0.0.5
```

Also probed a `Username` without a domain prefix (`bob`): Target Account `bob`, Target Domain `-` — unchanged, as intended. `cargo test`, `cargo fmt --check`, and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)