### PR TITLE
fix: enforce group-by equality in temporal correlations

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,7 +5,7 @@
 **バグ修正:**
 
 - `update-rules` 実行後に表示される文法的に誤ったメッセージ「Successed submodule update」を「Submodule update succeeded」に修正した。 (#1840) (@YamatoSecurity)
-- `temporal`/`temporal_ordered` 相関が、参照ルールのマッチを結合する際にルールの `group-by` 値を検証していなかった問題を修正した。各参照ルールは group-by 値ごとに集計されるものの、タイムスタンプがタイムフレームに収まってさえいれば異なるグループ（例: 異なる Computer）のマッチ同士が相関してしまい、誤検知を生んでいた。参照ルールのマッチは、ベースとなるマッチと同じ group-by 値を持つことを要求するようにした。 (@Shirofune-Security)
+- `temporal`/`temporal_ordered` 相関が、参照ルールのマッチを結合する際にルールの `group-by` 値を検証していなかった問題を修正した。各参照ルールは group-by 値ごとに集計されるものの、タイムスタンプがタイムフレームに収まってさえいれば異なるグループ（例: 異なる Computer）のマッチ同士が相関してしまい、誤検知を生んでいた。参照ルールのマッチは、ベースとなるマッチと同じ group-by 値を持つことを要求するようにした。 (#1839) (@Shirofune-Security)
 
 **その他:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,6 +5,7 @@
 **バグ修正:**
 
 - `update-rules` 実行後に表示される文法的に誤ったメッセージ「Successed submodule update」を「Submodule update succeeded」に修正した。 (#1840) (@YamatoSecurity)
+- `temporal`/`temporal_ordered` 相関が、参照ルールのマッチを結合する際にルールの `group-by` 値を検証していなかった問題を修正した。各参照ルールは group-by 値ごとに集計されるものの、タイムスタンプがタイムフレームに収まってさえいれば異なるグループ（例: 異なる Computer）のマッチ同士が相関してしまい、誤検知を生んでいた。参照ルールのマッチは、ベースとなるマッチと同じ group-by 値を持つことを要求するようにした。 (@Shirofune-Security)
 
 **その他:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes:**
 
 - Fixed the ungrammatical "Successed submodule update" message printed after `update-rules` (now "Submodule update succeeded"). (#1840) (@YamatoSecurity)
+- Fixed `temporal`/`temporal_ordered` correlations not enforcing the rule's `group-by` value when combining referenced-rule matches. Each referenced rule was aggregated per group-by value, but matches from different groups (e.g. different Computers) could still be correlated together as long as their timestamps fit the timeframe, producing false-positive alerts. Referenced-rule matches are now required to share the base match's group-by value. (@Shirofune-Security)
 
 **Other:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Bug Fixes:**
 
 - Fixed the ungrammatical "Successed submodule update" message printed after `update-rules` (now "Submodule update succeeded"). (#1840) (@YamatoSecurity)
-- Fixed `temporal`/`temporal_ordered` correlations not enforcing the rule's `group-by` value when combining referenced-rule matches. Each referenced rule was aggregated per group-by value, but matches from different groups (e.g. different Computers) could still be correlated together as long as their timestamps fit the timeframe, producing false-positive alerts. Referenced-rule matches are now required to share the base match's group-by value. (@Shirofune-Security)
+- Fixed `temporal`/`temporal_ordered` correlations not enforcing the rule's `group-by` value when combining referenced-rule matches. Each referenced rule was aggregated per group-by value, but matches from different groups (e.g. different Computers) could still be correlated together as long as their timestamps fit the timeframe, producing false-positive alerts. Referenced-rule matches are now required to share the base match's group-by value. (#1839) (@Shirofune-Security)
 
 **Other:**
 

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -207,9 +207,12 @@ impl Detection {
 
     /// Evaluates a Sigma temporal correlation: for each aggregation result of the first
     /// referenced rule (`ids[0]`), checks that every other referenced rule also produced a
-    /// result within `timeframe`. When `temporal_ordered` is true the other results must occur
-    /// at or after the base result; otherwise anywhere within +/- `timeframe` of the base result
-    /// counts. Returns the base results for which all referenced rules matched.
+    /// result within `timeframe`. Only results sharing the base result's `group-by` value
+    /// (`AggResult.key`) are considered, so events from different groups (e.g. different
+    /// Computers) are never correlated together. When `temporal_ordered` is true the other
+    /// results must occur at or after the base result; otherwise anywhere within +/-
+    /// `timeframe` of the base result counts. Returns the base results for which all
+    /// referenced rules matched.
     fn detect_within_timeframe(
         ids: &[String],
         temporal_ref_all_results: &HashMap<String, Vec<AggResult>>,
@@ -229,12 +232,14 @@ impl Detection {
                     if let Some(target_records) = temporal_ref_all_results.get(id.as_str()) {
                         if temporal_ordered {
                             found = target_records.iter().any(|t| {
-                                (t.start_datetime >= last_base.start_datetime)
+                                t.key == base.key
+                                    && (t.start_datetime >= last_base.start_datetime)
                                     && (t.start_datetime <= last_base.start_datetime + timeframe)
                             });
                         } else {
                             found = target_records.iter().any(|t| {
-                                (t.start_datetime >= base.start_datetime - timeframe)
+                                t.key == base.key
+                                    && (t.start_datetime >= base.start_datetime - timeframe)
                                     && (t.start_datetime <= base.start_datetime + timeframe)
                             });
                         }
@@ -1611,6 +1616,50 @@ mod tests {
             &dummy_stored_static,
         );
         assert_eq!(5, cole.len());
+    }
+
+    #[test]
+    fn test_detect_within_timeframe_enforces_group_by() {
+        use chrono::Duration;
+        use hashbrown::HashMap;
+
+        let base_time = Utc.with_ymd_and_hms(2024, 1, 1, 10, 0, 0).unwrap();
+        let at = |min: i64| base_time + Duration::minutes(min);
+        // `AggResult.key` holds the group-by value (e.g. the Computer name).
+        let agg = |key: &str, t| AggResult::new(1, key.to_string(), vec![], t, vec![]);
+        let ids = vec!["a".to_string(), "b".to_string()];
+        let timeframe = Duration::minutes(10);
+
+        // Base rule "a" matched for Host1, but rule "b" only matched for Host2 within the
+        // window. The correlation must NOT fire because the matches are from different groups.
+        let mut diff_group: HashMap<String, Vec<AggResult>> = HashMap::new();
+        diff_group.insert("a".to_string(), vec![agg("Host1", at(0))]);
+        diff_group.insert("b".to_string(), vec![agg("Host2", at(5))]);
+        for ordered in [true, false] {
+            assert!(
+                Detection::detect_within_timeframe(&ids, &diff_group, timeframe, ordered)
+                    .is_empty(),
+                "matches from different group-by values must not correlate (ordered={ordered})"
+            );
+        }
+
+        // When rule "b" also matched for Host1 within the window, the correlation fires and the
+        // returned base result is the Host1 group (the mismatched Host2 candidate is ignored).
+        let mut same_group: HashMap<String, Vec<AggResult>> = HashMap::new();
+        same_group.insert("a".to_string(), vec![agg("Host1", at(0))]);
+        same_group.insert(
+            "b".to_string(),
+            vec![agg("Host2", at(3)), agg("Host1", at(5))],
+        );
+        for ordered in [true, false] {
+            let res = Detection::detect_within_timeframe(&ids, &same_group, timeframe, ordered);
+            assert_eq!(
+                res.len(),
+                1,
+                "same-group matches should correlate (ordered={ordered})"
+            );
+            assert_eq!(res[0].key, "Host1");
+        }
     }
 
     #[test]

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -380,8 +380,8 @@ fn merge_referenced_rule(
 /// The temporal rule itself is rewritten to reference the ids actually used and receives the
 /// same "count() >= 1" aggregation condition; Detection::add_aggcondition_msg later combines the
 /// TemporalRef results per time window (each result is already aggregated per group-by value by
-/// its own rule, but group equality is not checked when combining). Unless `generate: true` is
-/// set, the original
+/// its own rule, and only results sharing the same group-by value are correlated together).
+/// Unless `generate: true` is set, the original
 /// referenced rules are removed so they do not also emit detections of their own.
 fn parse_temporal_rules(
     temporal_rules: Vec<RuleNode>,


### PR DESCRIPTION
Related to #1810 (follow-up surfaced while reviewing #1838, the ordering fix for that issue).

## Summary

`temporal`/`temporal_ordered` correlations did not enforce the rule's `group-by` value when combining referenced-rule matches, so events from **different groups** (e.g. different `Computer`s) could be correlated together and raise false-positive alerts.

This was surfaced by Copilot's review of #1838 (the `temporal_ordered` ordering fix for #1810). It is a **separate, pre-existing** limitation — the combine step in `Detection::detect_within_timeframe` only compared timestamps — and was explicitly documented as known behavior in `parse_temporal_rules` ("group equality is not checked when combining"). This PR closes that gap independently of #1838.

## Details

Each referenced rule is aggregated per group-by value, and `AggResult.key` holds that value (built by `create_count_key` from the temporal rule's `group-by` fields, so it is formatted identically across every referenced rule). The combine step now requires each referenced-rule match to share the base match's `key`, so only events from the same group are correlated. When `group-by` is effectively absent the key is a constant (`"_"`), so the check is a harmless no-op in that case.

The stale "group equality is not checked" note in `parse_temporal_rules` is updated to match the new behavior.

## Testing

- Added `test_detect_within_timeframe_enforces_group_by`, covering, for both ordered and unordered correlations:
  - referenced match in a **different** group → does **not** correlate
  - referenced match in the **same** group (alongside a different-group decoy) → correlates, returning the correct group
- `cargo test --lib detections::detection -- --skip geoip` passes (skipped geoip tests need `update-rules` config data, unrelated).
- `cargo fmt --check` and `cargo clippy --lib` clean.

## Note on #1838

This PR and #1838 both touch `detect_within_timeframe` (they are intentionally independent). Whichever merges first, the other needs a trivial rebase — the `group-by` check simply moves into the reworked ordered-matching iterator introduced by #1838.

## Changelog

Added entries to `CHANGELOG.md` and `CHANGELOG-Japanese.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)