### PR TITLE
feat: add GeoIP enrichment to logon-summary command output

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## x.x.x
+
+**改善:**
+
+- `logon-summary` コマンドに `-G, --geo-ip` オプションを追加した。集計された各ログオンの送信元IPアドレスに対して `Source ASN`、`Source Country`、`Source City` 列を追加する。 (#1920) (@fukusuket)
+
 ## 4.0.0 [2026/07/29] - Black Hat Arsenal USA Release
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## x.x.x
+
+**Enhancements:**
+
+- Added the `-G, --geo-ip` option to the `logon-summary` command, which appends `Source ASN`, `Source Country` and `Source City` columns for the source IP address of each summarized logon. (#1920) (@fukusuket)
+
 ## 4.0.0 [2026/07/29] - Black Hat Arsenal USA Release
 
 **Enhancements:**

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -322,6 +322,14 @@ impl StoredStatic {
                     "GeoLite2-City.mmdb",
                 ],
             ),
+            Some(Action::LogonSummary(opt)) => GeoIPSearch::check_exist_geo_ip_files(
+                &opt.geo_ip,
+                vec![
+                    "GeoLite2-ASN.mmdb",
+                    "GeoLite2-Country.mmdb",
+                    "GeoLite2-City.mmdb",
+                ],
+            ),
             _ => Ok(None),
         };
         if let Err(err_msg) = geo_ip_db_result {
@@ -1439,6 +1447,16 @@ pub struct PivotKeywordOption {
 pub struct LogonSummaryOption {
     #[clap(flatten)]
     pub input_args: InputOption,
+
+    /// Add GeoIP (ASN, city, country) info to source IP addresses
+    #[arg(
+        help_heading = Some("Output"),
+        short = 'G',
+        long = "geo-ip",
+        value_name = "MAXMIND-DB-DIR",
+        display_order = 70
+    )]
+    pub geo_ip: Option<PathBuf>,
 
     /// Save the logon summary to two CSV files (ex: -o logon-summary)
     #[arg(help_heading = Some("Output"), short = 'o', long, value_name = "FILENAME-PREFIX", display_order = 410)]

--- a/src/detections/rule/correlation_parser.rs
+++ b/src/detections/rule/correlation_parser.rs
@@ -162,19 +162,18 @@ fn get_group_by_from_yaml(yaml: &Yaml) -> Result<Option<String>, Box<dyn Error>>
 /// TimeFrameInfo::parse_tframe in count.rs, but returns an Err for an unknown unit suffix
 /// instead of logging it.
 fn parse_tframe(value: String) -> Result<TimeFrameInfo, Box<dyn Error>> {
-    let time_unit;
     let mut target_val = value.as_str();
-    if target_val.ends_with('s') {
-        time_unit = "s";
+    let time_unit = if target_val.ends_with('s') {
+        "s"
     } else if target_val.ends_with('m') {
-        time_unit = "m";
+        "m"
     } else if target_val.ends_with('h') {
-        time_unit = "h";
+        "h"
     } else if target_val.ends_with('d') {
-        time_unit = "d";
+        "d"
     } else {
         return Err("Invalid time frame".into());
-    }
+    };
     if !time_unit.is_empty() {
         target_val = &value[..value.len() - 1];
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1308,7 +1308,7 @@ Any hostnames added to the critical_systems.txt file will have all alerts above 
             write_color_buffer(
                 &BufferWriter::stdout(ColorChoice::Always),
                 Some(Color::Rgb(0, 255, 0)),
-                &format!("- {:<25}", &format!("{}:", profile[0])),
+                &format!("- {:<25}", format!("{}:", profile[0])),
                 false,
             )
             .ok();

--- a/src/timeline/timelines.rs
+++ b/src/timeline/timelines.rs
@@ -470,7 +470,10 @@ impl Timeline {
         } else {
             ("First Logon", "Last Logon")
         };
-        let header = vec![
+        // With -G, the source IP address of every row is resolved through the MaxMind databases
+        // and three extra columns are appended.
+        let use_geo_ip = stored_static.geo_ip_search.is_some();
+        let mut header = vec![
             header_column.as_str(),
             first_label,
             last_label,
@@ -484,6 +487,9 @@ impl Timeline {
             "Source Computer",
             "Source IP Address",
         ];
+        if use_geo_ip {
+            header.extend(["Source ASN", "Source Country", "Source City"]);
+        }
         let target;
         if output.is_none() {
             let msg = format!("{} Logons:", make_ascii_titlecase(logon_res));
@@ -521,9 +527,10 @@ impl Timeline {
             .load_preset(UTF8_FULL)
             .apply_modifier(UTF8_ROUND_CORNERS);
         // The terminal table only shows a subset of the columns (count, first/last time, event,
-        // target account, target computer, source computer, source IP); the CSV has all of them.
+        // target account, target computer, source computer, source IP, plus the source country
+        // with -G); the CSV has all of them.
         let header_ref = &header;
-        logins_stats_tb.set_header([
+        let mut terminal_header = vec![
             header_ref[0],
             header_ref[1],
             header_ref[2],
@@ -532,7 +539,11 @@ impl Timeline {
             header_ref[6],
             header_ref[10],
             header_ref[11],
-        ]);
+        ];
+        if use_geo_ip {
+            terminal_header.push(header_ref[13]);
+        }
+        logins_stats_tb.set_header(terminal_header);
         // Index into the per-user [successful, failed] count/first/last arrays.
         let result_index = match logon_res {
             "successful" => 0,
@@ -565,7 +576,26 @@ impl Timeline {
                 Some(timestamp) => utils::format_time(&timestamp, false, tfo).to_string(),
                 None => "-".to_string(),
             };
-            let record_data = vec![
+            // The lookup is per displayed row rather than per record, and GeoIPSearch caches
+            // each address, so a repeated source IP costs nothing. Rows whose source IP is not a
+            // resolvable address (e.g. the "-" placeholder for events without one) get "-".
+            let geo_fields: [String; 3] = match &stored_static.geo_ip_search {
+                Some(geo_ip_search) => {
+                    match geo_ip_search.convert_ip_to_geo(login_event.source_ip.as_str()) {
+                        Ok(geo_data) => {
+                            let mut geo_data = geo_data.split('🦅').map(str::to_string);
+                            [
+                                geo_data.next().unwrap_or_default(),
+                                geo_data.next().unwrap_or_default(),
+                                geo_data.next().unwrap_or_default(),
+                            ]
+                        }
+                        Err(_) => ["-".to_string(), "-".to_string(), "-".to_string()],
+                    }
+                }
+                None => Default::default(),
+            };
+            let mut record_data = vec![
                 vnum_str.as_str(),
                 first_str.as_str(),
                 last_str.as_str(),
@@ -579,13 +609,29 @@ impl Timeline {
                 login_event.source_computer.as_str(),
                 login_event.source_ip.as_str(),
             ];
+            if use_geo_ip {
+                record_data.extend(geo_fields.iter().map(String::as_str));
+            }
             if let Some(ref mut writer) = wtr {
                 writer.write_record(&record_data).ok();
             }
             let row = record_data;
-            logins_stats_tb.add_row([
+            let mut table_row = vec![
                 row[0], row[1], row[2], row[3], row[4], row[6], row[10], row[11],
-            ]);
+            ];
+            if use_geo_ip {
+                // The country is the only GeoIP column the terminal table has room for, so fall
+                // back to the ASN when it is empty. That is where convert_ip_to_geo puts the
+                // "Local"/"Private" placeholders for addresses it does not look up -- without the
+                // fallback a private source IP would show "-", indistinguishable from a row with
+                // no source IP at all. The CSV keeps all three columns as-is.
+                table_row.push(match (geo_fields[1].as_str(), geo_fields[0].as_str()) {
+                    ("" | "-", "" | "-") => "-",
+                    ("" | "-", asn) => asn,
+                    (country, _) => country,
+                });
+            }
+            logins_stats_tb.add_row(table_row);
         }
         // If there is no row data, display a message indicating no detections.
         if logins_stats_tb.row_iter().len() == 0 {
@@ -1018,6 +1064,7 @@ mod tests {
                     start_timeline: None,
                 },
                 remove_duplicate_detections: false,
+                geo_ip: None,
             }));
         dummy_stored_static.logon_summary_flag = true;
         let mut timeline = Timeline::default();
@@ -1379,6 +1426,7 @@ mod tests {
                     start_timeline: None,
                 },
                 remove_duplicate_detections: false,
+                geo_ip: None,
             }));
         dummy_stored_static.logon_summary_flag = true;
         let mut timeline = Timeline::default();
@@ -1499,5 +1547,188 @@ mod tests {
         // Delete the file after the test.
         assert!(remove_file(&out_test_tm_logon_stats_successful_csv).is_ok());
         assert!(remove_file(&out_test_tm_logon_stats_failed_csv).is_ok());
+    }
+
+    /// Test the -G (GeoIP) columns of the logon-summary CSV output: a routable address is
+    /// resolved through the MaxMind databases, a private address is reported as "Private", and a
+    /// record without a source IP falls back to "-".
+    #[test]
+    pub fn test_tm_logon_stats_dsp_msg_geo_ip() {
+        let output_tmp_dir = tempfile::tempdir().unwrap();
+        let out_prefix = output_tmp_dir.path().join("test_tm_logon_stats_geo_ip");
+        let out_successful_csv = output_tmp_dir
+            .path()
+            .join("test_tm_logon_stats_geo_ip-successful.csv");
+        let out_failed_csv = output_tmp_dir
+            .path()
+            .join("test_tm_logon_stats_geo_ip-failed.csv");
+        let mut dummy_stored_static =
+            create_dummy_stored_static(Action::LogonSummary(LogonSummaryOption {
+                input_args: InputOption {
+                    directory: None,
+                    filepath: Some(Path::new("./dummy.evtx").to_path_buf()),
+                    live_analysis: false,
+                    recover_records: false,
+                    time_offset: None,
+                },
+                common_options: CommonOptions {
+                    no_color: false,
+                    quiet: false,
+                    help: None,
+                },
+                detect_common_options: DetectCommonOption {
+                    json_input: false,
+                    validate_checksums: false,
+                    evtx_file_ext: None,
+                    thread_number: None,
+                    quiet_errors: false,
+                    config: Path::new("./rules/config").to_path_buf(),
+                    verbose: false,
+                    include_computer: None,
+                    exclude_computer: None,
+                },
+                time_format_options: TimeFormatOptions {
+                    european_time: false,
+                    iso_8601: false,
+                    rfc_2822: false,
+                    rfc_3339: false,
+                    us_military_time: false,
+                    us_time: false,
+                    utc: false,
+                },
+                output: Some(out_prefix.clone()),
+                clobber_opt: ClobberOption { clobber: false },
+                time_range: TimeRangeOption {
+                    end_timeline: None,
+                    start_timeline: None,
+                },
+                remove_duplicate_detections: false,
+                // Test databases from https://github.com/maxmind/MaxMind-DB/tree/main/test-data
+                geo_ip: Some(Path::new("test_files/mmdb").to_path_buf()),
+            }));
+        assert!(dummy_stored_static.geo_ip_search.is_some());
+        dummy_stored_static.logon_summary_flag = true;
+        let mut timeline = Timeline::default();
+
+        // A successful logon from a routable address that the test databases know about.
+        let global_ip_record_str = r#"{
+            "Event": {
+                "System": {
+                    "EventID": 4624,
+                    "Channel": "Security",
+                    "Computer":"HAYABUSA-DESKTOP",
+                    "TimeCreated_attributes": {
+                        "SystemTime": "2021-12-23T00:00:00.000Z"
+                    }
+                },
+                "EventData": {
+                    "WorkstationName": "HAYABUSA",
+                    "IpAddress": "2.125.160.216",
+                    "TargetUserName": "testuser",
+                    "LogonType": "3"
+                }
+            },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        // A failed logon from a private address: reported as "Private" without a lookup.
+        let private_ip_record_str = r#"{
+            "Event": {
+                "System": {
+                    "EventID": 4625,
+                    "Channel": "Security",
+                    "Computer":"HAYABUSA-DESKTOP",
+                    "TimeCreated_attributes": {
+                        "SystemTime": "2022-12-23T00:00:00.000Z"
+                    }
+                },
+                "EventData": {
+                    "IpAddress": "192.168.100.200",
+                    "TargetUserName": "testuser",
+                    "LogonType": "3"
+                }
+            },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        // A failed logon with no source IP field at all: the "-" placeholder is not an address.
+        let no_ip_record_str = r#"{
+            "Event": {
+                "System": {
+                    "EventID": 4625,
+                    "Channel": "Security",
+                    "Computer":"HAYABUSA-DESKTOP",
+                    "TimeCreated_attributes": {
+                        "SystemTime": "2022-12-23T00:00:00.000Z"
+                    }
+                },
+                "EventData": {
+                    "TargetUserName": "testuser2",
+                    "LogonType": "0"
+                }
+            },
+            "Event_attributes": {"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"}
+        }"#;
+        let mut input_records = vec![];
+        for record_str in [
+            global_ip_record_str,
+            private_ip_record_str,
+            no_ip_record_str,
+        ] {
+            input_records.push(create_rec_info(
+                serde_json::from_str(record_str).unwrap(),
+                "testpath".to_string(),
+                &Nested::<String>::new(),
+                &false,
+                &false,
+                &dummy_stored_static.eventkey_alias,
+            ));
+        }
+        timeline
+            .stats
+            .logon_stats_start(&input_records, &dummy_stored_static);
+        timeline.tm_logon_stats_dsp_msg(&dummy_stored_static);
+
+        let tfo = &dummy_stored_static
+            .output_option
+            .as_ref()
+            .unwrap()
+            .time_format_options;
+        let mkdt = |date_str: &str| {
+            DateTime::<Utc>::from_naive_utc_and_offset(
+                NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%S%.fZ").unwrap(),
+                Utc,
+            )
+        };
+        let success_t =
+            crate::detections::utils::format_time(&mkdt("2021-12-23T00:00:00.000Z"), false, tfo)
+                .to_string();
+        let failed_t =
+            crate::detections::utils::format_time(&mkdt("2022-12-23T00:00:00.000Z"), false, tfo)
+                .to_string();
+
+        // The test City/Country databases resolve 2.125.160.216, but the test ASN database has no
+        // entry for it, so the ASN column is empty.
+        let expect_success = format!(
+            "Successful,First Logon,Last Logon,Event,Target Account,Target Domain,Target Computer,Logon Type,Source Account,Source Domain,Source Computer,Source IP Address,Source ASN,Source Country,Source City\n\
+             1,{success_t},{success_t},Sec 4624,testuser,-,HAYABUSA-DESKTOP,3 - Network,-,-,HAYABUSA,2.125.160.216,,United Kingdom,Boxford\n"
+        );
+        match read_to_string(&out_successful_csv) {
+            Err(_) => panic!("Failed to open file."),
+            Ok(contents) => assert_eq!(contents, expect_success),
+        };
+
+        // The failed rows are ordered by count and then by the logon grouping key, so the
+        // private-address row (Target Account "testuser") comes before the no-IP one.
+        let expect_failed = format!(
+            "Failed,First Attempt,Last Attempt,Event,Target Account,Target Domain,Target Computer,Logon Type,Source Account,Source Domain,Source Computer,Source IP Address,Source ASN,Source Country,Source City\n\
+             1,{failed_t},{failed_t},Sec 4625,testuser,-,HAYABUSA-DESKTOP,3 - Network,-,-,-,192.168.100.200,Private,-,-\n\
+             1,{failed_t},{failed_t},Sec 4625,testuser2,-,HAYABUSA-DESKTOP,0 - System,-,-,-,-,-,-,-\n"
+        );
+        match read_to_string(&out_failed_csv) {
+            Err(_) => panic!("Failed to open file."),
+            Ok(contents) => assert_eq!(contents, expect_failed),
+        };
+
+        assert!(remove_file(&out_successful_csv).is_ok());
+        assert!(remove_file(&out_failed_csv).is_ok());
     }
 }

--- a/website/docs/commands/analysis.ar.md
+++ b/website/docs/commands/analysis.ar.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           وقت بدء سجلات الأحداث المراد تحميلها (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   إضافة معلومات GeoIP (ASN، المدينة، الدولة) إلى عناوين IP المصدر
   -X, --remove-duplicate-records  إزالة سجلات الأحداث المكررة (default: disabled)
   -o, --output <FILENAME-PREFIX>  حفظ ملخص تسجيل الدخول في ملفي CSV (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           إخراج الطابع الزمني بتنسيق الوقت الأمريكي (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### إثراء معلومات GeoIP في أمر `logon-summary`
+
+عند تمرير `-G, --geo-ip` مع مسار مجلد يحتوي على قواعد بيانات MaxMind وهي `GeoLite2-ASN.mmdb` و`GeoLite2-Country.mmdb` و`GeoLite2-City.mmdb`، يتم البحث عن عنوان IP المصدر لكل صف وتُضاف الأعمدة `Source ASN` و`Source Country` و`Source City` إلى كلا ملفي CSV.
+لا يتسع جدول الطرفية إلا لعمود واحد منها، لذا يعرض `Source Country` (ويعود إلى عمود ASN عند كونه فارغًا، لأن القيمتين البديلتين `Local`/`Private` للعناوين غير القابلة للتوجيه تظهران هناك).
+
 ### أمثلة على أمر `logon-summary`
 
 * طباعة ملخص تسجيل الدخول: `hayabusa.exe logon-summary -f Security.evtx`
 * حفظ نتائج ملخص تسجيل الدخول: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* إضافة معلومات GeoIP إلى عناوين IP المصدر: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### لقطات شاشة لـ `logon-summary`
 

--- a/website/docs/commands/analysis.de.md
+++ b/website/docs/commands/analysis.de.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Startzeit der zu ladenden Ereignisprotokolle (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   GeoIP-Informationen (ASN, Stadt, Land) zu den Quell-IP-Adressen hinzufügen
   -X, --remove-duplicate-records  Doppelte Ereigniseinträge entfernen (default: disabled)
   -o, --output <FILENAME-PREFIX>  Die Anmeldezusammenfassung in zwei CSV-Dateien speichern (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Zeitstempel im US-Zeitformat ausgeben (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### GeoIP-Anreicherung bei `logon-summary`
+
+Wenn `-G, --geo-ip` auf ein Verzeichnis mit den MaxMind-Datenbanken `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` und `GeoLite2-City.mmdb` zeigt, wird die Quell-IP-Adresse jeder Zeile nachgeschlagen und beiden CSV-Dateien werden die Spalten `Source ASN`, `Source Country` und `Source City` hinzugefügt.
+In der Terminaltabelle ist nur für eine davon Platz, daher wird dort `Source Country` angezeigt (bei leerem Wert wird auf die ASN-Spalte zurückgegriffen, denn dort stehen die Platzhalter `Local`/`Private` für nicht routbare Adressen).
+
 ### Beispiele für den Befehl `logon-summary`
 
 * Anmeldezusammenfassung ausgeben: `hayabusa.exe logon-summary -f Security.evtx`
 * Ergebnisse der Anmeldezusammenfassung speichern: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* GeoIP-Informationen zu den Quell-IP-Adressen hinzufügen: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Screenshots von `logon-summary`
 

--- a/website/docs/commands/analysis.es.md
+++ b/website/docs/commands/analysis.es.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Hora de inicio de los registros de eventos a cargar (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Añadir información GeoIP (ASN, ciudad, país) a las direcciones IP de origen
   -X, --remove-duplicate-records  Eliminar registros de eventos duplicados (default: disabled)
   -o, --output <FILENAME-PREFIX>  Guardar el resumen de inicios de sesión en dos archivos CSV (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Mostrar la marca de tiempo en formato de hora de EE. UU. (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### Enriquecimiento GeoIP de `logon-summary`
+
+Si `-G, --geo-ip` apunta a un directorio que contiene las bases de datos de MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` y `GeoLite2-City.mmdb`, se consulta la dirección IP de origen de cada fila y se añaden las columnas `Source ASN`, `Source Country` y `Source City` a ambos archivos CSV.
+En la tabla del terminal solo cabe una de ellas, por lo que se muestra `Source Country` (si está vacía, se recurre a la columna ASN, que es donde aparecen los marcadores `Local`/`Private` de las direcciones no enrutables).
+
 ### Ejemplos del comando `logon-summary`
 
 * Imprimir el resumen de inicios de sesión: `hayabusa.exe logon-summary -f Security.evtx`
 * Guardar los resultados del resumen de inicios de sesión: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Añadir información GeoIP a las direcciones IP de origen: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Capturas de pantalla de `logon-summary`
 

--- a/website/docs/commands/analysis.fr.md
+++ b/website/docs/commands/analysis.fr.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Ajouter les informations GeoIP (ASN, ville, pays) aux adresses IP source
   -X, --remove-duplicate-records  Supprimer les enregistrements d'événements en double (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### Enrichissement GeoIP de `logon-summary`
+
+Lorsque `-G, --geo-ip` pointe vers un répertoire contenant les bases de données MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` et `GeoLite2-City.mmdb`, l'adresse IP source de chaque ligne est résolue et les colonnes `Source ASN`, `Source Country` et `Source City` sont ajoutées aux deux fichiers CSV.
+Le tableau du terminal n'a de place que pour l'une d'entre elles : il affiche donc `Source Country` (avec un repli sur la colonne ASN lorsqu'elle est vide, car c'est là qu'apparaissent les valeurs `Local`/`Private` des adresses non routables).
+
 ### Exemples de la commande `logon-summary`
 
 * Afficher le résumé des connexions : `hayabusa.exe logon-summary -f Security.evtx`
 * Enregistrer les résultats du résumé des connexions : `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Ajouter les informations GeoIP aux adresses IP source : `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Captures d'écran de `logon-summary`
 

--- a/website/docs/commands/analysis.hi.md
+++ b/website/docs/commands/analysis.hi.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           लोड करने के लिए इवेंट लॉग का प्रारंभ समय (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   स्रोत IP पतों में GeoIP (ASN, शहर, देश) जानकारी जोड़ें
   -X, --remove-duplicate-records  डुप्लिकेट इवेंट रिकॉर्ड हटाएं (default: disabled)
   -o, --output <FILENAME-PREFIX>  लॉगऑन सारांश को दो CSV फ़ाइलों में सहेजें (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           अमेरिकी समय प्रारूप में टाइमस्टैम्प आउटपुट करें (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP संवर्धन
+
+जब `-G, --geo-ip` को ऐसी डायरेक्टरी की ओर इंगित किया जाता है जिसमें MaxMind के `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` और `GeoLite2-City.mmdb` डेटाबेस हों, तो प्रत्येक पंक्ति के स्रोत IP पते को खोजा जाता है और दोनों CSV फ़ाइलों में `Source ASN`, `Source Country` और `Source City` कॉलम जोड़े जाते हैं।
+टर्मिनल तालिका में इनमें से केवल एक के लिए जगह है, इसलिए वह `Source Country` दिखाती है (खाली होने पर ASN कॉलम पर वापस आ जाती है, क्योंकि गैर-राउटेबल पतों के `Local`/`Private` मान वहीं आते हैं)।
+
 ### `logon-summary` कमांड उदाहरण
 
 * लॉगऑन सारांश प्रिंट करें: `hayabusa.exe logon-summary -f Security.evtx`
 * लॉगऑन सारांश परिणाम सहेजें: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* स्रोत IP पतों में GeoIP जानकारी जोड़ें: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` स्क्रीनशॉट
 

--- a/website/docs/commands/analysis.id.md
+++ b/website/docs/commands/analysis.id.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Tambahkan info GeoIP (ASN, kota, negara) ke alamat IP sumber
   -X, --remove-duplicate-records  Hapus record event duplikat (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### Pengayaan GeoIP `logon-summary`
+
+Jika `-G, --geo-ip` diarahkan ke direktori yang berisi basis data MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb`, dan `GeoLite2-City.mmdb`, alamat IP sumber pada setiap baris akan dicari dan kolom `Source ASN`, `Source Country`, dan `Source City` ditambahkan ke kedua file CSV.
+Tabel terminal hanya memiliki ruang untuk salah satunya, sehingga menampilkan `Source Country` (kembali ke kolom ASN jika kosong, karena di situlah nilai `Local`/`Private` untuk alamat non-routable muncul).
+
 ### Contoh perintah `logon-summary`
 
 * Cetak ringkasan logon: `hayabusa.exe logon-summary -f Security.evtx`
 * Simpan hasil ringkasan logon: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Tambahkan info GeoIP ke alamat IP sumber: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Tangkapan layar `logon-summary`
 

--- a/website/docs/commands/analysis.ja.md
+++ b/website/docs/commands/analysis.ja.md
@@ -380,6 +380,7 @@ Filtering:
       --timeline-start <DATE>           解析対象とするイベントログの開始時刻 (例: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   送信元IPアドレスにGeoIP (ASN、市、国) 情報を追加する
   -X, --remove-duplicate-records  重複したイベントレコードを削除する (デフォルト: 無効)
   -o, --output <FILENAME-PREFIX>  ログオンサマリをCSV形式で２つのファイルに保存する (例: -o logon-summary)
 
@@ -398,10 +399,16 @@ Time Format:
       --us-time           アメリカ形式で日付と時刻を出力する (例: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary`のGeoIP情報の付与
+
+MaxMindの`GeoLite2-ASN.mmdb`、`GeoLite2-Country.mmdb`、`GeoLite2-City.mmdb`が置かれたディレクトリを`-G, --geo-ip`で指定すると、各行の送信元IPアドレスが検索され、2つのCSVファイルに`Source ASN`、`Source Country`、`Source City`列が追加されます。
+画面出力のテーブルは列幅の都合で`Source Country`のみを表示します(空の場合はASN列にフォールバックします。ルーティング対象外のアドレスの`Local`/`Private`はASN列に入るためです)。
+
 ### `logon-summary`コマンドの使用例
 
 * ログオンサマリの出力: `hayabusa.exe logon-summary -f Security.evtx`
 * ログオンサマリ結果を保存する: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* 送信元IPアドレスにGeoIP情報を付与する: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary`のスクリーンショット
 

--- a/website/docs/commands/analysis.ko.md
+++ b/website/docs/commands/analysis.ko.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   출발지 IP 주소에 GeoIP (ASN, 도시, 국가) 정보 추가
   -X, --remove-duplicate-records  중복 이벤트 레코드 제거 (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP 정보 추가
+
+MaxMind의 `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb`, `GeoLite2-City.mmdb` 데이터베이스가 있는 디렉터리를 `-G, --geo-ip`로 지정하면 각 행의 출발지 IP 주소를 조회하여 두 CSV 파일에 `Source ASN`, `Source Country`, `Source City` 열이 추가됩니다.
+터미널 테이블에는 이 중 하나만 표시할 공간이 있으므로 `Source Country`를 표시합니다(비어 있으면 ASN 열로 대체됩니다. 라우팅할 수 없는 주소의 `Local`/`Private` 값이 ASN 열에 들어가기 때문입니다).
+
 ### `logon-summary` 명령어 예시
 
 * 로그온 요약 출력: `hayabusa.exe logon-summary -f Security.evtx`
 * 로그온 요약 결과 저장: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* 출발지 IP 주소에 GeoIP 정보 추가: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` 스크린샷
 

--- a/website/docs/commands/analysis.md
+++ b/website/docs/commands/analysis.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Add GeoIP (ASN, city, country) info to source IP addresses
   -X, --remove-duplicate-records  Remove duplicate event records (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP enrichment
+
+With `-G, --geo-ip` pointing at a directory that contains the MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` and `GeoLite2-City.mmdb` databases, the source IP address of each row is looked up and `Source ASN`, `Source Country` and `Source City` columns are added to both CSV files.
+The terminal table only has room for one of them, so it shows `Source Country` (falling back to the ASN, which is where the `Local`/`Private` placeholders for non-routable addresses appear).
+
 ### `logon-summary` command examples
 
 * Print logon summary: `hayabusa.exe logon-summary -f Security.evtx`
 * Save logon summary results: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Add GeoIP info to the source IP addresses: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` screenshots
 

--- a/website/docs/commands/analysis.my.md
+++ b/website/docs/commands/analysis.my.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   source IP address များတွင် GeoIP (ASN, မြို့, နိုင်ငံ) အချက်အလက် ထည့်ရန်
   -X, --remove-duplicate-records  ထပ်နေသော event record များကို ဖယ်ရှားရန် (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP အချက်အလက် ဖြည့်စွက်ခြင်း
+
+MaxMind ၏ `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` နှင့် `GeoLite2-City.mmdb` database များ ရှိသော directory ကို `-G, --geo-ip` ဖြင့် သတ်မှတ်ပါက row တစ်ခုစီ၏ source IP address ကို ရှာဖွေပြီး CSV ဖိုင်နှစ်ခုလုံးတွင် `Source ASN`, `Source Country` နှင့် `Source City` column များ ထပ်ဖြည့်ပေးပါသည်။
+Terminal table တွင် တစ်ခုတည်းသာ နေရာရှိသဖြင့် `Source Country` ကို ပြသပါသည် (ဗလာဖြစ်ပါက ASN column သို့ ပြန်သုံးပါသည်။ routing မလုပ်နိုင်သော address များ၏ `Local`/`Private` တန်ဖိုးများသည် ASN column တွင် ရှိသောကြောင့် ဖြစ်သည်)။
+
 ### `logon-summary` command ဥပမာများ
 
 * logon summary ကို print ထုတ်ရန်: `hayabusa.exe logon-summary -f Security.evtx`
 * logon summary ရလဒ်များကို သိမ်းဆည်းရန်: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* source IP address များတွင် GeoIP အချက်အလက် ထည့်ရန်: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` screenshots
 

--- a/website/docs/commands/analysis.pt-BR.md
+++ b/website/docs/commands/analysis.pt-BR.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Start time of the event logs to load (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Adicionar informações de GeoIP (ASN, cidade, país) aos endereços IP de origem
   -X, --remove-duplicate-records  Remover registros de eventos duplicados (default: disabled)
   -o, --output <FILENAME-PREFIX>  Save the logon summary to two CSV files (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Output timestamp in US time format (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### Enriquecimento de GeoIP do `logon-summary`
+
+Quando `-G, --geo-ip` aponta para um diretório que contém os bancos de dados MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` e `GeoLite2-City.mmdb`, o endereço IP de origem de cada linha é consultado e as colunas `Source ASN`, `Source Country` e `Source City` são adicionadas aos dois arquivos CSV.
+A tabela do terminal só tem espaço para uma delas, então exibe `Source Country` (recorrendo à coluna ASN quando estiver vazia, pois é nela que aparecem os marcadores `Local`/`Private` dos endereços não roteáveis).
+
 ### Exemplos do comando `logon-summary`
 
 * Exibir o resumo de logon: `hayabusa.exe logon-summary -f Security.evtx`
 * Salvar os resultados do resumo de logon: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Adicionar informações de GeoIP aos endereços IP de origem: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Capturas de tela do `logon-summary`
 

--- a/website/docs/commands/analysis.th.md
+++ b/website/docs/commands/analysis.th.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           เวลาเริ่มต้นของบันทึกเหตุการณ์ที่จะโหลด (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   เพิ่มข้อมูล GeoIP (ASN, เมือง, ประเทศ) ให้กับที่อยู่ IP ต้นทาง
   -X, --remove-duplicate-records  ลบเรคคอร์ดเหตุการณ์ที่ซ้ำกัน (ค่าเริ่มต้น: ปิดใช้งาน)
   -o, --output <FILENAME-PREFIX>  บันทึกสรุปการล็อกออนลงในไฟล์ CSV สองไฟล์ (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           แสดงเวลาในรูปแบบเวลาสหรัฐฯ (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### การเพิ่มข้อมูล GeoIP ของ `logon-summary`
+
+เมื่อระบุ `-G, --geo-ip` ให้ชี้ไปยังไดเรกทอรีที่มีฐานข้อมูล `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` และ `GeoLite2-City.mmdb` ของ MaxMind ระบบจะค้นหาที่อยู่ IP ต้นทางของแต่ละแถว และเพิ่มคอลัมน์ `Source ASN`, `Source Country` และ `Source City` ลงในไฟล์ CSV ทั้งสองไฟล์
+ตารางบนเทอร์มินัลมีพื้นที่พอสำหรับคอลัมน์เดียวเท่านั้น จึงแสดง `Source Country` (หากว่างจะย้อนกลับไปใช้คอลัมน์ ASN เนื่องจากค่า `Local`/`Private` ของที่อยู่ที่ไม่สามารถกำหนดเส้นทางได้จะอยู่ในคอลัมน์ ASN)
+
 ### ตัวอย่างคำสั่ง `logon-summary`
 
 * พิมพ์สรุปการล็อกออน: `hayabusa.exe logon-summary -f Security.evtx`
 * บันทึกผลลัพธ์สรุปการล็อกออน: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* เพิ่มข้อมูล GeoIP ให้กับที่อยู่ IP ต้นทาง: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### ภาพหน้าจอ `logon-summary`
 

--- a/website/docs/commands/analysis.tr.md
+++ b/website/docs/commands/analysis.tr.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Yüklenecek olay günlüklerinin başlangıç zamanı (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Kaynak IP adreslerine GeoIP (ASN, şehir, ülke) bilgisi ekle
   -X, --remove-duplicate-records  Yinelenen olay kayıtlarını kaldır (default: disabled)
   -o, --output <FILENAME-PREFIX>  Oturum açma özetini iki CSV dosyasına kaydet (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Zaman damgasını ABD saat biçiminde çıktı ver (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP zenginleştirmesi
+
+`-G, --geo-ip` seçeneği MaxMind'in `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` ve `GeoLite2-City.mmdb` veritabanlarını içeren bir dizini gösterdiğinde, her satırın kaynak IP adresi sorgulanır ve her iki CSV dosyasına `Source ASN`, `Source Country` ve `Source City` sütunları eklenir.
+Terminal tablosunda bunlardan yalnızca birine yer vardır; bu nedenle `Source Country` gösterilir (boş olduğunda ASN sütununa geri dönülür, çünkü yönlendirilemeyen adreslerin `Local`/`Private` değerleri orada yer alır).
+
 ### `logon-summary` komut örnekleri
 
 * Oturum açma özetini yazdırın: `hayabusa.exe logon-summary -f Security.evtx`
 * Oturum açma özeti sonuçlarını kaydedin: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Kaynak IP adreslerine GeoIP bilgisi ekleyin: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` ekran görüntüleri
 

--- a/website/docs/commands/analysis.uk.md
+++ b/website/docs/commands/analysis.uk.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           Час початку журналів подій для завантаження (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   Додавати інформацію GeoIP (ASN, місто, країна) до IP-адрес джерела
   -X, --remove-duplicate-records  Видаляти дублікати записів подій (default: disabled)
   -o, --output <FILENAME-PREFIX>  Зберегти зведення входів у два файли CSV (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           Виводити позначку часу у форматі США (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### Збагачення `logon-summary` даними GeoIP
+
+Якщо `-G, --geo-ip` вказує на каталог із базами даних MaxMind `GeoLite2-ASN.mmdb`, `GeoLite2-Country.mmdb` і `GeoLite2-City.mmdb`, IP-адреса джерела кожного рядка шукається в базах, а до обох файлів CSV додаються стовпці `Source ASN`, `Source Country` та `Source City`.
+У таблиці в терміналі є місце лише для одного з них, тому там показано `Source Country` (якщо він порожній, використовується стовпець ASN, бо саме в ньому з’являються значення `Local`/`Private` для немаршрутизованих адрес).
+
 ### Приклади команди `logon-summary`
 
 * Вивести зведення входів: `hayabusa.exe logon-summary -f Security.evtx`
 * Зберегти результати зведення входів: `hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* Додати інформацію GeoIP до IP-адрес джерела: `hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### Знімки екрана `logon-summary`
 

--- a/website/docs/commands/analysis.zh-TW.md
+++ b/website/docs/commands/analysis.zh-TW.md
@@ -377,6 +377,7 @@ Filtering:
       --timeline-start <DATE>           要載入的事件記錄開始時間 (ex: "2020-02-22 00:00:00 +09:00")
 
 Output:
+  -G, --geo-ip <MAXMIND-DB-DIR>   為來源 IP 位址加上 GeoIP (ASN、城市、國家) 資訊
   -X, --remove-duplicate-records  移除重複的事件記錄 (default: disabled)
   -o, --output <FILENAME-PREFIX>  將登入摘要儲存至兩個 CSV 檔案 (ex: -o logon-summary)
 
@@ -395,10 +396,16 @@ Time Format:
       --us-time           以美國時間格式輸出時間戳記 (ex: 02-22-2022 10:00:00.123 PM -06:00)
 ```
 
+### `logon-summary` GeoIP 資訊
+
+當 `-G, --geo-ip` 指向包含 MaxMind `GeoLite2-ASN.mmdb`、`GeoLite2-Country.mmdb` 與 `GeoLite2-City.mmdb` 資料庫的目錄時，每一列的來源 IP 位址都會被查詢，並在兩個 CSV 檔案中加入 `Source ASN`、`Source Country` 與 `Source City` 欄位。
+終端機表格只容得下其中一欄，因此顯示 `Source Country`（若為空則改用 ASN 欄位，因為無法路由的位址的 `Local`/`Private` 值會出現在 ASN 欄位）。
+
 ### `logon-summary` 命令範例
 
 * 印出登入摘要：`hayabusa.exe logon-summary -f Security.evtx`
 * 儲存登入摘要結果：`hayabusa.exe logon-summary -d ../logs -o logon-summary.csv`
+* 為來源 IP 位址加上 GeoIP 資訊：`hayabusa.exe logon-summary -d ../logs -G /usr/local/share/GeoIP -o logon-summary.csv`
 
 ### `logon-summary` 螢幕截圖
 


### PR DESCRIPTION
## What Changed

Adds the `-G, --geo-ip` option to the `logon-summary` command. It was previously only
available on `dfir-timeline`.

- **`src/detections/configs.rs`**
  - Added `geo_ip: Option<PathBuf>` to `LogonSummaryOption` (`-G, --geo-ip <MAXMIND-DB-DIR>`,
    under the `Output` help heading).
  - Added a `LogonSummary` arm to the `geo_ip_db_result` match in `create_static_data`, so the
    existing `.mmdb` existence check -> `GeoIPSearch::new` -> `StoredStatic::geo_ip_search` path
    is reused as-is.

- **`src/timeline/timelines.rs`** (`tm_loginstats_tb_dsp_msg` only)
  - Both CSV files get three extra columns: `Source ASN`, `Source Country`, `Source City`.
  - The terminal table only has room for one, so it shows `Source Country`. When that value is
    empty it falls back to the ASN column, because that is where `convert_ip_to_geo` puts its
    `Local`/`Private` placeholders -- without the fallback a private source IP would render as
    `-`, indistinguishable from a row with no source IP at all. The CSV keeps all three values
    exactly as `dfir-timeline` produces them.

Two notes on the approach:

- The lookup happens **per displayed row, not per record**, and `GeoIPSearch` caches each
  address internally, so the scan itself is not slowed down. The aggregation side
  (`metrics.rs` / `LoginEvent`) is untouched -- the geo data is derived from `source_ip`, which
  is already part of the grouping key, so grouping and row ordering are unchanged.
- `geoip_field_mapping.yaml` is not consulted. `dfir-timeline` needs it to locate the source IP
  field and to filter by channel/EID, but `logon-summary` already resolves the source IP per
  channel (`IpAddress` / `ClientAddress` / `UserDataAddress` / `UserDataParam3` /
  `RdsGtwIpAddress`), so the address can be passed straight to `convert_ip_to_geo`.

Docs: `CHANGELOG.md` / `CHANGELOG-Japanese.md` (new `x.x.x` section) and the `logon-summary`
section of all 15 `website/docs/commands/analysis*.md` files (help block, a short explanation of
the enrichment, and a usage example).

## Evidence

### Terminal output

Before (no `-G`) -- unchanged from `main`:

```
| Successful | First Logon                    | ... | Source Computer | Source IP Address |
| 1          | 2021-12-23 00:00:00.000 +00:00 | ... | WS1             | 2.125.160.216     |
| 1          | 2021-12-23 01:00:00.000 +00:00 | ... | WS2             | 10.1.1.5          |
```

After (`-G ./test_files/mmdb`):

```
| Successful | First Logon                    | ... | Source IP Address | Source Country |
| 1          | 2021-12-23 00:00:00.000 +00:00 | ... | 2.125.160.216     | United Kingdom |
| 1          | 2021-12-23 01:00:00.000 +00:00 | ... | 10.1.1.5          | Private        |

| Failed | First Attempt                  | ... | Source IP Address | Source Country |
| 1      | 2021-12-23 03:00:00.000 +00:00 | ... | -                 | -              |
| 1      | 2021-12-23 02:00:00.000 +00:00 | ... | 81.2.69.192       | United Kingdom |
```

### CSV output (`-o`)

```
Successful,...,Source Computer,Source IP Address,Source ASN,Source Country,Source City
1,...,WS1,2.125.160.216,,United Kingdom,Boxford
1,...,WS2,10.1.1.5,Private,-,-

Failed,...,Source Computer,Source IP Address,Source ASN,Source Country,Source City
1,...,-,-,-,-,-
1,...,-,81.2.69.192,,United Kingdom,London
```

A routable address is resolved, a private address reports `Private`, and a record with no source
IP falls back to `-`. (The bundled MaxMind test ASN database has no entry for these addresses,
hence the empty `Source ASN` values.)

### Error handling

Pointing `-G` at a directory without the databases produces the same error as `dfir-timeline`
and exits with status 1:

```
[ERROR] Cannot find the appropriate MaxMind GeoIP .mmdb database files. filepath: ".../GeoLite2-ASN.mmdb"
Cannot find the appropriate MaxMind GeoIP .mmdb database files. filepath: ".../GeoLite2-Country.mmdb"
Cannot find the appropriate MaxMind GeoIP .mmdb database files. filepath: ".../GeoLite2-City.mmdb"
```

### Tests

- Added `test_tm_logon_stats_dsp_msg_geo_ip`, which asserts the CSV output byte-for-byte using
  the `test_files/mmdb` databases already in the repo, covering all three cases above.
- The existing `test_tm_logon_stats_dsp_msg` asserts the CSV output byte-for-byte **without**
  `-G` and still passes unchanged, which covers backward compatibility.
- `cargo test`: 525 passed, 0 failed. `cargo fmt --check` clean; `cargo clippy --all-targets`
  reports no new warnings (the one remaining warning is pre-existing, at `src/main.rs:1311`).
