### PR TITLE
logon-summary: count RDP logons from RemoteConnectionManager 1149 and LocalSessionManager 25

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,6 +4,7 @@
 
 **改善:**
 
+- `logon-summary` コマンドが、Terminal Services の運用ログからも RDP ログオンを集計するようにした。既存の LocalSessionManager `21` と Gateway `302` に加えて、RemoteConnectionManager/Operational `1149`（ネットワークレベル認証）と LocalSessionManager/Operational `25`（セッション再接続）を対象に追加した。これにより、対応する Security `4624` がログからあふれて消えている場合でも、RDP ログオンを集計できる。 (#1893) (@YamatoSecurity)
 - `extract-base64` コマンドに、PowerShellのイベントID `4100`/`4102`（Microsoft-Windows-PowerShell/Operational および PowerShellCore/Operational）と、クラシックの `403`/`600`（Windows PowerShell）を追加した。`4100`/`4102` は `ContextInfo`（`Host Application = powershell -encodedcommand ...`）と `Payload` フィールドを、`403`/`600` は既存の `400` と同様に `EventData.Data` の詳細ブロックをスキャンする。 (#1889) (@YamatoSecurity)
 - `logon-summary` の成功ログオンテーブルに `First Logon`/`Last Logon` 列を、失敗ログオンテーブルに `First Attempt`/`Last Attempt` 列を追加した。各アカウント/ソースの組み合わせがログオン（または試行）した時間の範囲を表示する。 (#1883) (@YamatoSecurity)
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,7 +4,7 @@
 
 **改善:**
 
-- `logon-summary` コマンドが、Terminal Services の運用ログからも RDP ログオンを集計するようにした。既存の LocalSessionManager `21` と Gateway `302` に加えて、RemoteConnectionManager/Operational `1149`（ネットワークレベル認証）と LocalSessionManager/Operational `25`（セッション再接続）を対象に追加した。これにより、対応する Security `4624` がログからあふれて消えている場合でも、RDP ログオンを集計できる。 (#1893) (@YamatoSecurity)
+- `logon-summary` コマンドが、RDP のセッションイベントも集計するようにした。既存の LocalSessionManager `21` と Gateway `302` に加えて、Security `4778`/`4779`（セッションの再接続/切断。RDP クライアントのワークステーション名とIPを含む）と、Terminal Services の運用ログの RemoteConnectionManager/Operational `1149`（ネットワークレベル認証）・LocalSessionManager/Operational `25`（セッション再接続）を対象に追加した。これにより、対応する Security `4624` がログからあふれて消えている場合でも RDP ログオンを集計でき、再接続/切断では接続元クライアントのホスト名も表示される。 (#1893) (@YamatoSecurity)
 - `extract-base64` コマンドに、PowerShellのイベントID `4100`/`4102`（Microsoft-Windows-PowerShell/Operational および PowerShellCore/Operational）と、クラシックの `403`/`600`（Windows PowerShell）を追加した。`4100`/`4102` は `ContextInfo`（`Host Application = powershell -encodedcommand ...`）と `Payload` フィールドを、`403`/`600` は既存の `400` と同様に `EventData.Data` の詳細ブロックをスキャンする。 (#1889) (@YamatoSecurity)
 - `logon-summary` の成功ログオンテーブルに `First Logon`/`Last Logon` 列を、失敗ログオンテーブルに `First Attempt`/`Last Attempt` 列を追加した。各アカウント/ソースの組み合わせがログオン（または試行）した時間の範囲を表示する。 (#1883) (@YamatoSecurity)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements:**
 
+- The `logon-summary` command now also counts RDP logons from the Terminal Services operational logs — RemoteConnectionManager/Operational `1149` (network-level authentication) and LocalSessionManager/Operational `25` (session reconnect), on top of the existing LocalSessionManager `21` and Gateway `302` — so RDP logons are still summarized when the matching Security `4624` has been flooded out of the log. (#1893) (@YamatoSecurity)
 - Added PowerShell event IDs `4100`/`4102` (Microsoft-Windows-PowerShell/Operational and PowerShellCore/Operational) and classic `403`/`600` (Windows PowerShell) to the `extract-base64` command. `4100`/`4102` scan the `ContextInfo` (`Host Application = powershell -encodedcommand ...`) and `Payload` fields; `403`/`600` scan the `EventData.Data` detail blob like the existing `400`. (#1889) (@YamatoSecurity)
 - Added `First Logon`/`Last Logon` columns to the `logon-summary` successful-logons table and `First Attempt`/`Last Attempt` columns to the failed-logons table, showing the time range over which each account/source combination logged on (or attempted to). (#1883) (@YamatoSecurity)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Enhancements:**
 
-- The `logon-summary` command now also counts RDP logons from the Terminal Services operational logs — RemoteConnectionManager/Operational `1149` (network-level authentication) and LocalSessionManager/Operational `25` (session reconnect), on top of the existing LocalSessionManager `21` and Gateway `302` — so RDP logons are still summarized when the matching Security `4624` has been flooded out of the log. (#1893) (@YamatoSecurity)
+- The `logon-summary` command now also counts RDP session events: Security `4778`/`4779` (session reconnect/disconnect, which carry the RDP client's workstation name and IP) and the Terminal Services operational events RemoteConnectionManager/Operational `1149` (network-level authentication) and LocalSessionManager/Operational `25` (session reconnect) — on top of the existing LocalSessionManager `21` and Gateway `302`. This keeps RDP logons summarized even when the matching Security `4624` has been flooded out of the log, and surfaces the source client hostname for reconnect/disconnect. (#1893) (@YamatoSecurity)
 - Added PowerShell event IDs `4100`/`4102` (Microsoft-Windows-PowerShell/Operational and PowerShellCore/Operational) and classic `403`/`600` (Windows PowerShell) to the `extract-base64` command. `4100`/`4102` scan the `ContextInfo` (`Host Application = powershell -encodedcommand ...`) and `Payload` fields; `403`/`600` scan the `EventData.Data` detail blob like the existing `400`. (#1889) (@YamatoSecurity)
 - Added `First Logon`/`Last Logon` columns to the `logon-summary` successful-logons table and `First Attempt`/`Last Attempt` columns to the failed-logons table, showing the time range over which each account/source combination logged on (or attempted to). (#1883) (@YamatoSecurity)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,7 @@ fn apply_channel_filters(
                         - Security
                         - Microsoft-Windows-TerminalServices-Gateway/Operational
                         - Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
+                        - Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational
             "#;
         let yaml_data = YamlLoader::load_from_str(yaml_str);
         let node = RuleNode::new(

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -6,7 +6,7 @@ use crate::detections::{
     utils,
 };
 use crate::timeline::log_metrics::LogMetrics;
-use crate::timeline::metrics::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec};
+use crate::timeline::metrics::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec, Sec4778};
 use bytesize::ByteSize;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use compact_str::CompactString;
@@ -310,9 +310,11 @@ impl EventMetrics {
         }
     }
     /// Counts logon events for the logon-summary command: Security 4624 (successful logon),
-    /// Security 4625 (failed logon), and the RDP events that survive Security-log flooding —
-    /// RDS LocalSessionManager 21/25 (logon/reconnect), RemoteConnectionManager 1149 (network-level
-    /// authentication) and RDS Gateway 302 (RD Gateway logon) — all counted as successful logons.
+    /// Security 4625 (failed logon), Security 4778/4779 (RDP session reconnect/disconnect, which
+    /// carry the client's workstation name), and the RDP operational events that survive
+    /// Security-log flooding — RDS LocalSessionManager 21/25 (logon/reconnect), RemoteConnectionManager
+    /// 1149 (network-level authentication) and RDS Gateway 302 (RD Gateway logon). All but 4625 are
+    /// counted as successful logons.
     fn stats_login_eventid(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         // Maps the LogonType number to a human-readable label for display.
         let logontype_map: HashMap<&str, &str> = HashMap::from([
@@ -365,13 +367,8 @@ impl EventMetrics {
                 );
                 if let Some(channel) = is_target_event(event_id, &channel) {
                     let channel_name = match channel {
-                        Sec => {
-                            if event_id == 4624 {
-                                CompactString::from("Sec 4624")
-                            } else {
-                                CompactString::from("Sec 4625")
-                            }
-                        }
+                        // 4624/4625 and 4778/4779 all live in the Security log.
+                        Sec | Sec4778 => CompactString::from(format!("Sec {event_id}")),
                         RdsLsm => CompactString::from(format!("RDS-LSM {event_id}")),
                         RdsRcm => CompactString::from("RDS-RCM 1149"),
                         RdsGtw => CompactString::from("RDS-GTW 302"),
@@ -381,6 +378,11 @@ impl EventMetrics {
                     let dst_user = match channel {
                         Sec => get_event_value_as_string(
                             "TargetUserName",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
+                        Sec4778 => get_event_value_as_string(
+                            "AccountName",
                             &record.record,
                             &stored_static.eventkey_alias,
                         ),
@@ -427,6 +429,11 @@ impl EventMetrics {
                             &record.record,
                             &stored_static.eventkey_alias,
                         ),
+                        Sec4778 => get_event_value_as_string(
+                            "AccountDomain",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
                         RdsLsm => {
                             let user_with_domain = get_event_value_as_string(
                                 "UserDataUser",
@@ -466,14 +473,28 @@ impl EventMetrics {
                         &record.record,
                         &stored_static.eventkey_alias,
                     );
-                    let source_computer = get_event_value_as_string(
-                        "WorkstationName",
-                        &record.record,
-                        &stored_static.eventkey_alias,
-                    );
+                    // 4778/4779 record the RDP client's workstation name in ClientName; the other
+                    // sources use the Security WorkstationName (absent, i.e. "-", for the RDS logs).
+                    let source_computer = match channel {
+                        Sec4778 => get_event_value_as_string(
+                            "ClientName",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
+                        _ => get_event_value_as_string(
+                            "WorkstationName",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
+                    };
                     let source_ip = match channel {
                         Sec => get_event_value_as_string(
                             "IpAddress",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
+                        Sec4778 => get_event_value_as_string(
+                            "ClientAddress",
                             &record.record,
                             &stored_static.eventkey_alias,
                         ),
@@ -507,8 +528,8 @@ impl EventMetrics {
                     }
 
                     // Fetch (or initialize) the aggregate for this logon event. At this point the
-                    // EventID is 4624, 4625, 21, 25, 1149 or 302; 4625 counts as a failed logon
-                    // (index 1) and the others as successful logons (index 0).
+                    // EventID is 4624, 4625, 4778, 4779, 21, 25, 1149 or 302; 4625 counts as a
+                    // failed logon (index 1) and the others as successful logons (index 0).
                     let entry: &mut LogonStats = self
                         .stats_login_list
                         .entry(LoginEvent {
@@ -580,10 +601,11 @@ fn get_event_value_as_string(
 
 /// Event log channels that contain the logon events tracked by the logon-summary command.
 enum Channel {
-    Sec,    // Security
-    RdsLsm, // Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
-    RdsRcm, // Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational
-    RdsGtw, // Microsoft-Windows-TerminalServices-Gateway/Operational
+    Sec,     // Security (4624/4625)
+    Sec4778, // Security 4778/4779 (RDP session reconnect/disconnect; carries the client name)
+    RdsLsm,  // Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
+    RdsRcm,  // Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational
+    RdsGtw,  // Microsoft-Windows-TerminalServices-Gateway/Operational
 }
 
 /// Returns which channel the record's logon event belongs to if its (EventID, Channel) pair is
@@ -591,6 +613,11 @@ enum Channel {
 fn is_target_event(event_id: i64, channel: &str) -> Option<Channel> {
     if (event_id == 4624 || event_id == 4625) && channel == "Security" {
         return Some(Sec);
+    }
+    // 4778 = session reconnected, 4779 = session disconnected. Unlike the RDS operational events
+    // these carry the RDP client's workstation name (ClientName) and client IP (ClientAddress).
+    if (event_id == 4778 || event_id == 4779) && channel == "Security" {
+        return Some(Sec4778);
     }
     // 21 = RDP session logon, 25 = RDP session reconnect. Both survive the Security-log flooding
     // that can evict the matching 4624, so they are counted as successful logons.
@@ -734,14 +761,16 @@ mod tests {
 
     #[test]
     fn test_is_target_event_covers_rdp_channels() {
-        use super::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec};
+        use super::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec, Sec4778};
         use super::is_target_event;
         let lsm = "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational";
         let rcm = "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational";
         let gtw = "Microsoft-Windows-TerminalServices-Gateway/Operational";
-        // Security 4624/4625
+        // Security 4624/4625 and the RDP reconnect/disconnect pair 4778/4779
         assert!(matches!(is_target_event(4624, "Security"), Some(Sec)));
         assert!(matches!(is_target_event(4625, "Security"), Some(Sec)));
+        assert!(matches!(is_target_event(4778, "Security"), Some(Sec4778)));
+        assert!(matches!(is_target_event(4779, "Security"), Some(Sec4778)));
         // RDP logon sources (21/302 existed; 25 and 1149 are new)
         assert!(matches!(is_target_event(21, lsm), Some(RdsLsm))); // session logon
         assert!(matches!(is_target_event(25, lsm), Some(RdsLsm))); // session reconnect

--- a/src/timeline/metrics.rs
+++ b/src/timeline/metrics.rs
@@ -6,7 +6,7 @@ use crate::detections::{
     utils,
 };
 use crate::timeline::log_metrics::LogMetrics;
-use crate::timeline::metrics::Channel::{RdsGtw, RdsLsm, Sec};
+use crate::timeline::metrics::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec};
 use bytesize::ByteSize;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use compact_str::CompactString;
@@ -310,8 +310,9 @@ impl EventMetrics {
         }
     }
     /// Counts logon events for the logon-summary command: Security 4624 (successful logon),
-    /// Security 4625 (failed logon), RDS LocalSessionManager 21 and RDS Gateway 302 (both
-    /// counted as successful logons).
+    /// Security 4625 (failed logon), and the RDP events that survive Security-log flooding —
+    /// RDS LocalSessionManager 21/25 (logon/reconnect), RemoteConnectionManager 1149 (network-level
+    /// authentication) and RDS Gateway 302 (RD Gateway logon) — all counted as successful logons.
     fn stats_login_eventid(&mut self, records: &[EvtxRecordInfo], stored_static: &StoredStatic) {
         // Maps the LogonType number to a human-readable label for display.
         let logontype_map: HashMap<&str, &str> = HashMap::from([
@@ -371,7 +372,8 @@ impl EventMetrics {
                                 CompactString::from("Sec 4625")
                             }
                         }
-                        RdsLsm => CompactString::from("RDS-LSM 21"),
+                        RdsLsm => CompactString::from(format!("RDS-LSM {event_id}")),
+                        RdsRcm => CompactString::from("RDS-RCM 1149"),
                         RdsGtw => CompactString::from("RDS-GTW 302"),
                     };
                     // The RDS events store the account as a single "DOMAIN\user" field, so the
@@ -394,6 +396,12 @@ impl EventMetrics {
                                 .unwrap_or(&user_with_domain);
                             CompactString::from(user)
                         }
+                        // 1149 stores the user (Param1) and domain (Param2) in separate fields.
+                        RdsRcm => get_event_value_as_string(
+                            "UserDataParam1",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
                         RdsGtw => {
                             let user_with_domain = get_event_value_as_string(
                                 "RdsGtwUsername",
@@ -428,6 +436,11 @@ impl EventMetrics {
                             let domain = user_with_domain.rsplit_once('\\').map(|x| x.0);
                             CompactString::from(domain.unwrap_or("-"))
                         }
+                        RdsRcm => get_event_value_as_string(
+                            "UserDataParam2",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
                         RdsGtw => {
                             let user_with_domain = get_event_value_as_string(
                                 "RdsGtwUsername",
@@ -469,6 +482,11 @@ impl EventMetrics {
                             &record.record,
                             &stored_static.eventkey_alias,
                         ),
+                        RdsRcm => get_event_value_as_string(
+                            "UserDataParam3",
+                            &record.record,
+                            &stored_static.eventkey_alias,
+                        ),
                         RdsGtw => get_event_value_as_string(
                             "RdsGtwIpAddress",
                             &record.record,
@@ -489,8 +507,8 @@ impl EventMetrics {
                     }
 
                     // Fetch (or initialize) the aggregate for this logon event. At this point the
-                    // EventID is 4624, 4625, 21 or 302; 4625 counts as a failed logon (index 1)
-                    // and the others as successful logons (index 0).
+                    // EventID is 4624, 4625, 21, 25, 1149 or 302; 4625 counts as a failed logon
+                    // (index 1) and the others as successful logons (index 0).
                     let entry: &mut LogonStats = self
                         .stats_login_list
                         .entry(LoginEvent {
@@ -564,6 +582,7 @@ fn get_event_value_as_string(
 enum Channel {
     Sec,    // Security
     RdsLsm, // Microsoft-Windows-TerminalServices-LocalSessionManager/Operational
+    RdsRcm, // Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational
     RdsGtw, // Microsoft-Windows-TerminalServices-Gateway/Operational
 }
 
@@ -573,10 +592,19 @@ fn is_target_event(event_id: i64, channel: &str) -> Option<Channel> {
     if (event_id == 4624 || event_id == 4625) && channel == "Security" {
         return Some(Sec);
     }
-    if event_id == 21
+    // 21 = RDP session logon, 25 = RDP session reconnect. Both survive the Security-log flooding
+    // that can evict the matching 4624, so they are counted as successful logons.
+    if (event_id == 21 || event_id == 25)
         && channel == "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational"
     {
         return Some(RdsLsm);
+    }
+    // 1149 = "User authentication succeeded" (network-level authentication); carries the user and
+    // source IP even when the corresponding 4624 has been flooded out.
+    if event_id == 1149
+        && channel == "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational"
+    {
+        return Some(RdsRcm);
     }
     if event_id == 302 && channel == "Microsoft-Windows-TerminalServices-Gateway/Operational" {
         return Some(RdsGtw);
@@ -702,5 +730,26 @@ mod tests {
             assert!(expect.contains_key(&k));
             assert_eq!(expect.get(&k).unwrap(), &v);
         }
+    }
+
+    #[test]
+    fn test_is_target_event_covers_rdp_channels() {
+        use super::Channel::{RdsGtw, RdsLsm, RdsRcm, Sec};
+        use super::is_target_event;
+        let lsm = "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational";
+        let rcm = "Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational";
+        let gtw = "Microsoft-Windows-TerminalServices-Gateway/Operational";
+        // Security 4624/4625
+        assert!(matches!(is_target_event(4624, "Security"), Some(Sec)));
+        assert!(matches!(is_target_event(4625, "Security"), Some(Sec)));
+        // RDP logon sources (21/302 existed; 25 and 1149 are new)
+        assert!(matches!(is_target_event(21, lsm), Some(RdsLsm))); // session logon
+        assert!(matches!(is_target_event(25, lsm), Some(RdsLsm))); // session reconnect
+        assert!(matches!(is_target_event(1149, rcm), Some(RdsRcm))); // NLA authentication
+        assert!(matches!(is_target_event(302, gtw), Some(RdsGtw))); // RD Gateway
+        // Non-logon EIDs and channel mismatches must be ignored.
+        assert!(is_target_event(22, lsm).is_none()); // 22 = shell start, not a logon
+        assert!(is_target_event(1149, lsm).is_none()); // right EID, wrong channel
+        assert!(is_target_event(4624, lsm).is_none());
     }
 }


### PR DESCRIPTION
Closes #1892. From discussion #1391 (thanks @mischw).

When a Security **4624** is flooded out by an RDP brute-force, the logon can still be recovered from the Terminal Services logs — but `logon-summary` only counted LocalSessionManager **21** and Gateway **302**. This adds the remaining host-side RDP logon/session events, matching Hayabusa's own builtin-rule taxonomy.

## Added event sources

| Channel | EID | Label | Account | Source computer | Source IP |
|---|---|---|---|---|---|
| RemoteConnectionManager/Operational | **1149** | `RDS-RCM 1149` | `Param1`/`Param2` | — (not in event) | `Param3` |
| LocalSessionManager/Operational | **25** | `RDS-LSM 25` | `User` | — (not in event) | `Address` |
| Security | **4778** / **4779** | `Sec 4778`/`Sec 4779` | `AccountName`/`AccountDomain` | **`ClientName`** | `ClientAddress` |

- **1149 / 25** survive Security-log flooding but only carry the source **IP**.
- **4778 (reconnect) / 4779 (disconnect)** additionally carry the RDP **client's workstation name** (`ClientName`), so they fill in the source-hostname the RDS operational events lack. Both count as successful logons.
- `RDPClient` 1024/1102 are intentionally excluded (outbound connections, not logons to the host).

Security is already in the channel filter; the `RemoteConnectionManager/Operational` channel is added for the 1149 case. All fields reuse existing `eventkey_alias.txt` aliases.

## Verified end-to-end on the sample-evtx corpus

RDS-RCM 1149: **0 → 5**, RDS-LSM 25: **0 → 2**, and Sec 4778/4779 now surface with the client hostname:
```
Event      Account      Domain      Source Computer   Source IP
Sec 4778   admmarsid    OFFSEC      JUMP01            10.23.23.9      (RDP-hijacking sample: attacker jump box)
Sec 4779   admmig       OFFSEC      JUMP01            10.23.23.9
Sec 4778   Administrator WINDOMAIN  DESKTOP-RKEBDDR   192.168.56.1
RDS-RCM 1149  admin01    example    -                 fe80::80ac:4126:fa58:1b81%10   (IPv6 source)
```

`cargo fmt -- --check` ✔ · `cargo clippy --all-targets -- -D warnings` ✔ · `cargo test` ✔ (513 passed, incl. an `is_target_event` routing test covering 4624/4625/4778/4779/21/25/1149/302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
