### PR TITLE
ci: fetch the aarch64 musl toolchain from GitHub instead of musl.cc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
   upload:
     runs-on: ${{ matrix.info.os }}
     strategy:
+      # One target failing should not cancel the other eight: `upload-all-platforms` needs them
+      # all, so a cancelled matrix means re-running every build to find out whether the rest were
+      # fine. Let each target report its own result.
+      fail-fast: false
       matrix:
         info:
           - {
@@ -102,15 +106,31 @@ jobs:
           # ships an x86_64 musl-gcc, and linking with the glibc gcc-aarch64-linux-gnu produces a
           # binary that is killed at startup (issue #1332). This static toolchain builds the C
           # dependencies (vendored OpenSSL, mimalloc) and links against musl correctly.
-          curl -sSL https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C "$HOME"
-          echo "$HOME/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
-          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> "$GITHUB_ENV"
-          echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> "$GITHUB_ENV"
-          echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> "$GITHUB_ENV"
+          #
+          # Fetched from the cross-tools/musl-cross GitHub release rather than musl.cc. musl.cc is
+          # a single volunteer-run host with no CDN, and it stopped answering entirely, failing
+          # every release run at this step with `curl: (28) Failed to connect to musl.cc port 443`.
+          # GitHub Releases are already a hard dependency of this workflow, so this adds no new
+          # point of failure. Both toolchains are musl-cross-make builds of the same components.
+          TOOLCHAIN_VERSION="20260515"
+          TOOLCHAIN_SHA256="90282c463498dcdab9b96a464a0925d53f30c884b2d7b25e3998999416ae34b8"
+          # Download to a file rather than piping into tar: a failed fetch then reports as a curl
+          # error instead of a confusing `gzip: stdin: unexpected end of file`. -f so an HTTP error
+          # page is never mistaken for the archive, and --retry to ride out a transient blip.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o /tmp/aarch64-musl-cross.tar.xz \
+            "https://github.com/cross-tools/musl-cross/releases/download/${TOOLCHAIN_VERSION}/aarch64-unknown-linux-musl.tar.xz"
+          # This toolchain compiles and links a published release binary, so pin its hash.
+          echo "${TOOLCHAIN_SHA256}  /tmp/aarch64-musl-cross.tar.xz" | sha256sum -c -
+          tar -xJf /tmp/aarch64-musl-cross.tar.xz -C "$HOME"
+          echo "$HOME/aarch64-unknown-linux-musl/bin" >> "$GITHUB_PATH"
+          echo "CC_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-gcc" >> "$GITHUB_ENV"
+          echo "CXX_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-g++" >> "$GITHUB_ENV"
+          echo "AR_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-ar" >> "$GITHUB_ENV"
           cat << EOF >> ./.cargo/config.toml
 
           [target.aarch64-unknown-linux-musl]
-          linker = "aarch64-linux-musl-gcc"
+          linker = "aarch64-unknown-linux-musl-gcc"
           EOF
 
       - name: Build Hayabusa binary


### PR DESCRIPTION
The release workflow cannot complete right now. `upload (ubuntu-latest, aarch64-unknown-linux-musl)` dies before it reaches `cargo build`:

```
curl: (28) Failed to connect to musl.cc port 443 after 136096 ms: Couldn't connect to server
gzip: stdin: unexpected end of file
tar: Child returned status 1
##[error]Process completed with exit code 2.
```

`musl.cc` is a single volunteer-run host with no CDN or SLA, and it has stopped answering — this is not a one-off blip; the step fails the same way on re-run. Because the matrix is fail-fast, that one job also cancels the other eight targets, and `upload-all-platforms` / `all-packages-zip` are then skipped, so the whole release is blocked.

## Change

Fetch the toolchain from the [cross-tools/musl-cross](https://github.com/cross-tools/musl-cross) GitHub release instead. It publishes `aarch64-unknown-linux-musl.tar.xz` built from the same `musl-cross-make` recipe, and GitHub Releases are already a hard dependency of this workflow — so this adds no new point of failure rather than trading one flaky host for another.

The tool prefix differs between the two builds (`aarch64-unknown-linux-musl-gcc` vs. musl.cc's `aarch64-linux-musl-gcc`), so `CC`/`CXX`/`AR`, the `$GITHUB_PATH` entry and the `linker` in `.cargo/config.toml` are updated to match. The reasoning in the existing comment is kept: this still has to be a real musl cross toolchain, because linking with the glibc `gcc-aarch64-linux-gnu` produces a binary killed at startup (#1332).

Hardened the fetch while touching it:

- **`-f`** so an HTTP error page can never be piped in as if it were the archive (the old `-sSL` had no `-f`).
- **`--retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30`** to ride out a transient blip instead of failing a release on one bad request.
- **Download to a file, then extract.** The old `curl | tar` turned a network failure into `gzip: stdin: unexpected end of file`, which reads like archive corruption rather than "the host is down".
- **Pinned sha256.** This toolchain compiles and links a binary we publish, so it is worth verifying rather than trusting whatever an unpinned URL returns.

Also set **`fail-fast: false`** on the upload matrix. `upload-all-platforms` needs every target anyway, so cancelling the survivors buys nothing and costs a full re-run just to learn whether the other eight were fine.

## Verification

Checked against the real artifact rather than assumed:

- the pinned sha256 (`90282c46…`) matches the published `aarch64-unknown-linux-musl.tar.xz.sha256`;
- extracting it produces `$HOME/aarch64-unknown-linux-musl/bin/aarch64-unknown-linux-musl-{gcc,g++,ar,ranlib,strip}`, exactly the paths and names the step now references;
- the workflow YAML parses, and the matrix still lists all nine targets.

The toolchain binaries are x86_64-hosted, which is right for `ubuntu-latest` but means the cross-build itself can only be exercised on the runner — worth watching that job on the next release run.