### PR TITLE
ci: stop bundling README/CHANGELOG PDFs in release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,28 +209,6 @@ jobs:
           path: release-binaries-encoded-rules/*
           include-hidden-files: true
 
-      - name: Setup node
-        if: matrix.info.target == 'aarch64-apple-darwin'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-
-      - name: Create PDF
-        if: matrix.info.target == 'aarch64-apple-darwin'
-        run: |
-          npm i -g md-to-pdf
-          md-to-pdf ./*.md --md-file-encoding utf-8
-          mv ./README.pdf ./README-${{ github.event.inputs.release_ver }}-English.pdf
-          mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
-
-      - name: Upload Document Artifacts
-        if: matrix.info.target == 'aarch64-apple-darwin'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: hayabusa-documents
-          path: |
-            ./*.pdf
-
   upload-all-platforms:
     needs: upload
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes PDF generation from the release workflow. Documentation now lives on the website, so the release packages no longer need PDF copies of the markdown files.

## Also fixes the 3.10.0 release failure
The macOS `Create PDF` step ran `md-to-pdf ./*.md` then `mv ./README-Japanese.pdf …`. Since the README became a landing page (`4a6ba73b`), the Japanese README was archived to `OLD-README-Japanese.md`, so `README-Japanese.pdf` is never produced and the `mv` failed with `No such file or directory` → the whole macOS upload job failed. (Example: [run 28707396161](https://github.com/Yamato-Security/hayabusa/actions/runs/28707396161/job/85136732702).)

## Change
Removed three steps from the macOS `upload` job:
- **Setup node** (only present to `npm i -g md-to-pdf`)
- **Create PDF** (`md-to-pdf` + the `mv` renames)
- **Upload Document Artifacts** (uploaded `./*.pdf` as `hayabusa-documents`)

No downstream breakage: the `upload-all-platforms` / `all-packages-zip` jobs download with `pattern: hayabusa-*`, which simply matches the binary artifacts now (one fewer artifact, no error). The release just ships without PDFs.

> Note: this was also committed on the `finalize-3.10.0` branch, but #1836 was merged before it landed, so it's not in `main` — hence this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)