### PR TITLE
fix: honor -c custom config dir for pivot_keywords.txt in pivot-keywords-list (#1046)

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 
 **バグ修正:**
 
+- `pivot-keywords-list` で `-c`（カスタムのルール設定ディレクトリ）が無視され、常に実行ファイル同梱の `pivot_keywords.txt` を読み込んでいた問題を修正した。他の設定ファイルと同様に、`pivot_keywords.txt` を `-c` ディレクトリ経由で解決するようにした（存在しない場合は同梱コピーにフォールバック）。 (#1902) (@YamatoSecurity)
 - `read_jsonl_to_value`/`read_json_to_value` のファイルオープンエラーが、ファイルパスの代わりにプレースホルダー `{path}` をそのまま出力していた問題を修正した（エラー文字列が `format!` ではなく通常の文字列リテラルだった）。 (#1897) (@YamatoSecurity)
 - `eid-metrics` テーブルの「Event」列の幅計算で、55桁未満のターミナルで `u16` のアンダーフローが発生する問題を修正した。`terminal_width - 55` が45文字の下限を適用する前にアンダーフローし、オーバーフローチェック有効のビルドではパニックし、リリースビルドでは巨大な値にラップしていた（列の上限が実質無効になっていた）。飽和減算を使うようにした。 (#1897) (@YamatoSecurity)
 - 明示的な UTC オフセット（例: `+09:00`）を持つ Splunk-JSON のタイムスタンプが `NaiveDateTime` で解析されてオフセットが破棄され、ローカルの時計時刻がそのまま UTC として保存されていた問題を修正した。これにより `log-metrics` の First/Last Timestamp 列に加えて `eid-metrics`/`logon-summary` の時刻範囲（`EventMetrics::stats_time_cnt` と `parse_evtx_datetime`）もずれていた。タイムラインの集計処理は、オフセットを適用する共通のパーサー（`utils::parse_evtx_timestamp`）を使うようにした。 (#1897) (@YamatoSecurity)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Bug Fixes:**
 
+- Fixed `-c` (custom rules config directory) being ignored by `pivot-keywords-list`, which always loaded `pivot_keywords.txt` from the bundled config next to the executable. It now resolves `pivot_keywords.txt` through the `-c` directory (falling back to the bundled copy), the same way every other config file is loaded. (#1902) (@YamatoSecurity)
 - Fixed the `read_jsonl_to_value`/`read_json_to_value` file-open error printing the literal placeholder `{path}` instead of the file path (the error string was a plain string literal rather than a `format!`). (#1897) (@YamatoSecurity)
 - Fixed a `u16` underflow in the `eid-metrics` table's "Event" column width on terminals narrower than 55 columns: `terminal_width - 55` underflowed before the 45-character floor could apply, panicking in overflow-checked builds and wrapping to a huge value in release builds (leaving the column effectively uncapped). It now uses saturating subtraction. (#1897) (@YamatoSecurity)
 - Fixed Splunk-JSON timestamps carrying an explicit UTC offset (e.g. `+09:00`) being parsed as a `NaiveDateTime`, which discards the offset and stored the local wall-clock time as if it were UTC — skewing the `log-metrics` First/Last Timestamp columns as well as the `eid-metrics`/`logon-summary` time ranges (`EventMetrics::stats_time_cnt` and `parse_evtx_datetime`). The timeline aggregators now share one offset-aware parser (`utils::parse_evtx_timestamp`) that applies the offset. (#1897) (@YamatoSecurity)

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -189,8 +189,9 @@ pub struct StoredStatic {
 
 /// Resolves a bundled config file: prefer `<config_path>/<name>`, otherwise fall back to the
 /// `rules/config/<name>` copy shipped next to the executable. Collapses the config-file fallback
-/// chain that was previously copy-pasted for every setting file.
-fn resolve_config_file(config_path: &Path, name: &str) -> PathBuf {
+/// chain that was previously copy-pasted for every setting file. `config_path` is the `-c` custom
+/// rules-config directory, so honoring it here is what makes `-c` apply to every config file.
+pub fn resolve_config_file(config_path: &Path, name: &str) -> PathBuf {
     check_setting_path(config_path, name, false).unwrap_or_else(|| {
         check_setting_path(
             &CURRENT_EXE_PATH.to_path_buf(),
@@ -3005,5 +3006,22 @@ mod tests {
         assert!(has(&csv, "timeline-end"));
         assert!(has(&sub("eid-metrics"), "clobber"));
         assert!(has(&sub("search"), "disable-abbreviations"));
+    }
+
+    /// #1046: `resolve_config_file` — used for `pivot_keywords.txt` and every other config file —
+    /// must honor the `-c` custom config directory, preferring `<config_path>/<name>` when present
+    /// (rather than always reading the bundled copy next to the executable).
+    #[test]
+    fn resolve_config_file_honors_custom_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pivot_keywords.txt"),
+            "Custom Users.SubjectUserName\n",
+        )
+        .unwrap();
+        assert_eq!(
+            super::resolve_config_file(dir.path(), "pivot_keywords.txt"),
+            dir.path().join("pivot_keywords.txt")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use hashbrown::{HashMap, HashSet};
 use hayabusa::debug::checkpoint_process_timer::CheckPointProcessTimer;
 use hayabusa::detections::configs::{
     Action, CURRENT_EXE_PATH, ConfigReader, EventKeyAliasConfig, ONE_CONFIG_MAP, StoredStatic,
-    TargetEventTime, TargetIds, load_pivot_keywords,
+    TargetEventTime, TargetIds, load_pivot_keywords, resolve_config_file,
 };
 use hayabusa::detections::detection::{self, EvtxRecordInfo};
 use hayabusa::detections::message::{AlertMessage, DetectInfo, get_event_time};
@@ -772,15 +772,13 @@ impl App {
                 );
             }
             Action::PivotKeywordsList(_) => {
+                // Resolve pivot_keywords.txt through the `-c` custom config directory (falling back
+                // to the bundled copy), the same way every other config file is loaded, so that
+                // `-c <dir>` can supply a custom pivot_keywords.txt (issue #1046).
                 load_pivot_keywords(
-                    check_setting_path(
-                        &CURRENT_EXE_PATH.to_path_buf(),
-                        "rules/config/pivot_keywords.txt",
-                        true,
-                    )
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
+                    resolve_config_file(&stored_static.config_path, "pivot_keywords.txt")
+                        .to_str()
+                        .unwrap(),
                     &stored_static.pivot_keyword,
                 );
                 if Path::new("./encoded_rules.yml").exists() {


### PR DESCRIPTION
Closes #1046.

## The bug
`pivot-keywords-list` loaded `pivot_keywords.txt` from a **hardcoded** path (`CURRENT_EXE_PATH/rules/config/pivot_keywords.txt`), so `-c <dir>` was ignored and you couldn't supply a custom `pivot_keywords.txt`.

## The fix
Resolve it through `resolve_config_file(&stored_static.config_path, "pivot_keywords.txt")` — the exact helper every **other** config file already uses, which prefers `<-c dir>/<name>` and falls back to the bundled copy. (`resolve_config_file` is made `pub` so the binary crate can call it.)

```diff
- load_pivot_keywords(
-     check_setting_path(&CURRENT_EXE_PATH.to_path_buf(), "rules/config/pivot_keywords.txt", true)
-         .unwrap().to_str().unwrap(),
-     &stored_static.pivot_keyword);
+ load_pivot_keywords(
+     resolve_config_file(&stored_static.config_path, "pivot_keywords.txt").to_str().unwrap(),
+     &stored_static.pivot_keyword);
```

## Verification
- **End-to-end:** with `-c` pointing at a config dir whose `pivot_keywords.txt` renames the `Users` category to a marker, `pivot-keywords-list` emits the **custom** category file; without `-c` it uses the bundled config (no marker). Confirmed on the sample corpus.
- **Unit test** `resolve_config_file_honors_custom_config_dir` (custom-dir copy is preferred). 499 lib tests pass, fmt clean.