### PR TITLE
chore: fix clippy needless-borrow in format args (Rust 1.97)

### DIFF
--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -563,7 +563,7 @@ impl Detection {
                             let tactic_key: CompactString = html_attck_tac.into();
                             let unique_key = CompactString::from(format!(
                                 "{}|{}|{}",
-                                &computer_name_to_mitre_tactics, &tactic_key, &rule.rule_path
+                                computer_name_to_mitre_tactics, tactic_key, rule.rule_path
                             ));
                             let is_unique = COMPUTER_MITRE_ATTCK_UNIQUE_KEYS.insert(unique_key);
                             if let Some(entry) =

--- a/src/detections/rule/count.rs
+++ b/src/detections/rule/count.rs
@@ -1818,7 +1818,7 @@ mod tests {
             expect_start_timedate.push(expect_agg.start_datetime);
         }
         for agg_result in agg_results {
-            println!("{}", &agg_result.start_datetime);
+            println!("{}", agg_result.start_datetime);
             // The unwrap doubles as the check that start_datetime was stored correctly:
             // binary_search fails if it is not among the expected values.
             let index = expect_start_timedate

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,8 +273,8 @@ impl App {
             write_color_buffer(&BufferWriter::stdout(ColorChoice::Always), None, "", true).ok();
             self.output_eggs(&format!(
                 "{:02}/{:02}",
-                &analysis_start_time.month(),
-                &analysis_start_time.day()
+                analysis_start_time.month(),
+                analysis_start_time.day()
             ));
         }
         let _guard = if !self.is_matched_architecture_and_binary() {
@@ -696,7 +696,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                             Path::new(&keywords_file_name),
                             format!(
                                 " The file {} already exists. Please specify a different filename or add the -C, --clobber option to overwrite.",
-                                &keywords_file_name
+                                keywords_file_name
                             ),
                         ) {
                             error_flag = true
@@ -754,7 +754,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                         writeln!(
                             output,
                             "{}",
-                            &(pivot_file.as_path().display().to_string() + "-" + key + ".txt")
+                            (pivot_file.as_path().display().to_string() + "-" + key + ".txt")
                         )
                         .ok();
                     });
@@ -2195,7 +2195,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                 let file_size = ByteSize::b(size);
                 let pb_msg = format!(
                     "{:?} ({})",
-                    &evtx_file.to_str().unwrap_or_default().replace('\\', "/"),
+                    evtx_file.to_str().unwrap_or_default().replace('\\', "/"),
                     file_size.display()
                 );
                 if !pb_msg.is_empty() {
@@ -2640,7 +2640,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                     let errmsg = format!(
                         "Timestamp parse error. Filepath: {},{} {}",
                         path,
-                        &target_timestamp
+                        target_timestamp
                             .to_string()
                             .replace("\\\"", "")
                             .replace('"', ""),
@@ -2789,7 +2789,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
                                     let errmsg = format!(
                                         "Timestamp parse error. Filepath: {},{} {}",
                                         path,
-                                        &splunk_api_record["Event"]["System"]["SystemTime"]
+                                        splunk_api_record["Event"]["System"]["SystemTime"]
                                             .to_string()
                                             .replace("\\\"", "")
                                             .replace('"', ""),

--- a/src/options/htmlreport.rs
+++ b/src/options/htmlreport.rs
@@ -68,7 +68,7 @@ impl HtmlReporter {
         let mut md_data = Nested::<String>::new();
         for section_name in self.section_order.iter() {
             if let Some(v) = self.section_markdown.get(section_name) {
-                md_data.push(format!("## {}\n", &section_name));
+                md_data.push(format!("## {}\n", section_name));
                 if v.is_empty() {
                     md_data.push("not found data.\n");
                 } else {

--- a/src/options/update.rs
+++ b/src/options/update.rs
@@ -220,7 +220,7 @@ impl Update {
                     "{}|{}|{}|{}|{:?}",
                     yaml["title"].as_str().unwrap_or(&String::default()),
                     yaml["modified"].as_str().unwrap_or(yaml_date),
-                    &filepath,
+                    filepath,
                     yaml["ruletype"].as_str().unwrap_or("Other"),
                     yaml
                 ),

--- a/src/results/csv.rs
+++ b/src/results/csv.rs
@@ -153,7 +153,7 @@ pub(crate) fn emit_csv_inner(
                 write_color_buffer(
                     &output_writer.display_writer,
                     None,
-                    &format!("{{ {} }}", &result.0),
+                    &format!("{{ {} }}", result.0),
                     true,
                 )
                 .ok();
@@ -164,7 +164,7 @@ pub(crate) fn emit_csv_inner(
                     writer.write_all(b"\n")?;
                 }
                 *first = false;
-                write!(writer, "{{ {} }}", &result.0)?;
+                write!(writer, "{{ {} }}", result.0)?;
             }
         } else if json_output_flag {
             // JSON output
@@ -183,7 +183,7 @@ pub(crate) fn emit_csv_inner(
                 write_color_buffer(
                     &output_writer.display_writer,
                     None,
-                    &format!("{{\n{}\n}}", &result.0),
+                    &format!("{{\n{}\n}}", result.0),
                     true,
                 )
                 .ok();
@@ -194,7 +194,7 @@ pub(crate) fn emit_csv_inner(
                     writer.write_all(b"\n")?;
                 }
                 *first = false;
-                write!(writer, "{{\n{}\n}}", &result.0)?;
+                write!(writer, "{{\n{}\n}}", result.0)?;
             }
         } else if let ResultWriter::Csv(csv_writer) = &mut output_writer.result_writer {
             // CSV output format

--- a/src/results/html_stock.rs
+++ b/src/results/html_stock.rs
@@ -16,8 +16,8 @@ pub(crate) fn _output_html_computer_by_mitre_attck(html_output_stock: &mut Neste
         .iter()
         .sorted_by(|a, b| {
             Ord::cmp(
-                &format!("{}-{}", &b.value()[b.value().len() - 1].0, b.key()),
-                &format!("{}-{}", &a.value()[a.value().len() - 1].0, a.key()),
+                &format!("{}-{}", b.value()[b.value().len() - 1].0, b.key()),
+                &format!("{}-{}", a.value()[a.value().len() - 1].0, a.key()),
             )
         })
         .enumerate()

--- a/src/results/summary.rs
+++ b/src/results/summary.rs
@@ -105,7 +105,7 @@ pub(crate) fn calc_statistic_info(
             };
             for computername in &computer_names {
                 let computer_rule_check_key =
-                    CompactString::from(format!("{}|{}", computername, &detect_info.rule_path));
+                    CompactString::from(format!("{}|{}", computername, detect_info.rule_path));
                 if !result_state
                     .detected_computer_and_rule_names
                     .contains(&computer_rule_check_key)
@@ -438,12 +438,12 @@ pub fn output_result_summary(
         println!();
 
         if stored_static.html_report_flag {
-            html_output_stock.push(format!("- Events with hits: {}", &saved_alerts_output));
-            html_output_stock.push(format!("- Total events analyzed: {}", &all_record_output));
+            html_output_stock.push(format!("- Events with hits: {}", saved_alerts_output));
+            html_output_stock.push(format!("- Total events analyzed: {}", all_record_output));
             html_output_stock.push(format!("- {reduction_output}"));
             html_output_stock.push(format!(
                 "- Recovered events analyzed: {}",
-                &result_state
+                result_state
                     .recover_record_cnt
                     .to_formatted_string(&Locale::en)
             ));
@@ -826,7 +826,7 @@ fn _print_detection_summary_by_date(
         if !exist_max_data {
             max_detect_str = "n/a".into();
         }
-        let output_str = format!("{}: {}", level.to_full(), &max_detect_str);
+        let output_str = format!("{}: {}", level.to_full(), max_detect_str);
         write!(wtr, "{output_str}").ok();
         // Print a ", " separator after every level except the last displayed one (count() - 2
         // because UNDEFINED, the final item of the reversed iteration, is skipped).
@@ -903,7 +903,7 @@ fn _print_detection_summary_by_computer(
 
         wtr.set_color(ColorSpec::new().set_fg(_get_output_color(color_map, &level)))
             .ok();
-        writeln!(wtr, "{}: {}", level.to_full(), &result_str).ok();
+        writeln!(wtr, "{}: {}", level.to_full(), result_str).ok();
     }
     buf_wtr.print(&wtr).ok();
 }
@@ -977,7 +977,7 @@ fn _print_detection_summary_tables(
                     html_output_stock.push(format!(
                         "- [{}]({}) ({}) - {}",
                         html_escape_value(x.0),
-                        &rule_path.replace('\\', "/"),
+                        rule_path.replace('\\', "/"),
                         x.1.to_formatted_string(&Locale::en),
                         html_escape_value(
                             rule_detect_author_map

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -322,7 +322,7 @@ impl EventMetrics {
                     .unwrap_or("n/a".into());
                     let errmsg = format!(
                         "Failed to parse event ID from event file: {}\nEvent record ID: {}\n",
-                        &record.evtx_filepath, rec_id
+                        record.evtx_filepath, rec_id
                     );
                     if stored_static.verbose_flag {
                         AlertMessage::alert(&errmsg).ok();


### PR DESCRIPTION
CI's clippy gate (latest-stable toolchain) has moved to **Rust 1.97.0** (2026-07-07), which makes `clippy::needless_borrow` fire on a redundant reference passed to a formatting-macro argument — `format!("{}", &x)`, `writeln!(w, "{}", &x)`, `println!("{}", &x)`. As a result `cargo clippy --all-targets -- -D warnings` now **fails on `main`**, blocking open PRs.

Fix: remove the redundant `&` at each site (machine-applied via `cargo clippy --fix`), across `detection.rs`, `count.rs`, `main.rs`, `results/{summary,csv,html_stock}.rs`, `options/{htmlreport,update}.rs`, and `timeline/metrics.rs`. Purely mechanical — no behavior change.

- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean on Rust 1.97.0.
- 486 lib + 19 bin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)