### PR TITLE
refactor: collapse And/All/Or selection nodes into one NarySelectionNode

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -9,6 +9,7 @@
 **その他:**
 
 - HTMLレポートのMITRE ATT&CKタクティクの集計用グローバル変数（`COMPUTER_MITRE_ATTCK_MAP` と `COMPUTER_MITRE_ATTCK_UNIQUE_KEYS`）を、テーブル出力後にクリアすることで単一レポートの範囲に限定した。これにより、同一プロセス内で後続のレポートを生成してもキーが残留してタクティクごとのユニーク数が過少カウントされることがなくなった。あわせて、タクティクのセルを結合する際の中間 `Vec` を削除した。通常の（単一レポートの）実行では挙動に変更はない。 (#1840) (@YamatoSecurity)
+- 3つのほぼ同一な検知セレクションノード型（`AndSelectionNode`、`AllSelectionNode`、`OrSelectionNode`）を、論理演算子 `All`/`Any` でパラメータ化した単一の `NarySelectionNode` に統合し、重複コード約105行を削除した。純粋なリファクタリングで、出力がバイト単位で同一であることを確認済み。 (#1843) (@YamatoSecurity)
 
 ## 3.10.0 [2026/07/04] - Independence Day Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Other:**
 
 - Scoped the MITRE ATT&CK tactics HTML-report accumulators (`COMPUTER_MITRE_ATTCK_MAP` and `COMPUTER_MITRE_ATTCK_UNIQUE_KEYS`) to a single report by clearing them after the table is emitted, so a report generated later in the same process no longer leaks keys or undercounts the per-tactic unique count; also removed an intermediate `Vec` when joining the tactic cells. No behavior change for normal single-report runs. (#1840) (@YamatoSecurity)
+- Collapsed the three near-identical detection-selection node types (`AndSelectionNode`, `AllSelectionNode`, `OrSelectionNode`) into a single `NarySelectionNode` parameterised by a logical `All`/`Any` operator, removing ~105 lines of duplicated code. Pure refactor; output verified byte-identical. (#1843) (@YamatoSecurity)
 
 ## 3.10.0 [2026/07/04] - Independence Day Release
 

--- a/src/detections/rule/condition_parser.rs
+++ b/src/detections/rule/condition_parser.rs
@@ -1,9 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 
-use self::selectionnodes::{
-    AndSelectionNode, NotSelectionNode, OrSelectionNode, RefSelectionNode, SelectionNode,
-};
+use self::selectionnodes::{NarySelectionNode, NotSelectionNode, RefSelectionNode, SelectionNode};
 use super::selectionnodes;
 use hashbrown::HashMap;
 use itertools::Itertools;
@@ -66,7 +64,7 @@ impl ConditionToken {
                 Result::Ok((*sub_token).into_selection_node(name_to_node)?)
             }
             ConditionToken::AndContainer(sub_tokens) => {
-                let mut select_and_node = AndSelectionNode::new();
+                let mut select_and_node = NarySelectionNode::and();
                 for sub_token in sub_tokens {
                     let sub_node = sub_token.into_selection_node(name_to_node)?;
                     select_and_node.child_nodes.push(sub_node);
@@ -74,7 +72,7 @@ impl ConditionToken {
                 Result::Ok(Box::new(select_and_node))
             }
             ConditionToken::OrContainer(sub_tokens) => {
-                let mut select_or_node = OrSelectionNode::new();
+                let mut select_or_node = NarySelectionNode::or();
                 for sub_token in sub_tokens {
                     let sub_node = sub_token.into_selection_node(name_to_node)?;
                     select_or_node.child_nodes.push(sub_node);

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -7,7 +7,7 @@ use crate::detections::rule::aggregation_parser::{
     AggregationConditionToken, AggregationParseInfo,
 };
 use crate::detections::rule::count::TimeFrameInfo;
-use crate::detections::rule::selectionnodes::{OrSelectionNode, SelectionNode};
+use crate::detections::rule::selectionnodes::{NarySelectionNode, SelectionNode};
 use crate::detections::rule::{CorrelationType, DetectionNode, RuleNode};
 use hashbrown::{HashMap, HashSet};
 use uuid::Uuid;
@@ -103,8 +103,8 @@ fn parse_condition(
 
 /// ORs together the referenced rules' condition trees so that the merged correlation rule
 /// matches any event matched by any of the referenced rules.
-fn to_or_selection_node(related_rule_nodes: Vec<RuleNode>) -> OrSelectionNode {
-    let mut or_selection_node = OrSelectionNode::new();
+fn to_or_selection_node(related_rule_nodes: Vec<RuleNode>) -> NarySelectionNode {
+    let mut or_selection_node = NarySelectionNode::or();
     for rule_node in related_rule_nodes {
         or_selection_node
             .child_nodes

--- a/src/detections/rule/matchers.rs
+++ b/src/detections/rule/matchers.rs
@@ -390,7 +390,7 @@ impl LeafMatcher for DefaultMatcher {
             {
                 self.fast_match = convert_to_base64_str(None, pattern[0].as_str(), &mut err_msgs);
             } else if self.pipes[0] == PipeElement::Contains && self.pipes[1] == PipeElement::All
-            // |contains|all was already turned into an AndSelectionNode during parsing
+            // |contains|all was already turned into an AND-op NarySelectionNode during parsing
             // (rule/mod.rs), so treat it as a plain contains here.
             {
                 self.fast_match = convert_to_fast_match(format!("*{}*", pattern[0]).as_str(), true);
@@ -427,7 +427,7 @@ impl LeafMatcher for DefaultMatcher {
             if self.pipes.contains(&PipeElement::Contains)
                 && self.pipes.contains(&PipeElement::All)
                 && self.pipes.contains(&PipeElement::Windash)
-            // |contains|all|windash was already turned into an AndSelectionNode during parsing
+            // |contains|all|windash was already turned into an AND-op NarySelectionNode during parsing
             // (rule/mod.rs), so treat it as contains plus windash here.
             {
                 let mut fastmatches =
@@ -1018,7 +1018,7 @@ mod tests {
     };
 
     use super::super::selectionnodes::{
-        AndSelectionNode, LeafSelectionNode, OrSelectionNode, SelectionNode,
+        LeafSelectionNode, LogicalOp, NarySelectionNode, SelectionNode,
     };
     use crate::detections::configs::{
         Action, Config, CsvOutputOption, OutputOption, STORED_EKEY_ALIAS, StoredStatic,
@@ -1146,14 +1146,15 @@ mod tests {
 
         // ContextInfo
         {
-            // Verify that OrSelectionNode is correctly loaded.
+            // Verify that an OR-op NarySelectionNode is correctly loaded.
             let child_node = detection_children[2] as &dyn SelectionNode;
-            assert!(child_node.is::<OrSelectionNode>());
-            let child_node = child_node.downcast_ref::<OrSelectionNode>().unwrap();
+            assert!(child_node.is::<NarySelectionNode>());
+            let child_node = child_node.downcast_ref::<NarySelectionNode>().unwrap();
+            assert_eq!(child_node.op, LogicalOp::Any);
             let ancestors = child_node.get_children();
             assert_eq!(ancestors.len(), 2);
 
-            // Test patterns where LeafSelectionNode is under OrSelectionNode.
+            // Test patterns where LeafSelectionNode is under the OR node.
             // Verify that the Host Application node, which is a LeafSelectionNode, is correct.
             let hostapp_en_node = ancestors[0] as &dyn SelectionNode;
             assert!(hostapp_en_node.is::<LeafSelectionNode>());
@@ -1192,10 +1193,11 @@ mod tests {
 
         // ImagePath
         {
-            // Verify that AndSelectionNode is correctly loaded.
+            // Verify that an AND-op NarySelectionNode is correctly loaded.
             let child_node = detection_children[3] as &dyn SelectionNode;
-            assert!(child_node.is::<AndSelectionNode>());
-            let child_node = child_node.downcast_ref::<AndSelectionNode>().unwrap();
+            assert!(child_node.is::<NarySelectionNode>());
+            let child_node = child_node.downcast_ref::<NarySelectionNode>().unwrap();
+            assert_eq!(child_node.op, LogicalOp::All);
             let ancestors = child_node.get_children();
             assert_eq!(ancestors.len(), 3);
 

--- a/src/detections/rule/mod.rs
+++ b/src/detections/rule/mod.rs
@@ -402,7 +402,7 @@ impl DetectionNode {
         if yaml.as_hash().is_some() {
             // Associative arrays are interpreted as AND conditions.
             let yaml_hash = yaml.as_hash().unwrap();
-            let mut and_node = selectionnodes::AndSelectionNode::new();
+            let mut and_node = selectionnodes::NarySelectionNode::and();
 
             yaml_hash.keys().for_each(|hash_key| {
                 let child_yaml = yaml_hash.get(hash_key).unwrap();
@@ -414,8 +414,8 @@ impl DetectionNode {
             Box::new(and_node)
         } else if yaml.as_vec().is_some() && key_list.len() == 1 && key_list[0].eq("|all") {
             // If the key is just "|all" (the keyless all modifier), every keyword in the list has
-            // to match, so combine the children with an AllSelectionNode (AND semantics).
-            let mut all_node = selectionnodes::AllSelectionNode::new();
+            // to match, so combine the children with an AND-op NarySelectionNode (AND semantics).
+            let mut all_node = selectionnodes::NarySelectionNode::and();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);
                 all_node.child_nodes.push(child_node);
@@ -436,11 +436,11 @@ impl DetectionNode {
                 .iter()
                 .any(|k| k.split('|').skip(1).any(|m| m == "neq"))
             {
-                let mut or_node = selectionnodes::OrSelectionNode::new();
+                let mut or_node = selectionnodes::NarySelectionNode::or();
                 or_node.child_nodes = children;
                 Box::new(or_node)
             } else {
-                let mut and_node = selectionnodes::AndSelectionNode::new();
+                let mut and_node = selectionnodes::NarySelectionNode::and();
                 and_node.child_nodes = children;
                 Box::new(and_node)
             }
@@ -452,7 +452,7 @@ impl DetectionNode {
             // `neq` negates the whole comparison, so a plain (OR-linked) list of values under a `neq`
             // modifier means "different from ALL of them" (De Morgan: NOT(a OR b) == NOT a AND NOT b).
             // Interpret the array as an AND condition instead of the usual OR.
-            let mut and_node = selectionnodes::AndSelectionNode::new();
+            let mut and_node = selectionnodes::NarySelectionNode::and();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);
                 and_node.child_nodes.push(child_node);
@@ -460,7 +460,7 @@ impl DetectionNode {
             Box::new(and_node)
         } else if yaml.as_vec().is_some() {
             // Arrays are interpreted as OR conditions.
-            let mut or_node = selectionnodes::OrSelectionNode::new();
+            let mut or_node = selectionnodes::NarySelectionNode::or();
             yaml.as_vec().unwrap().iter().for_each(|child_yaml| {
                 let child_node = Self::parse_selection_recursively(key_list, child_yaml);
                 or_node.child_nodes.push(child_node);

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -15,7 +15,7 @@ pub trait SelectionNode: Downcast + Send + Sync {
 
     /// Performs initialization.
     /// Since this method can return errors, report here when the rule file is invalid and a
-    /// SelectionNode cannot be constructed. AndSelectionNode and the like also implement a new()
+    /// SelectionNode cannot be constructed. NarySelectionNode and the like also implement a new()
     /// function in addition to init(), but new() is only meant to create an instance and should
     /// not contain lengthy processing. This keeps the error handling for rule file parsing
     /// consolidated in init().
@@ -31,162 +31,57 @@ pub trait SelectionNode: Downcast + Send + Sync {
 // node types such as LeafSelectionNode.
 downcast_rs::impl_downcast!(SelectionNode);
 
-/// Node representing an AND condition under detection-selection.
-/// Built from a YAML hash (every key/value pair must match), from a value list whose field key
-/// carries the `|all` modifier, or for `and` operators in condition expressions; matches only
-/// when all child nodes match.
-pub struct AndSelectionNode {
+/// Logical combinator for a [`NarySelectionNode`]'s children.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LogicalOp {
+    /// AND: the node matches only when **all** children match. Built from a YAML hash (every
+    /// key/value pair must match), from a value list whose field key carries the `|all` modifier,
+    /// and for `and` operators in condition expressions.
+    All,
+    /// OR: the node matches when **any** child matches. Built from a YAML array of values, for `or`
+    /// operators in condition expressions, and when the correlation parser merges referenced rules.
+    Any,
+}
+
+/// Node combining child selection nodes with a logical AND ([`LogicalOp::All`]) or OR
+/// ([`LogicalOp::Any`]). Replaces the former separate AndSelectionNode / AllSelectionNode /
+/// OrSelectionNode types, which differed only in the combinator used by `select`.
+pub struct NarySelectionNode {
+    pub op: LogicalOp,
     pub child_nodes: Vec<Box<dyn SelectionNode>>,
 }
 
-impl AndSelectionNode {
-    pub fn new() -> AndSelectionNode {
-        AndSelectionNode {
+impl NarySelectionNode {
+    pub fn new(op: LogicalOp) -> NarySelectionNode {
+        NarySelectionNode {
+            op,
             child_nodes: vec![],
         }
     }
+
+    /// Convenience constructor for an AND node (matches only when every child matches).
+    pub fn and() -> NarySelectionNode {
+        NarySelectionNode::new(LogicalOp::All)
+    }
+
+    /// Convenience constructor for an OR node (matches when any child matches).
+    pub fn or() -> NarySelectionNode {
+        NarySelectionNode::new(LogicalOp::Any)
+    }
 }
 
-impl SelectionNode for AndSelectionNode {
+impl SelectionNode for NarySelectionNode {
     fn select(&self, event_record: &EvtxRecordInfo, eventkey_alias: &EventKeyAliasConfig) -> bool {
-        self.child_nodes
-            .iter()
-            .all(|child_node| child_node.select(event_record, eventkey_alias))
-    }
-
-    fn init(&mut self) -> Result<(), Vec<String>> {
-        let err_msgs = self
-            .child_nodes
-            .iter_mut()
-            .map(|child_node| {
-                let res = child_node.init();
-                if let Err(err) = res { err } else { vec![] }
-            })
-            .fold(
-                vec![],
-                |mut acc: Vec<String>, cur: Vec<String>| -> Vec<String> {
-                    acc.extend(cur);
-                    acc
-                },
-            );
-
-        if err_msgs.is_empty() {
-            Result::Ok(())
-        } else {
-            Result::Err(err_msgs)
+        match self.op {
+            LogicalOp::All => self
+                .child_nodes
+                .iter()
+                .all(|child_node| child_node.select(event_record, eventkey_alias)),
+            LogicalOp::Any => self
+                .child_nodes
+                .iter()
+                .any(|child_node| child_node.select(event_record, eventkey_alias)),
         }
-    }
-
-    fn get_children(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = vec![];
-        self.child_nodes.iter().for_each(|child_node| {
-            ret.push(child_node.as_ref());
-        });
-
-        ret
-    }
-
-    fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = self.get_children();
-
-        self.child_nodes
-            .iter()
-            .flat_map(|child_node| child_node.get_descendants())
-            .for_each(|descendant_node| {
-                ret.push(descendant_node);
-            });
-
-        ret
-    }
-}
-
-/// Node for the keyless `|all` modifier under detection-selection: every keyword in the value
-/// list must match. Matching behaves like AndSelectionNode, but it is kept as a distinct type.
-pub struct AllSelectionNode {
-    pub child_nodes: Vec<Box<dyn SelectionNode>>,
-}
-
-impl AllSelectionNode {
-    pub fn new() -> AllSelectionNode {
-        AllSelectionNode {
-            child_nodes: vec![],
-        }
-    }
-}
-
-impl SelectionNode for AllSelectionNode {
-    fn select(&self, event_record: &EvtxRecordInfo, eventkey_alias: &EventKeyAliasConfig) -> bool {
-        self.child_nodes
-            .iter()
-            .all(|child_node| child_node.select(event_record, eventkey_alias))
-    }
-
-    fn init(&mut self) -> Result<(), Vec<String>> {
-        let err_msgs = self
-            .child_nodes
-            .iter_mut()
-            .map(|child_node| {
-                let res = child_node.init();
-                if let Err(err) = res { err } else { vec![] }
-            })
-            .fold(
-                vec![],
-                |mut acc: Vec<String>, cur: Vec<String>| -> Vec<String> {
-                    acc.extend(cur);
-                    acc
-                },
-            );
-
-        if err_msgs.is_empty() {
-            Result::Ok(())
-        } else {
-            Result::Err(err_msgs)
-        }
-    }
-
-    fn get_children(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = vec![];
-        self.child_nodes.iter().for_each(|child_node| {
-            ret.push(child_node.as_ref());
-        });
-
-        ret
-    }
-
-    fn get_descendants(&self) -> Vec<&dyn SelectionNode> {
-        let mut ret = self.get_children();
-
-        self.child_nodes
-            .iter()
-            .flat_map(|child_node| child_node.get_descendants())
-            .for_each(|descendant_node| {
-                ret.push(descendant_node);
-            });
-
-        ret
-    }
-}
-
-/// Node representing an OR condition under detection-selection.
-/// Built from a YAML array of values, for `or` operators in condition expressions, or when the
-/// correlation parser merges referenced rules; matches when any child node matches.
-pub struct OrSelectionNode {
-    pub child_nodes: Vec<Box<dyn SelectionNode>>,
-}
-
-impl OrSelectionNode {
-    pub fn new() -> OrSelectionNode {
-        OrSelectionNode {
-            child_nodes: vec![],
-        }
-    }
-}
-
-impl SelectionNode for OrSelectionNode {
-    fn select(&self, event_record: &EvtxRecordInfo, eventkey_alias: &EventKeyAliasConfig) -> bool {
-        self.child_nodes
-            .iter()
-            .any(|child_node| child_node.select(event_record, eventkey_alias))
     }
 
     fn init(&mut self) -> Result<(), Vec<String>> {

--- a/src/detections/rule/selectionnodes.rs
+++ b/src/detections/rule/selectionnodes.rs
@@ -15,10 +15,10 @@ pub trait SelectionNode: Downcast + Send + Sync {
 
     /// Performs initialization.
     /// Since this method can return errors, report here when the rule file is invalid and a
-    /// SelectionNode cannot be constructed. NarySelectionNode and the like also implement a new()
-    /// function in addition to init(), but new() is only meant to create an instance and should
-    /// not contain lengthy processing. This keeps the error handling for rule file parsing
-    /// consolidated in init().
+    /// SelectionNode cannot be constructed. NarySelectionNode and the like also provide lightweight
+    /// constructors (e.g. `new`/`and`/`or`) in addition to init(), but those are only meant to
+    /// create an instance and should not contain lengthy processing. This keeps the error handling
+    /// for rule file parsing consolidated in init().
     fn init(&mut self) -> Result<(), Vec<String>>;
 
     /// Gets the child nodes ("child" in the graph-theory sense).


### PR DESCRIPTION
Closes #1842.

## Problem
`AndSelectionNode`, `AllSelectionNode`, and `OrSelectionNode` (`src/detections/rule/selectionnodes.rs`) were three separate types with heavily copy-pasted impls:
- `init` / `get_children` / `get_descendants` were **byte-for-byte identical** across all three.
- `select`: And and All were **identical** (`.all()`); Or used `.any()`.

~200 lines that should be ~50, with real drift risk (the And/All duplication previously caused a mislabel bug).

## Change
One `NarySelectionNode { op: LogicalOp, child_nodes }` where `op` is `All` (AND) or `Any` (OR):
- `select()` dispatches `.all()` vs `.any()`;
- `init` / `get_children` / `get_descendants` are single shared impls.

Construction sites use `NarySelectionNode::and()` (former `And` **and** `All`) and `::or()` (former `Or`). Nothing ever distinguished And from All by concrete type — the only production selection-node downcast is to `LeafSelectionNode` — so the merge is safe; the two `matchers.rs` tests that downcast to `Or`/`And` now assert the `op` field instead.

`selectionnodes.rs` drops **~105 lines** (three node blocks → one).

## Verification (pure refactor, no behavior change)
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `RUST_TEST_THREADS=1 cargo test` (**478 lib + 17 integration**) all pass.
- **csv-timeline output verified BYTE-IDENTICAL** to the base: scanned the full `hayabusa-sample-evtx` dataset (599 evtx) with **all rules enabled** (`-a -A -w -s`, so no channel filter — all ~4,900 rules run) and the sorted CSV matched the base byte-for-byte (same SHA-256 over **32,448** detections).

_(The same refactor was applied and merged on the hayabusa-pro fork.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)