### PR TITLE
ci: run field-modifier sync monthly instead of daily

### DIFF
--- a/.github/workflows/sync-field-modifiers.yml
+++ b/.github/workflows/sync-field-modifiers.yml
@@ -3,13 +3,13 @@ name: Sync field-modifier counts
 # Keep the "Supported Field Modifiers" tables in the docs in sync with the
 # upstream auto-generated source in the hayabusa-rules repo
 # (doc/SupportedSigmaFieldModifiers.md), which is regenerated whenever the Sigma
-# or Hayabusa rulesets change. Runs daily (and on demand); when the counts
+# or Hayabusa rulesets change. Runs monthly (and on demand); when the counts
 # change it opens a pull request against main so the protected-branch rules are
 # respected. The docs deploy triggers automatically when the PR is merged.
 
 on:
   schedule:
-    - cron: "0 23 * * *" # daily at 23:00 UTC, ~2h after hayabusa-rules regenerates the table
+    - cron: "0 23 1 * *" # monthly, at 23:00 UTC on the 1st (use workflow_dispatch for an ad-hoc sync)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The `Sync field-modifier counts` workflow (which opened e.g. #1898) ran on a **daily** cron (`0 23 * * *`). The "Supported Field Modifiers" doc tables change only when the Sigma/Hayabusa rulesets add or remove a modifier — rarely — so the daily run almost always produced a no-op.

Change the schedule to **monthly**: `0 23 1 * *` (23:00 UTC on the 1st of each month). `workflow_dispatch` is retained, so an ad-hoc sync can still be triggered immediately after a ruleset change.

Only the cron line and the accompanying comments change; the job itself is untouched.