### PR TITLE
fix: GeoIP lookup treated all public IPv6 addresses as Private

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -15,6 +15,7 @@
 - null-UUIDのテストルールを除外ルール・ノイジールールの件数から除くための判定が、ルールIDではなく除外リストファイルのパスと比較していたため機能しておらず、テストルールが`Excluded rules`の件数を水増ししていた問題を修正した。 (#1821) (@YamatoSecurity)
 - Results Summary（およびHTMLレポート）のユニーク検知のパーセンテージがレベル間で鏡写しに入れ替わっていた問題を修正した。逆順ループのインデックスでパーセンテージを計算していたため、例えば`critical`の行に`informational`のパーセンテージが表示されていた（正しかったのは中央の`medium`のみ）。 (#1812) (@YamatoSecurity)
 - `logon-summary`コマンドで、RDSゲートウェイのログオン（`Microsoft-Windows-TerminalServices-Gateway/Operational`のEID 302）のTarget Domain列が常に`-`になっていた問題を修正した。`dst_domain`の抽出がイベントキーエイリアス`RdsGtwUsername`をスペルミスの`RdsGtwUserName`で参照していたため、`DOMAIN\user`形式の値からドメインが取得されていなかった。 (#1809) (@YamatoSecurity)
+- GeoIP機能がすべてのパブリックIPv6アドレスを`Private`として扱い、GeoIP検索を行っていなかった問題を修正した。IPv6のプライベート範囲リストにグローバルユニキャスト空間全体である`2000::/3`が含まれていたことが原因。あわせて冗長な`FD00::/8`（`FC00::/7`に包含される）も削除し、パブリックIPv6アドレスにASN・国・都市の情報が付与されるようにした。 (#1819) (@YamatoSecurity)
 
 ## 3.9.0 [2026/04/29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Added unique and total alert count to MITRE ATT&CK tactics found. (#1753) (@fuku
 - The exemption that keeps the null-UUID test rule out of the excluded/noisy rule counts compared the exclude-list file path instead of the rule ID, so it never applied and test rules inflated the `Excluded rules` count. (#1821) (@YamatoSecurity)
 - Unique detection percentages in the Results Summary (and the HTML report) were mirrored across levels: the percentage was computed with the reversed loop index, so e.g. the `critical` row showed `informational`'s percentage and vice versa (only `medium` was correct). (#1812) (@YamatoSecurity)
 - `logon-summary`: the Target Domain column was always `-` for RDS Gateway logons (EID 302 in `Microsoft-Windows-TerminalServices-Gateway/Operational`) because the `dst_domain` lookup used the misspelled event key alias `RdsGtwUserName` instead of `RdsGtwUsername`, so the domain in `DOMAIN\user` values was silently dropped. (#1809) (@YamatoSecurity)
+- The GeoIP function treated every public IPv6 address as `Private` and never performed a lookup for them, because the IPv6 private range list included `2000::/3` (the entire global unicast space). Removed it (along with the redundant `FD00::/8`, a subset of `FC00::/7`) so that public IPv6 addresses are now enriched with ASN/Country/City. (#1819) (@YamatoSecurity)
 
 **Other:**
 

--- a/src/options/geoip_search.rs
+++ b/src/options/geoip_search.rs
@@ -66,9 +66,7 @@ impl GeoIPSearch {
     }
 
     /// Checks whether target_ip falls within one of the CIDR ranges below, which are excluded
-    /// from GeoIP lookup and reported as "Private". Note that the IPv6 list includes 2000::/3
-    /// (global unicast), so effectively all IPv6 addresses except loopback are treated as
-    /// private.
+    /// from GeoIP lookup and reported as "Private".
     fn check_in_private_ip_range(&self, target_ip: &IpAddr) -> bool {
         let private_cidr = if target_ip.is_ipv4() {
             vec![
@@ -79,11 +77,9 @@ impl GeoIPSearch {
         } else {
             vec![
                 IpCidr::from_str("::/128").unwrap(),    // IPv6 Unspecified
-                IpCidr::from_str("2000::/3").unwrap(),  // IPv6 Global Unicast
                 IpCidr::from_str("FE80::/10").unwrap(), // IPv6 Link Local Unicast
-                IpCidr::from_str("FC00::/7").unwrap(),  // IPv6 Unique Local Address
-                IpCidr::from_str("FD00::/8").unwrap(),  // IPv6 Unique Local Address
-                IpCidr::from_str("FF00::/8").unwrap(),  // IPv6 Multicast Address
+                IpCidr::from_str("FC00::/7").unwrap(), // IPv6 Unique Local Address (covers FD00::/8)
+                IpCidr::from_str("FF00::/8").unwrap(), // IPv6 Multicast Address
             ]
         };
         for cidr in private_cidr {
@@ -234,7 +230,6 @@ mod tests {
             GeoIPSearch::check_exist_geo_ip_files(&Some(test_path.clone()), target_files.clone()),
             Ok(Some(test_path.clone()))
         );
-        IP_MAP.lock().unwrap().clear();
         let geo_ip = GeoIPSearch::new(&test_path, target_files);
         let expect = "🦅United Kingdom🦅Boxford";
         let actual = geo_ip.convert_ip_to_geo("2.125.160.216");
@@ -261,11 +256,13 @@ mod tests {
             Ok(Some(test_path.clone()))
         );
         let geo_ip = GeoIPSearch::new(&test_path, target_files);
+        // Use an address no other test looks up: tests run in parallel and share the global
+        // IP_MAP cache, so touching another test's address would be racy.
         IP_MAP.lock().unwrap().insert(
-            IpAddr::from_str("2.125.160.216").unwrap(),
+            IpAddr::from_str("2.125.160.217").unwrap(),
             "this is dummy".into(),
         );
-        let actual = geo_ip.convert_ip_to_geo("2.125.160.216");
+        let actual = geo_ip.convert_ip_to_geo("2.125.160.217");
         assert!(actual.is_ok());
         assert_eq!(CompactString::from("this is dummy"), actual.unwrap());
     }
@@ -284,7 +281,6 @@ mod tests {
             GeoIPSearch::check_exist_geo_ip_files(&Some(test_path.clone()), target_files.clone()),
             Ok(Some(test_path.clone()))
         );
-        IP_MAP.lock().unwrap().clear();
         let geo_ip = GeoIPSearch::new(&test_path, target_files);
         let loopback = geo_ip.convert_ip_to_geo("127.0.0.1");
         assert!(loopback.is_ok());
@@ -314,7 +310,6 @@ mod tests {
             GeoIPSearch::check_exist_geo_ip_files(&Some(test_path.clone()), target_files.clone()),
             Ok(Some(test_path.clone()))
         );
-        IP_MAP.lock().unwrap().clear();
         let geo_ip = GeoIPSearch::new(&test_path, target_files);
         let loopback = geo_ip.convert_ip_to_geo("::1");
         assert!(loopback.is_ok());
@@ -322,8 +317,20 @@ mod tests {
         let link_local = geo_ip.convert_ip_to_geo("fe80::123:33ef:fe11:1");
         assert!(link_local.is_ok());
         assert_eq!("Private🦅-🦅-", link_local.unwrap());
-        let global_unicast = geo_ip.convert_ip_to_geo("2001:1234:abcd:1234::1");
+        let unspecified = geo_ip.convert_ip_to_geo("::");
+        assert!(unspecified.is_ok());
+        assert_eq!("Private🦅-🦅-", unspecified.unwrap());
+        let unique_local = geo_ip.convert_ip_to_geo("fd12:3456:789a::1");
+        assert!(unique_local.is_ok());
+        assert_eq!("Private🦅-🦅-", unique_local.unwrap());
+        let multicast = geo_ip.convert_ip_to_geo("ff02::1");
+        assert!(multicast.is_ok());
+        assert_eq!("Private🦅-🦅-", multicast.unwrap());
+        // Global unicast addresses must be looked up in the databases instead of being
+        // reported as Private (issue #1819). 2001:218::/32 is Japan in the MaxMind test
+        // data (with no ASN or city entry, so those fields are empty).
+        let global_unicast = geo_ip.convert_ip_to_geo("2001:218::1");
         assert!(global_unicast.is_ok());
-        assert_eq!("Private🦅-🦅-", global_unicast.unwrap());
+        assert_eq!("🦅Japan🦅", global_unicast.unwrap());
     }
 }


### PR DESCRIPTION
## What

Fixes #1819.

`GeoIPSearch::check_in_private_ip_range()` included `2000::/3` — the entire IPv6 global unicast (publicly routable) space — in its private range list, so `convert_ip_to_geo()` returned `Private🦅-🦅-` for every public IPv6 address before ever consulting the MaxMind databases. GeoIP enrichment therefore silently never worked for native IPv6 traffic (only IPv4-mapped `::ffff:` addresses escaped, since they are converted to IPv4 first).

Changes:
- Removed `2000::/3` from the IPv6 private range list, along with the redundant `FD00::/8` (a subset of `FC00::/7`). The list now contains only genuinely non-global ranges: `::/128`, `FE80::/10`, `FC00::/7`, `FF00::/8`. (IPv6 loopback `::1` is already handled separately via `is_loopback()`.)
- Updated `test_check_in_private_range_v6`, which previously asserted the buggy behavior: a global unicast address (`2001:218::1`, Japan in the MaxMind test data) must now return a real lookup result, and added unspecified/unique-local/multicast cases that must stay `Private`.
- De-flaked the geoip tests: they run in parallel and share the global `IP_MAP` cache, and the `IP_MAP.clear()` calls plus the dummy-cache test reusing the same IP as the real-lookup test could race (the real-lookup test could observe the dummy value, or the dummy could be cleared mid-test). Each test now uses addresses no other test touches, and the clears are gone. Verified stable across 10 consecutive runs.

## Verification

Ran `csv-timeline -J -G test_files/mmdb` end-to-end on crafted 4624 events with a public IPv6, a link-local IPv6, and an RFC1918 IPv4 source address.

Before (current main) — all three, including the public IPv6, reported as Private:
```
SrcIP: 2001:218::1  → SrcASN: Private, SrcCountry: -, SrcCity: -
SrcIP: fe80::1234   → SrcASN: Private, SrcCountry: -, SrcCity: -
SrcIP: 192.168.1.10 → SrcASN: Private, SrcCountry: -, SrcCity: -
```

After — the public IPv6 gets a real lookup; non-global addresses still report Private:
```
SrcIP: 2001:218::1  → SrcCountry: Japan (no ASN/City entry in the test data)
SrcIP: fe80::1234   → SrcASN: Private, SrcCountry: -, SrcCity: -
SrcIP: 192.168.1.10 → SrcASN: Private, SrcCountry: -, SrcCity: -
```

`cargo test`, `cargo fmt --check`, and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)