### PR TITLE
docs: add Linux GeoIP database auto-update steps to DFIR timeline page

### DIFF
--- a/website/docs/commands/dfir-timeline.ar.md
+++ b/website/docs/commands/dfir-timeline.ar.md
@@ -312,6 +312,13 @@ hayabusa.exe csv-timeline -d ../hayabusa-sample-evtx --RFC-3339 -o timesketch-im
 2. عدِّل `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: أدخل `AccountID` و `LicenseKey` اللذين تنشئهما بعد تسجيل الدخول إلى موقع MaxMind. تأكد من أن سطر `EditionIDs` يقول `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. شغِّل الملف التنفيذي `geoipupdate`.
 
+الخطوات على Linux:
+
+1. ثبِّت باستخدام `sudo apt install geoip-update`.
+2. عدِّل ملف الإعداد باستخدام `sudo nano /etc/GeoIP.conf`.
+3. حدِّث ملفات قاعدة البيانات باستخدام `sudo geoipupdate`.
+4. أضف `-G /var/lib/GeoIP/` عندما تريد إضافة معلومات GeoIP.
+
 ### ملفات تكوين الأمر `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: تعيينات أسماء القنوات واختصاراتها.

--- a/website/docs/commands/dfir-timeline.de.md
+++ b/website/docs/commands/dfir-timeline.de.md
@@ -312,6 +312,13 @@ Schritte unter Windows:
 2. Bearbeiten Sie `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Tragen Sie Ihre `AccountID` und Ihren `LicenseKey` ein, die Sie nach dem Anmelden auf der MaxMind-Website erstellen. Stellen Sie sicher, dass die `EditionIDs`-Zeile `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country` lautet.
 3. Führen Sie die ausführbare Datei `geoipupdate` aus.
 
+Schritte unter Linux:
+
+1. Installieren Sie mit `sudo apt install geoip-update`.
+2. Bearbeiten Sie die Konfigurationsdatei mit `sudo nano /etc/GeoIP.conf`.
+3. Aktualisieren Sie die Datenbankdateien mit `sudo geoipupdate`.
+4. Fügen Sie `-G /var/lib/GeoIP/` hinzu, wenn Sie GeoIP-Informationen hinzufügen möchten.
+
 ### `csv-timeline`-Befehlskonfigurationsdateien
 
 `./rules/config/channel_abbreviations.txt`: Zuordnungen von Channel-Namen und ihren Abkürzungen.

--- a/website/docs/commands/dfir-timeline.es.md
+++ b/website/docs/commands/dfir-timeline.es.md
@@ -312,6 +312,13 @@ Pasos en Windows:
 2. Edite `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Ponga su `AccountID` y `LicenseKey` que crea después de iniciar sesión en el sitio web de MaxMind. Asegúrese de que la línea `EditionIDs` diga `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Ejecute el ejecutable `geoipupdate`.
 
+Pasos en Linux:
+
+1. Instale con `sudo apt install geoip-update`.
+2. Edite el archivo de configuración con `sudo nano /etc/GeoIP.conf`.
+3. Actualice los archivos de la base de datos con `sudo geoipupdate`.
+4. Añada `-G /var/lib/GeoIP/` cuando desee añadir información de GeoIP.
+
 ### Archivos de configuración del comando `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: Asignaciones de nombres de canales y sus abreviaturas.

--- a/website/docs/commands/dfir-timeline.fr.md
+++ b/website/docs/commands/dfir-timeline.fr.md
@@ -312,6 +312,13 @@ Vous pouvez installer l'outil MaxMind `geoipupdate` [ici](https://github.com/max
 2. Modifiez `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf` : Saisissez votre `AccountID` et votre `LicenseKey` que vous créez après vous être connecté au site MaxMind. Assurez-vous que la ligne `EditionIDs` indique `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Exécutez l'exécutable `geoipupdate`.
 
+Étapes sur Linux :
+
+1. Installez avec `sudo apt install geoip-update`.
+2. Modifiez le fichier de configuration avec `sudo nano /etc/GeoIP.conf`.
+3. Mettez à jour les fichiers de base de données avec `sudo geoipupdate`.
+4. Ajoutez `-G /var/lib/GeoIP/` lorsque vous voulez ajouter des informations GeoIP.
+
 ### Fichiers de configuration de la commande `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt` : Correspondances des noms de canaux et de leurs abréviations.

--- a/website/docs/commands/dfir-timeline.hi.md
+++ b/website/docs/commands/dfir-timeline.hi.md
@@ -312,6 +312,13 @@ Windows पर चरण:
 2. `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf` संपादित करें: MaxMind वेबसाइट में लॉग इन करने के बाद आपके द्वारा बनाई गई अपनी `AccountID` और `LicenseKey` डालें। सुनिश्चित करें कि `EditionIDs` लाइन में `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country` लिखा हो।
 3. `geoipupdate` निष्पादन योग्य चलाएँ।
 
+Linux पर चरण:
+
+1. `sudo apt install geoip-update` से इंस्टॉल करें।
+2. `sudo nano /etc/GeoIP.conf` से कॉन्फ़िग फ़ाइल संपादित करें।
+3. `sudo geoipupdate` से डेटाबेस फ़ाइलें अपडेट करें।
+4. जब आप GeoIP जानकारी जोड़ना चाहते हैं तो `-G /var/lib/GeoIP/` जोड़ें।
+
 ### `csv-timeline` कमांड कॉन्फ़िग फ़ाइलें
 
 `./rules/config/channel_abbreviations.txt`: चैनल नामों और उनके संक्षिप्त रूपों की मैपिंग।

--- a/website/docs/commands/dfir-timeline.id.md
+++ b/website/docs/commands/dfir-timeline.id.md
@@ -312,6 +312,13 @@ Langkah-langkah pada Windows:
 2. Edit `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Masukkan `AccountID` dan `LicenseKey` yang Anda buat setelah masuk ke situs web MaxMind. Pastikan baris `EditionIDs` berbunyi `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Jalankan executable `geoipupdate`.
 
+Langkah-langkah pada Linux:
+
+1. Instal dengan `sudo apt install geoip-update`.
+2. Edit file konfigurasi dengan `sudo nano /etc/GeoIP.conf`.
+3. Perbarui file database dengan `sudo geoipupdate`.
+4. Tambahkan `-G /var/lib/GeoIP/` saat Anda ingin menambahkan informasi GeoIP.
+
 ### File konfigurasi perintah `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: Pemetaan nama channel dan singkatannya.

--- a/website/docs/commands/dfir-timeline.ja.md
+++ b/website/docs/commands/dfir-timeline.ja.md
@@ -312,6 +312,13 @@ Windowsでの手順:
 2. `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`を編集する: MaxMindのウェブサイトにログインした後に作成した`AccountID`と`LicenseKey`を入れる。`EditionIDs`の行に、`EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`とあることを確認する。
 3. `geoipupdate`を実行する。
 
+Linuxでの手順:
+
+1. `sudo apt install geoip-update`でインストールする。
+2. `sudo nano /etc/GeoIP.conf`で設定ファイルを編集する。
+3. `sudo geoipupdate`でデータベースファイルを更新する。
+4. GeoIP情報を追加する場合は、`-G /var/lib/GeoIP/`を追加する。
+
 ### `csv-timeline`コマンドの設定ファイル
 
 `./rules/config/channel_abbreviations.txt`: チャンネル名とその略称のマッピング。

--- a/website/docs/commands/dfir-timeline.ko.md
+++ b/website/docs/commands/dfir-timeline.ko.md
@@ -312,6 +312,13 @@ Windows에서의 단계:
 2. `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf` 편집: MaxMind 웹사이트에 로그인한 후 생성한 `AccountID`와 `LicenseKey`를 입력하십시오. `EditionIDs` 줄이 `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`로 되어 있는지 확인하십시오.
 3. `geoipupdate` 실행 파일을 실행하십시오.
 
+Linux에서의 단계:
+
+1. `sudo apt install geoip-update`로 설치하십시오.
+2. `sudo nano /etc/GeoIP.conf`로 설정 파일을 편집하십시오.
+3. `sudo geoipupdate`로 데이터베이스 파일을 업데이트하십시오.
+4. GeoIP 정보를 추가하려면 `-G /var/lib/GeoIP/`를 추가하십시오.
+
 ### `csv-timeline` 명령어 설정 파일
 
 `./rules/config/channel_abbreviations.txt`: 채널 이름과 그 약어의 매핑.

--- a/website/docs/commands/dfir-timeline.md
+++ b/website/docs/commands/dfir-timeline.md
@@ -312,6 +312,13 @@ Steps on Windows:
 2. Edit `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Put in your `AccountID` and `LicenseKey` you create after logging into the MaxMind website. Make sure the `EditionIDs` line says `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Run the `geoipupdate` executable.
 
+Steps on Linux:
+
+1. Install with `sudo apt install geoip-update`
+2. Edit config file with `sudo nano /etc/GeoIP.conf`
+3. Update the database files with `sudo geoipupdate`
+4. Add `-G /var/lib/GeoIP/` when you want to add GeoIP information.
+
 ### `csv-timeline` command config files
 
 `./rules/config/channel_abbreviations.txt`: Mappings of channel names and their abbreviations.

--- a/website/docs/commands/dfir-timeline.my.md
+++ b/website/docs/commands/dfir-timeline.my.md
@@ -312,6 +312,13 @@ Windows တွင် အဆင့်များ -
 2. `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf` ကို တည်းဖြတ်ပါ - MaxMind website သို့ login ဝင်ပြီးနောက် သင်ဖန်တီးသော `AccountID` နှင့် `LicenseKey` ကို ထည့်ပါ။ `EditionIDs` လိုင်းတွင် `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country` ဟု ပါရှိစေရန် သေချာပါ။
 3. `geoipupdate` executable ကို run ပါ။
 
+Linux တွင် အဆင့်များ -
+
+1. `sudo apt install geoip-update` ဖြင့် install လုပ်ပါ။
+2. `sudo nano /etc/GeoIP.conf` ဖြင့် config file ကို တည်းဖြတ်ပါ။
+3. `sudo geoipupdate` ဖြင့် database file များကို update လုပ်ပါ။
+4. GeoIP အချက်အလက် ထည့်လိုသည့်အခါ `-G /var/lib/GeoIP/` ကို ထည့်ပါ။
+
 ### `csv-timeline` command config files
 
 `./rules/config/channel_abbreviations.txt`: channel အမည်များနှင့် ၎င်းတို့၏ အတိုကောက်များ၏ mapping များ။

--- a/website/docs/commands/dfir-timeline.pt-BR.md
+++ b/website/docs/commands/dfir-timeline.pt-BR.md
@@ -312,6 +312,13 @@ Etapas no Windows:
 2. Edite `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Coloque seu `AccountID` e `LicenseKey` que você cria após fazer login no site da MaxMind. Certifique-se de que a linha `EditionIDs` diga `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Execute o executável `geoipupdate`.
 
+Etapas no Linux:
+
+1. Instale com `sudo apt install geoip-update`.
+2. Edite o arquivo de configuração com `sudo nano /etc/GeoIP.conf`.
+3. Atualize os arquivos do banco de dados com `sudo geoipupdate`.
+4. Adicione `-G /var/lib/GeoIP/` quando quiser adicionar informações de GeoIP.
+
 ### Arquivos de configuração do comando `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: Mapeamentos de nomes de canais e suas abreviações.

--- a/website/docs/commands/dfir-timeline.th.md
+++ b/website/docs/commands/dfir-timeline.th.md
@@ -312,6 +312,13 @@ hayabusa.exe csv-timeline -d ../hayabusa-sample-evtx --RFC-3339 -o timesketch-im
 2. แก้ไข `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: ใส่ `AccountID` และ `LicenseKey` ของคุณที่สร้างขึ้นหลังจากเข้าสู่ระบบเว็บไซต์ MaxMind ตรวจสอบให้แน่ใจว่าบรรทัด `EditionIDs` ระบุว่า `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`
 3. รันไฟล์ปฏิบัติการ `geoipupdate`
 
+ขั้นตอนบน Linux:
+
+1. ติดตั้งด้วย `sudo apt install geoip-update`
+2. แก้ไขไฟล์กำหนดค่าด้วย `sudo nano /etc/GeoIP.conf`
+3. อัปเดตไฟล์ฐานข้อมูลด้วย `sudo geoipupdate`
+4. เพิ่ม `-G /var/lib/GeoIP/` เมื่อคุณต้องการเพิ่มข้อมูล GeoIP
+
 ### ไฟล์กำหนดค่าของคำสั่ง `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: การแมประหว่างชื่อช่องและตัวย่อของช่อง

--- a/website/docs/commands/dfir-timeline.tr.md
+++ b/website/docs/commands/dfir-timeline.tr.md
@@ -312,6 +312,13 @@ Windows'ta adımlar:
 2. `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf` dosyasını düzenleyin: MaxMind web sitesine giriş yaptıktan sonra oluşturduğunuz `AccountID` ve `LicenseKey` bilgilerinizi girin. `EditionIDs` satırının `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country` dediğinden emin olun.
 3. `geoipupdate` yürütülebilir dosyasını çalıştırın.
 
+Linux'ta adımlar:
+
+1. `sudo apt install geoip-update` ile kurun.
+2. Yapılandırma dosyasını `sudo nano /etc/GeoIP.conf` ile düzenleyin.
+3. Veritabanı dosyalarını `sudo geoipupdate` ile güncelleyin.
+4. GeoIP bilgisi eklemek istediğinizde `-G /var/lib/GeoIP/` ekleyin.
+
 ### `csv-timeline` komutu yapılandırma dosyaları
 
 `./rules/config/channel_abbreviations.txt`: Kanal adlarının ve kısaltmalarının eşlemeleri.

--- a/website/docs/commands/dfir-timeline.uk.md
+++ b/website/docs/commands/dfir-timeline.uk.md
@@ -312,6 +312,13 @@ hayabusa.exe csv-timeline -d ../hayabusa-sample-evtx --RFC-3339 -o timesketch-im
 2. Відредагуйте `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`: Вкажіть свої `AccountID` та `LicenseKey`, які ви створюєте після входу на вебсайт MaxMind. Переконайтеся, що рядок `EditionIDs` містить `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`.
 3. Запустіть виконуваний файл `geoipupdate`.
 
+Кроки в Linux:
+
+1. Встановіть за допомогою `sudo apt install geoip-update`.
+2. Відредагуйте файл конфігурації за допомогою `sudo nano /etc/GeoIP.conf`.
+3. Оновіть файли бази даних за допомогою `sudo geoipupdate`.
+4. Додайте `-G /var/lib/GeoIP/`, коли хочете додати інформацію GeoIP.
+
 ### Конфігураційні файли команди `csv-timeline`
 
 `./rules/config/channel_abbreviations.txt`: Зіставлення імен каналів та їхніх скорочень.

--- a/website/docs/commands/dfir-timeline.zh-TW.md
+++ b/website/docs/commands/dfir-timeline.zh-TW.md
@@ -312,6 +312,13 @@ Windows 上的步驟：
 2. 編輯 `\ProgramData\MaxMind/GeoIPUpdate\GeoIP.conf`：填入您登入 MaxMind 網站後建立的 `AccountID` 與 `LicenseKey`。確認 `EditionIDs` 那一行為 `EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country`。
 3. 執行 `geoipupdate` 執行檔。
 
+Linux 上的步驟：
+
+1. 使用 `sudo apt install geoip-update` 安裝。
+2. 使用 `sudo nano /etc/GeoIP.conf` 編輯設定檔。
+3. 使用 `sudo geoipupdate` 更新資料庫檔案。
+4. 當您想加入 GeoIP 資訊時，加上 `-G /var/lib/GeoIP/`。
+
 ### `csv-timeline` 指令設定檔
 
 `./rules/config/channel_abbreviations.txt`：channel 名稱與其縮寫的對應。


### PR DESCRIPTION
## Summary

The **"Automatic updates of GeoIP databases"** subsection of the [DFIR Timeline Commands docs](https://yamato-security.github.io/hayabusa/commands/dfir-timeline/?h=geoip#automatic-updates-of-geoip-databases) previously only documented **macOS** and **Windows**. This adds a **"Steps on Linux:"** block directly below the Windows steps.

### Linux steps added

1. Install with `sudo apt install geoip-update`
2. Edit config file with `sudo nano /etc/GeoIP.conf`
3. Update the database files with `sudo geoipupdate`
4. Add `-G /var/lib/GeoIP/` when you want to add GeoIP information.

## Scope

Applied to **all 15 language versions** of `website/docs/commands/dfir-timeline.*.md` (en, ja, zh-TW, ko, de, tr, fr, es, pt-BR, uk, hi, id, my, th, ar), with the "Steps on Linux:" heading and step wording translated to match each page's existing macOS/Windows style.

> [!NOTE]
> The command `sudo apt install geoip-update` was used exactly as provided. MaxMind's Debian/Ubuntu package is commonly named `geoipupdate` (no hyphen) — worth confirming the exact package name before merge, in which case I can update all 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)