### PR TITLE
chore: bump hayabusa-evtx to 0.9.9 (dependency updates)

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -24,6 +24,7 @@
 **その他:**
 
 - 可読性向上のため、`src/` 内の分かりにくい・誤解を招く・Hayabusa固有の変数・引数・構造体フィールド名76個を、より明確で慣用的なRustの名前にリネームした（例: `datas`→`records`、`con_cal`→`joined_value`、`name_2_node`→`name_to_node`、`hlch`→`horizontal_line_char`、`rulepath`→`rule_path`、`ext_field`→`output_fields`、および実際にはAND条件の`AllSelectionNode`を保持していた誤名の`or_node`→`all_node`）。内部識別子のみの変更で、挙動・出力に変化はない。 (#1830) (@YamatoSecurity)
+- `hayabusa-evtx` クレートを `0.9.9` に更新し、その依存クレート（特に `thiserror` 1→2、`criterion` 0.5→0.8）をすべて最新版に更新した。挙動に変更はない。 (#1835) (@YamatoSecurity)
 - レビューで判明した2箇所のデッドコードを削除した。JSON文字列エスケープ処理の常に空になる `addition_header` 分岐と、相対時刻オフセット解析における到達しない分岐および単位ごとの `Vec` 割り当て。挙動に変更はない。 (#1834) (@YamatoSecurity)
 
 ## 3.9.0 [2026/04/29]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Translated all remaining Japanese code comments to English, cleaned up and added many code comments for readability, and fixed misspelled internal identifiers. Comments and identifiers only; no behavior changes. (#1808) (@YamatoSecurity)
 - Renamed 76 cryptic, misleading, or hayabusa-specific variable, parameter, and struct-field names in `src/` (e.g. `datas`→`records`, `con_cal`→`joined_value`, `name_2_node`→`name_to_node`, `hlch`→`horizontal_line_char`, `rulepath`→`rule_path`, `ext_field`→`output_fields`, and a misnamed `or_node`→`all_node` that actually held an AND-semantics `AllSelectionNode`) to clearer, idiomatic Rust names for readability. Internal identifiers only; no behavior or output changes. (#1830) (@YamatoSecurity)
+- Updated the `hayabusa-evtx` crate to `0.9.9`, bumping all of its dependencies (notably `thiserror` 1→2 and `criterion` 0.5→0.8) to their latest versions. No behavior change. (#1835) (@YamatoSecurity)
 - Removed two pieces of dead code surfaced during review: an always-empty `addition_header` branch in the JSON string escaper, and a never-taken branch plus a per-unit `Vec` allocation in the relative time-offset parser. No behavior change. (#1834) (@YamatoSecurity)
 
 ## 3.9.0 [2026/04/29]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,8 +680,8 @@ dependencies = [
 
 [[package]]
 name = "evtx"
-version = "0.9.8"
-source = "git+https://github.com/Yamato-Security/hayabusa-evtx.git?rev=c1367df2f3ee5918ef83b93e5084cb5dc63241fe#c1367df2f3ee5918ef83b93e5084cb5dc63241fe"
+version = "0.9.9"
+source = "git+https://github.com/Yamato-Security/hayabusa-evtx.git?rev=730edad702b43c5e5c8c5680afdbc5ffd2691353#730edad702b43c5e5c8c5680afdbc5ffd2691353"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -679,7 +691,7 @@ dependencies = [
  "crc32fast",
  "dialoguer",
  "encoding",
- "hashbrown 0.17.1",
+ "hashbrown 0.14.5",
  "indoc",
  "jemallocator",
  "log",
@@ -689,7 +701,7 @@ dependencies = [
  "rpmalloc",
  "serde_json",
  "skeptic",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "winstructs",
 ]
 
@@ -869,6 +881,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2694,6 +2710,26 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ csv = "1.4.*"
 dashmap = "*"
 dialoguer = "*"
 downcast-rs = "2.*"
-evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"] , rev = "c1367df2f3ee5918ef83b93e5084cb5dc63241fe" } # 0.9.8 2026/06/27 update
+evtx = { git = "https://github.com/Yamato-Security/hayabusa-evtx.git" , features = ["fast-alloc"] , rev = "730edad702b43c5e5c8c5680afdbc5ffd2691353" } # 0.9.9 2026/07/04 update
 # Enable the vendored-OpenSSL HTTPS/TLS backend for libgit2. The wildcard
 # `0.*` resolved to a build of libgit2 with no TLS transport, so `update-rules`
 # failed with `class=Ssl (16) - there is no TLS stream available`. The project


### PR DESCRIPTION
Points the `evtx` git dependency at **hayabusa-evtx 0.9.9** (rev `730edad7`, Yamato-Security/hayabusa-evtx#91), which bumps all of evtx's dependencies to their latest versions — `thiserror` 1→2, `criterion` (dev) 0.5→0.8, and `cargo update` refreshes for `quick-xml`, `hashbrown`, `clap`, `chrono`, `rayon`, and others.

## No behavior change
The evtx `0.9.8 → 0.9.9` diff is **Cargo.toml / Cargo.lock / CHANGELOG only — no `.rs` source changes** — so parsing behavior is unchanged (and evtx's own snapshot test suite passed against the bumped dependencies in #91).

## Testing
`cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `RUST_TEST_THREADS=1 cargo test` (478 lib + 17 integration tests) all pass with the new evtx rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)