### PR TITLE
chore: gitignore Claude Code's local .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ config/critical_systems.txt
 !/website/requirements.txt
 !/website/docs/stylesheets/
 !/website/docs/stylesheets/extra.css
+
+# Claude Code local state (worktrees, session data). Ephemeral and per-developer;
+# committing it is never intended. If shared Claude config is ever added to the repo,
+# re-include the specific path with a `!` rule below.
+/.claude/


### PR DESCRIPTION
`.claude/` holds per-developer local state — currently the worktrees Claude Code creates while working on a branch. It is never meant to be committed, but it was untracked rather than ignored, so a `git add -A` swept it into a commit on the #1909 branch (since amended away and force-pushed).

**Nothing sensitive was exposed that time**, which I verified rather than assumed:

- `.claude/` contained only `worktrees/` — no settings, transcripts, or credentials.
- Each worktree is itself a git repository, so git recorded them as **gitlinks**: one `Subproject commit <sha>` line each, with no file contents uploaded. (That is what git's "adding embedded git repository" warning means.)
- All five referenced commits resolve to already-public commits in this repo.

Worth knowing: the orphaned commit is still retrievable by SHA (`gh api repos/Yamato-Security/hayabusa/commits/2614b403` returns it) — force-pushing does not delete it, and GitHub keeps unreferenced commits until garbage collection. In this case there is nothing to purge, but the same accident with real file contents would be a different story.

Ignoring the directory removes the trap. If shared Claude configuration is ever added to the repo, re-include that specific path with a `!` rule.

Docs/config only — no code paths touched.